### PR TITLE
⚡PKCE client configs

### DIFF
--- a/src/Directory/Directory/IdentityServer/Config.cs
+++ b/src/Directory/Directory/IdentityServer/Config.cs
@@ -72,13 +72,48 @@ namespace Directory.IdentityServer
                     AllowedScopes = { ApiResourceKeys.RefData }
                 },
 
-                // MVC PoC client // TODO: Remove when ready
+                // MVC PoC clients // TODO: Remove when ready
                 new Client
                 {
-                    ClientId = "mvc-poc",
-                    ClientName = "MVC Proof of Concept",
-                    AllowedGrantTypes = GrantTypes.Hybrid,
+                    // This is a Hybrid Flow version of the client, which should be used if PKCE isn't supported
+                    // We may not know until we try if ASP.NET 4.x (The Framework Directory) supprts it...
+                    // Bear in mind MVC is a server-side app and can therefore use Client Credentials
+                    // for client-level API access tokens if it wants.
+                    // though if a user is logged in, their access token may be easer, if appropriate.
+                    ClientId = "mvc-poc-hybrid",
+                    ClientName = "MVC Proof of Concept (Hybrid flow)",
+                    AllowedGrantTypes = GrantTypes.HybridAndClientCredentials,
                     RequireConsent = false,
+
+                    ClientSecrets =
+                    {
+                        // Don't reuse secrets for realsies!
+                        new Secret(config[$"ClientSecrets:{TrustedClientIds.UploadApi}"].Sha256())
+                    },
+
+                    RedirectUris = { "https://localhost:5201/signin-oidc" },
+                    PostLogoutRedirectUris = { "https://localhost:5201/signout-callback-oidc" },
+
+                    AllowedScopes =
+                    {
+                        IdentityServerConstants.StandardScopes.OpenId,
+                        IdentityServerConstants.StandardScopes.Profile,
+                        ApiResourceKeys.RefData
+                    },
+                    AllowOfflineAccess = true
+                },
+                new Client
+                {
+                    // This is a PKCE Flow version of the client, which should be used if PKCE is supported
+                    // We may not know until we try if ASP.NET 4.x (The Framework Directory) supprts it...
+                    // Bear in mind MVC is a server-side app and can therefore use Client Credentials
+                    // for client-level API access tokens if it wants.
+                    // though if a user is logged in, their access token may be easer, if appropriate.
+                    ClientId = "mvc-poc-pkce",
+                    ClientName = "MVC Proof of Concept (PKCE flow)",
+                    AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
+                    RequireConsent = false,
+                    RequirePkce = true,
 
                     ClientSecrets =
                     {

--- a/src/Directory/MvcPoc/Startup.cs
+++ b/src/Directory/MvcPoc/Startup.cs
@@ -31,6 +31,34 @@ namespace MvcPoc
                 opts.DefaultChallengeScheme = "oidc";
             })
             .AddCookie("Cookies")
+            // Example Hybrid Flow Configuration
+            // This should be used if the Client doesn't support PKCE
+            // ASP.NET Core does, so really this app shouldn't use this
+            // But the Framework Directory may not support it, so this serves as an example.
+            //
+            //.AddOpenIdConnect("oidc", opts =>
+            //{
+            //    opts.SignInScheme = "Cookies";
+
+            //    opts.Authority = "https://localhost:5001";
+            //    opts.RequireHttpsMetadata = true;
+
+            //    opts.ClientId = "mvc-poc-hybrid";
+            //    opts.ClientSecret = Configuration[$"ClientSecrets:{TrustedClientIds.UploadApi}"];
+            //    opts.ResponseType = "code id_token";
+
+            //    opts.SaveTokens = true;
+            //    opts.GetClaimsFromUserInfoEndpoint = true;
+
+            //    opts.Scope.Add(ApiResourceKeys.RefData);
+            //    opts.Scope.Add("offline_access");
+            //    //opts.ClaimActions.MapJsonKey("website", "website"); // TODO: actually we don't have this claim...
+            //});
+            //
+            // Example PKCE Flow Configuration
+            // This should always be used if the Client supports PKCE, which ASP.NET Core does
+            // But the Framework Directory may not support it, so the above Hybrid Config may be needed.
+            //
             .AddOpenIdConnect("oidc", opts =>
             {
                 opts.SignInScheme = "Cookies";
@@ -38,9 +66,9 @@ namespace MvcPoc
                 opts.Authority = "https://localhost:5001";
                 opts.RequireHttpsMetadata = true;
 
-                opts.ClientId = "mvc-poc";
-                opts.ClientSecret = Configuration[$"ClientSecrets:{TrustedClientIds.Upload}"];
-                opts.ResponseType = "code id_token";
+                opts.ClientId = "mvc-poc-pkce";
+                opts.ClientSecret = Configuration[$"ClientSecrets:{TrustedClientIds.UploadApi}"];
+                opts.ResponseType = "code";
 
                 opts.SaveTokens = true;
                 opts.GetClaimsFromUserInfoEndpoint = true;

--- a/src/Upload/Upload/Upload.csproj
+++ b/src/Upload/Upload/Upload.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <UserSecretsId>76e2e948-308b-4d0d-9607-3ff17b380236</UserSecretsId>
+    <UserSecretsId>f802e04f-2173-4a8a-9878-231ed88b5005</UserSecretsId>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
fixes [AB#17069](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/17069)

- Updated all "server-side" client configs to support Client Credentials
- Updated all interactive client configs to support PKCE where appropriate
- The MVC PoC Hybrid flow config remains as an example, in case ASP.NET 4.5+ (Framework) doesn't support PKCE.