### PR TITLE
⚡multi-job pipeline for Directory builds

### DIFF
--- a/.azure/pipelines/directory.yml
+++ b/.azure/pipelines/directory.yml
@@ -15,31 +15,74 @@ trigger:
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
-pool:
-  name: Default
-  demands:
-  - dotnet
-  - npm
+jobs:
+- job: Dotnet
+  pool:
+    name: Default
+    demands:
+    - dotnet
+  steps:
+  - script: dotnet build -c Release --nologo
+    displayName: Build Directory.csproj
+    workingDirectory: src/Directory/Directory
 
-steps:
-- script: dotnet build --nologo
-  displayName: dotnet build Directory.csproj
-  workingDirectory: src/Directory/Directory
-- script: npm ci
-  displayName: npm install (CI) for Theme
-  workingDirectory: src/theme
-- script: npm run build
-  displayName: Build Shared Theme
-  workingDirectory: src/theme
-- script: npm ci
-  displayName: npm install (CI) for Razor Pages
-  workingDirectory: src/Directory/Directory
-- script: npm run build
-  displayName: Build Razor Pages bundles
-  workingDirectory: src/Directory/Directory
-- script: npm ci
-  displayName: npm install (CI) for React
-  workingDirectory: src/Directory/Directory/ClientApp
-- script: npm run build
-  displayName: Build React ClientApp
-  workingDirectory: src/Directory/Directory/ClientApp
+- job: Theme
+  pool:
+    name: Default
+    demands:
+    - npm
+  variables:
+    baseDir: src/theme
+  steps:
+  - script: npm ci
+    displayName: Install Dependencies
+    workingDirectory: $(baseDir)
+  - script: npm run build
+    displayName: Build
+    workingDirectory: $(baseDir)
+  - upload: $(baseDir)/dist
+    artifact: theme
+
+- job: Server_Pages
+  pool:
+    name: Default
+    demands:
+    - npm
+  dependsOn: Theme
+  variables:
+    baseDir: src/Directory/Directory
+  steps:
+  - task: DownloadPipelineArtifact@1
+    inputs:
+      artifactName: theme
+      downloadPath: src/theme/dist
+  - script: npm ci
+    displayName: Install Dependencies
+    workingDirectory: $(baseDir)
+  - script: npm run build
+    displayName: Build
+    workingDirectory: $(baseDir)
+  - upload: $(baseDir)/wwwroot/dist
+    artifact: serverbundle
+
+- job: React_ClientApp
+  pool:
+    name: Default
+    demands:
+    - npm
+  dependsOn: Theme
+  variables:
+    baseDir: src/Directory/Directory/ClientApp
+  steps:
+  - task: DownloadPipelineArtifact@1
+    inputs:
+      artifactName: theme
+      downloadPath: src/theme/dist
+  - script: npm ci
+    displayName: Install Dependencies
+    workingDirectory: $(baseDir)
+  - script: npm run build
+    displayName: Build
+    workingDirectory: $(baseDir)
+  - upload: $(baseDir)/build
+    artifact: clientapp


### PR DESCRIPTION
Due to the various moving parts (mostly involving different npm dependencies) Directory builds were getting a bit long.

This changes to use multiple jobs in parallel where possible, and builds now take about a third of the time 🎉 