### PR TITLE
⚡RefDataLoader: Now uses Generic Host

### DIFF
--- a/src/RefDataLoader/RefDataLoader/DataService.cs
+++ b/src/RefDataLoader/RefDataLoader/DataService.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Data.ReferenceData;
 using Common.DTO;
 using Config;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using System;
@@ -10,19 +11,20 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RefDataLoader
 {
-    public class DataService : IDataService
+    public class DataService : IDataService, IHostedService
     {
         private readonly ApiSettings _config;
         private readonly HttpClient _client;
 
-        public DataService(IOptions<ApiSettings> options, HttpClient client)
+        public DataService(IOptions<ApiSettings> options, IHttpClientFactory client)
         {
             _config = options.Value;
-            _client = client;
+            _client = client.CreateClient(string.Empty);
         }
 
         public async Task SeedData()
@@ -180,6 +182,12 @@ namespace RefDataLoader
             var json = await r.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<T>>(json);
         }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+            => await SeedData();
+
+        public Task StopAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
     }
 
     public interface IDataService

--- a/src/RefDataLoader/RefDataLoader/Program.cs
+++ b/src/RefDataLoader/RefDataLoader/Program.cs
@@ -1,50 +1,16 @@
-﻿using Config;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.IO;
-using System.Net.Http.Headers;
+﻿using Microsoft.Extensions.Hosting;
 using System.Threading.Tasks;
 
 namespace RefDataLoader
 {
     public static class Program
     {
-        //todo figure out how to use fancy core 3.0 stuff to tidy this up
-        static async Task Main()
-        {
-            var dataService = (DataService)ConfigureServices()
-               .GetService(typeof(IDataService));
-            await dataService.SeedData();
-        }
+        static async Task Main(string[] args)
+            => await CreateHostBuilder(args).RunConsoleAsync();
 
-        private static IServiceProvider ConfigureServices()
-        {
-            var services = new ServiceCollection();
-
-            // Config
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", false, true)
-                .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json", true)
-                .AddEnvironmentVariables()
-                .Build();
-            services.AddSingleton(_ => config);
-            services.Configure<ApiSettings>(config.GetSection("ApiSettings"));
-
-            services.AddTransient<IDataService, DataService>();
-
-            // Services
-            services.AddHttpClient<IDataService, DataService>(client =>
-            {
-                client.BaseAddress = new Uri(config["ApiSettings:BaseUri"]);
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(
-                    new MediaTypeWithQualityHeaderValue("application/json"));
-            });
-            
-
-            return services.BuildServiceProvider();
-        }
+        public static IHostBuilder CreateHostBuilder(string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureServices(Startup.ConfigureServices)
+                .ConfigureServices(Startup.Configure);
     }
 }

--- a/src/RefDataLoader/RefDataLoader/Properties/launchSettings.json
+++ b/src/RefDataLoader/RefDataLoader/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "RefDataLoader": {
       "commandName": "Project",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     }
   }

--- a/src/RefDataLoader/RefDataLoader/Startup.cs
+++ b/src/RefDataLoader/RefDataLoader/Startup.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Net.Http.Headers;
+using Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace RefDataLoader
+{
+    public static class Startup
+    {
+        /// <summary>
+        /// Configure Dependencies
+        /// </summary>
+        public static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        {
+            var config = context.Configuration;
+
+            services.Configure<ApiSettings>(config.GetSection("ApiSettings"));
+
+            services.AddHttpClient(string.Empty, client =>
+            {
+                client.BaseAddress = new Uri(config["ApiSettings:BaseUri"]);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue("application/json"));
+            });
+        }
+
+        /// <summary>
+        /// Configure Startup Services
+        /// </summary>
+        public static void Configure(HostBuilderContext context, IServiceCollection services)
+        {
+            services.AddHostedService<DataService>();
+        }
+    }
+}


### PR DESCRIPTION
- `Program.cs` is much simpler and looks more familiar, like in ASP.NET Core
  - `Main()` builds a Host and runs it
  - the Host build steps are in `Program.cs`
    - loads app configuration automatically
    - adds DI services from `Startup.ConfigureServices()`
    - configures the app "pipeline" from `Startup.Configure()`
- has a `Startup.cs` like in ASP.NET Core, with `ConfigureServices()` for DI and `Configure()` for setting up how the app runs.
- The `DataService` has been converted to a HostedService, so it can be run on startup by the generic Host
- switched from `ASPNETCORE_` environment variables to `DOTNET_`, since this isn't an ASP.NET Core app