### PR TITLE
Added PublicationDbContextFactory to Publications Class Library

### DIFF
--- a/src/Publications/Publications/PublicationDbContext.cs
+++ b/src/Publications/Publications/PublicationDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 using Publications.Entities;
 using System;
 using System.Collections.Generic;
@@ -10,10 +11,22 @@ namespace Publications
 {
     public class PublicationDbContext : DbContext
     {
+        public PublicationDbContext() : base() { }
 
-        public PublicationDbContext(DbContextOptions<PublicationDbContext> options) : base(options)
-        { }
+        public PublicationDbContext(DbContextOptions<PublicationDbContext> options) : base(options) { }
 
         public DbSet<Publication> Publications { get; set; }
+    }
+
+    // Ideally this shouldnt be in the class library
+    public class PublicationDbContextFactory : IDesignTimeDbContextFactory<PublicationDbContext>
+    {
+        public PublicationDbContext CreateDbContext(string[] args)
+        {
+            var options = new DbContextOptionsBuilder<PublicationDbContext>();
+            options.UseSqlServer(Environment.GetEnvironmentVariable("sqldb_connection"));
+
+            return new PublicationDbContext(options.Options);
+        }
     }
 }


### PR DESCRIPTION
This is required to support EF migrations with the Azure app. This may not be the final solution, and is not the most ideal solution as it adds a dependency on the `sqldb_connection` environment variable in the class library. Ideally the factory would be in the `AzureFunctionsApp`.

This allows the creation of a migration script for pipelines.
```
dotnet ef migrations script -s .\PublicationsAzureFunctions\PublicationsAzureFunctions.csproj -p .\Publications\Publications.csproj -i -o .\migrate.sql
```