### PR TITLE
Publication fixes to catch edge cases

### DIFF
--- a/src/Publications/Publications/Entities/Publication.cs
+++ b/src/Publications/Publications/Entities/Publication.cs
@@ -10,7 +10,8 @@ namespace Publications.Entities
         [Key]
         public int InternalId { get; set; }
 
-        public int PublicationId { get; set; }
+        [Required]
+        public string PublicationId { get; set; }
 
         [Required]
         public string Organisation { get; set; }
@@ -20,7 +21,6 @@ namespace Publications.Entities
 
         public string Authors { get; set; }
 
-        [Required]
         public string Journal { get; set; }
 
         public int Year { get; set; }

--- a/src/Publications/Publications/Migrations/20200924135737_ChangePublicationIdToString.Designer.cs
+++ b/src/Publications/Publications/Migrations/20200924135737_ChangePublicationIdToString.Designer.cs
@@ -2,15 +2,17 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Publications;
 
 namespace Publications.Migrations
 {
     [DbContext(typeof(PublicationDbContext))]
-    partial class PublicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200924135737_ChangePublicationIdToString")]
+    partial class ChangePublicationIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -32,6 +34,7 @@ namespace Publications.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Journal")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Organisation")

--- a/src/Publications/Publications/Migrations/20200924135737_ChangePublicationIdToString.cs
+++ b/src/Publications/Publications/Migrations/20200924135737_ChangePublicationIdToString.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Publications.Migrations
+{
+    public partial class ChangePublicationIdToString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PublicationId",
+                table: "Publications",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "PublicationId",
+                table: "Publications",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(string));
+        }
+    }
+}

--- a/src/Publications/Publications/Migrations/20200924143852_RelaxRequiredFields.Designer.cs
+++ b/src/Publications/Publications/Migrations/20200924143852_RelaxRequiredFields.Designer.cs
@@ -2,15 +2,17 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Publications;
 
 namespace Publications.Migrations
 {
     [DbContext(typeof(PublicationDbContext))]
-    partial class PublicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200924143852_RelaxRequiredFields")]
+    partial class RelaxRequiredFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Publications/Publications/Migrations/20200924143852_RelaxRequiredFields.cs
+++ b/src/Publications/Publications/Migrations/20200924143852_RelaxRequiredFields.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Publications.Migrations
+{
+    public partial class RelaxRequiredFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Journal",
+                table: "Publications",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Journal",
+                table: "Publications",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Publications/Publications/PublicationDbContext.cs
+++ b/src/Publications/Publications/PublicationDbContext.cs
@@ -27,7 +27,7 @@ namespace Publications
             var options = new DbContextOptionsBuilder<PublicationDbContext>();
 
             // Connection string passed from environment variable as EF doesn't (yet) support supplying it as a CLI parameter
-            options.UseSqlServer(Environment.GetEnvironmentVariable("sqldb_connection"));
+            options.UseSqlServer(Environment.GetEnvironmentVariable("sqldb_connection"), options => options.EnableRetryOnFailure());
 
             return new PublicationDbContext(options.Options);
         }

--- a/src/Publications/Publications/Services/Dto/PublicationDTO.cs
+++ b/src/Publications/Publications/Services/Dto/PublicationDTO.cs
@@ -25,7 +25,7 @@ namespace Publications
 
     public class PublicationDto
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         public string Title { get; set; }
 


### PR DESCRIPTION
Restructured the Publications enitity to be more flexible with edge cases
- PublicationId can now be a string -> theres still an internal id that is an integer
- Journal -> No longer a required field

Added DbContext retry logic to attempt to fix issues connecting to a database that is in a 'cold' state
