### PR TITLE
Fix To Search and Facets

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -63,12 +63,6 @@ namespace Biobanks.Web.Controllers
             // Build up the rest of the model from the search results.
             _mapper.Map(searchResults, model);
 
-            //if search with no restrictions then store full list of facets for use on results page
-            if (selectedFacets == null)
-            {
-                HttpContext.Session.Add("restrictionFacets", model.Facets);
-            }
-
             //Handle no results
             if (!model.Biobanks.Any())
                 return await NoResults(new NoResultsModel

--- a/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
@@ -3,125 +3,125 @@
 @using Newtonsoft.Json
 @using Directory.Data.Constants
 @model FacetsModel
-@{
-    var currentGroup = "";
-}
 
 <div class="col-sm-4">
-    @if (!Model.Facets.IsNullOrEmpty())
-    {
-        @*var restrictionFacets = (IEnumerable<SearchFacetModel>)HttpContext.Current.Session["restrictionFacets"];*@
+	@if (!Model.Facets.IsNullOrEmpty())
+	{
+		foreach (var facetGroup in Model.Facets.GroupBy(x => x.GroupName))
+		{
 
-        foreach (var facet in Model.Facets)
-        {
-            if (currentGroup != facet.GroupName)
-            {
-                if (!string.IsNullOrEmpty(currentGroup))
-                {
-                    @* Close panel *@
-                    @Html.Raw("</div></div></div>")
-                }
+			// Facet Group Data
+			var firstFacet = facetGroup.First();
 
-                currentGroup = facet.GroupName;
+			var facetGroupNameId = $"FacetGroup{firstFacet.GroupNameWithoutSpaces}";
+			var facetGroupIconId = $"FacetGroupIcon{firstFacet.GroupNameWithoutSpaces}";
 
-                var facetGroupNameId = $"FacetGroup{facet.GroupNameWithoutSpaces}";
-                var facetGroupIconId = $"FacetGroupIcon{facet.GroupNameWithoutSpaces}";
+			var facetGroupCollapsedCookieValue = Request.Cookies[$"{facetGroupNameId}Collapsed"]?.Value;
 
-                var facetGroupCollapsedCookieValue = Request.Cookies[$"{facetGroupNameId}Collapsed"]?.Value;
+			var facetGroupCollapsed = facetGroupCollapsedCookieValue != null
+				? Convert.ToBoolean(facetGroupCollapsedCookieValue)
+				: firstFacet.GroupCollapsedByDefault;
 
-                var facetGroupCollapsed = facetGroupCollapsedCookieValue != null
-                    ? Convert.ToBoolean(facetGroupCollapsedCookieValue)
-                    : facet.GroupCollapsedByDefault;
+			var groupSelectedCount = facetGroup.Count(
+				y => Model.SelectedFacets.Any(sf => y.FacetValues.Select(fv => fv.FacetId).Contains(sf)));
 
-                @* Open panel and place header. *@
-                @Html.Raw("<div class=\"panel panel-default\">")
 
-                <div class="panel-heading facet-group-header" role="button" data-toggle="collapse" data-target="#@(facetGroupNameId)"
-                     aria-expanded="@((!facetGroupCollapsed).ToString())" aria-controls="@facetGroupNameId">
+			@* Facet Group Panel *@
+			<div class="panel panel-default">
+				
+				@* Panel Header *@
+				<div class="panel-heading facet-group-header" role="button" 
+					 data-toggle="collapse" 
+					 data-target="#@(facetGroupNameId)"
+					 aria-expanded="@((!facetGroupCollapsed).ToString())" 
+					 aria-controls="@facetGroupNameId">
 
-                    @facet.GroupName
+					@firstFacet.GroupName
 
-                    @{
-                        var groupSelectedCount = Model.Facets
-                            .Where(x => x.GroupName == currentGroup)
-                            .Count(y => Model.SelectedFacets.Any(sf => y.FacetValues.Select(fv => fv.FacetId).Contains(sf)));
-                    }
+					<span id="@facetGroupIconId" class="facet-group-icon fa @Html.Raw(facetGroupCollapsed ? "fa-plus-square" : "fa-minus-square") pull-right"></span>
 
-                    <span id="@facetGroupIconId" class="facet-group-icon fa @Html.Raw(facetGroupCollapsed ? "fa-plus-square" : "fa-minus-square") pull-right"></span>
+					@if (groupSelectedCount > 0)
+					{
+						<span class="badge facet-group-badge pull-right">@groupSelectedCount in use</span>
+					}
+				</div>
 
-                    @if (groupSelectedCount > 0)
-                    {
-                        <span class="badge facet-group-badge pull-right">@groupSelectedCount in use</span>
-                    }
-                </div>
+				@* Panel Body *@
+				<div id="@facetGroupNameId" class="panel-body facet-group @(facetGroupCollapsed ? "collapse" : "collapse in")" data-icon-id="@facetGroupIconId">
+					<div class="collapse-panel-body">
 
-                @* Open panel body. *@
-                @Html.Raw($"<div id=\"{facetGroupNameId}\" class=\"panel-body facet-group {(facetGroupCollapsed ? "collapse" : "collapse in")}\" data-icon-id=\"{facetGroupIconId}\">")
-                @Html.Raw("<div class=\"collapse-panel-body\">")
-            }
+						@* Facets *@
+						@foreach (var facet in facetGroup)
+						{
+							var facetName = "";
 
-            <div class="facet-container">
-                <p class="facet-header">
+							switch (facet.Name)
+							{
+								case "Macroscopic Assessment":
+									facetName = App.Config[ConfigKey.MacroscopicAssessmentName]; break;
+								case "Preservation Type": 
+									facetName = App.Config[ConfigKey.PreservationTypeName]; break;
+								case "Donor Count": 
+									facetName = App.Config[ConfigKey.DonorCountName]; break;
+								default: 
+									facetName = facet.Name;  break;
+							}
 
-                    @switch (facet.Name)
-                    {
-                        case "Preservation Type":
-                            <strong>@App.Config[ConfigKey.PreservationTypeName]</strong>
-                            break;
-                        case "Donor Count":
-                            <strong>@App.Config[ConfigKey.DonorCountName]</strong>
-                            break;
-                        case "Macroscopic Assessment":
-                            <strong>@App.Config[ConfigKey.MacroscopicAssessmentName]</strong>
-                            break;
-                        default:
-                            <strong>@facet.Name</strong>
-                            break;
-                    }
+							<div class="facet-container">
+								<p class="facet-header">
+									<strong>@facetName</strong>
+								</p>
 
-                </p>
+								<ul class="facet-list fa-ul">
+									@foreach (var facetValue in facet.FacetValues)
+									{
+										// Consent Restriction Edgecase
+										var facetValueName = facetValue.FacetValue;
 
-                <ul class="facet-list fa-ul">
-                    @foreach (var facetValue in facet.FacetValues)
-                    {
-                        if (!Model.FacetSelected(facetValue.FacetId))
-                        {
-                            <li>
-                                <a href="@Url.Action(Model.Action, "Search", new
-                                         {
-                                             diagnosis = Model.Diagnosis,
-                                             selectedFacets = JsonConvert.SerializeObject(Model.SelectedFacets.Concat(new List<string>
-                                             {
-                                                 facetValue.FacetId
-                                             }))
-                                         })">
-                                    <span class="fa fa-circle-o"></span>
-                                    @facetValue.FacetValue
-                                </a>
-                                <span class="facet-count">(@facetValue.Count)</span>
-                            </li>
-                        }
-                        else
-                        {
-                            <li>
-                                <a href="@Url.Action(Model.Action, "Search", new
-                                         {
-                                             diagnosis = Model.Diagnosis,
-                                             selectedFacets = JsonConvert.SerializeObject(Model.SelectedFacets.Where(
-                                                 x => x != facetValue.FacetId))
-                                         })">
-                                    <span class="fa fa-check-circle"></span>
-                                    @facetValue.FacetValue
-                                </a>
-                                (@facetValue.Count)
-                            </li>
-                        }
-                    }
-                </ul>
-            </div>
+										if (facet.IndexedName == "consentRestrictions" && facetValueName != "No restrictions")
+										{
+											facetValueName = $"No {facetValueName}";
+										}
 
-        }
-
-        @Html.Raw("</div></div></div>")
-    }
+										if (!Model.FacetSelected(facetValue.FacetId))
+										{
+											<li>
+												<a href="@Url.Action(Model.Action, "Search", new
+														 {
+															 diagnosis = Model.Diagnosis,
+															 selectedFacets = JsonConvert.SerializeObject(Model.SelectedFacets.Concat(new List<string>
+															 {
+																 facetValue.FacetId
+															 }))
+														 })">
+													<span class="fa fa-circle-o"></span>
+													@facetValueName
+												</a>
+												<span class="facet-count">(@facetValue.Count)</span>
+											</li>
+										}
+										else
+										{
+											<li>
+												<a href="@Url.Action(Model.Action, "Search", new
+														 {
+															 diagnosis = Model.Diagnosis,
+															 selectedFacets = JsonConvert.SerializeObject(Model.SelectedFacets.Where(
+																 x => x != facetValue.FacetId))
+														 })">
+													<span class="fa fa-check-circle"></span>
+													@facetValueName
+												</a>
+												(@facetValue.Count)
+											</li>
+										}
+									}
+								</ul>
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		}
+	}
 </div>

--- a/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
@@ -7,15 +7,15 @@
 <div class="col-sm-4">
 	@if (!Model.Facets.IsNullOrEmpty())
 	{
+		var facets = Model.Facets;
 
-		@*// TODO: Implement Once Feature Enabled
-		//Do not display County facet if config is turned off
-		if (facet.Name.EqualsText("County") && App.Config[ConfigKey.ShowCounties] == "false")
+		// Hide County Facet
+		if (App.Config[ConfigKey.ShowCounties] == "false")
 		{
-			continue;
-		}*@
+			facets = facets.Where(x => x.Name != "County");
+		}
 
-		foreach (var facetGroup in Model.Facets.GroupBy(x => x.GroupName))
+		foreach (var facetGroup in facets.GroupBy(x => x.GroupName))
 		{
 
 			// Facet Group Data

--- a/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
@@ -10,9 +10,9 @@
 <div class="col-sm-4">
     @if (!Model.Facets.IsNullOrEmpty())
     {
-        var restrictionFacets = (IEnumerable<SearchFacetModel>)HttpContext.Current.Session["restrictionFacets"];
+        @*var restrictionFacets = (IEnumerable<SearchFacetModel>)HttpContext.Current.Session["restrictionFacets"];*@
 
-        foreach (var facet in restrictionFacets)
+        foreach (var facet in Model.Facets)
         {
             if (currentGroup != facet.GroupName)
             {

--- a/src/Directory/Search/Elastic/BaseElasticSearchProvider.cs
+++ b/src/Directory/Search/Elastic/BaseElasticSearchProvider.cs
@@ -60,7 +60,7 @@ namespace Directory.Search.Elastic
                             nq.Term(
                                 $"{currentFacetDetail.NestedAggregationPath}.{currentFacetDetail.NestedAggregationFieldName}",
                                 selectedFacet.Value)))
-                    : !Query<CollectionDocument>.Term(selectedFacet.Name, selectedFacet.Value));
+                    : Query<CollectionDocument>.Term(selectedFacet.Name, selectedFacet.Value));
             }
 
             return queries;

--- a/src/Directory/Search/Elastic/BaseElasticSearchProvider.cs
+++ b/src/Directory/Search/Elastic/BaseElasticSearchProvider.cs
@@ -141,7 +141,7 @@ namespace Directory.Search.Elastic
                     .ToList();
         }
 
-        private static Facet ExtractFacet(string aggregateName,
+        protected static Facet ExtractFacet(string aggregateName,
             MultiBucketAggregate<KeyedBucket<string>> aggregate,
             MultiBucketAggregate<KeyedBucket<string>> metadataAggregate)
         {
@@ -177,7 +177,7 @@ namespace Directory.Search.Elastic
             };
         }
 
-        private static Facet ExtractReverseNestedFacet(string aggregateName,
+        protected static Facet ExtractReverseNestedFacet(string aggregateName,
             MultiBucketAggregate<KeyedBucket<string>> aggregate,
             MultiBucketAggregate<KeyedBucket<string>> metadataAggregate)
         {
@@ -204,7 +204,7 @@ namespace Directory.Search.Elastic
                         {
                             Name = x.Key,
                             SortOrder = metadata?.SortOrder ?? string.Empty,
-                            Value = x.ReverseNested("toTop").Cardinality("biobankCount").Value
+                            Value = x.ReverseNested("toTop")?.Cardinality("biobankCount").Value
                         };
                     }).ToList(),
                 GroupOrder = facetGroup?.SortOrder ?? 0,

--- a/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
+++ b/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
@@ -46,8 +46,6 @@ namespace Directory.Search.Elastic
                 settings.BasicAuthentication(username, password);
             }
 
-            settings.DisableDirectStreaming(); // Debug
-
             _client = new ElasticClient(settings);
         }
 

--- a/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
+++ b/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
@@ -157,7 +157,7 @@ namespace Directory.Search.Elastic
                 ExternalId = x.Terms("biobankExternalIds").Buckets.First().Key,
                 CollectionCount = x.Cardinality("collectionIds").Value,
                 SampleSetSummaries = x.Terms("sampleSetSummaries").Buckets.Select(y => y.Key)
-            }).ToList();
+            });
         }
 
         private static BiobankCollectionResult ExtractBiobankCollectionDetailSearchResults(IList<CollectionDocument> searchResult)


### PR DESCRIPTION
Fixes to search

- Fixed counting on facets; facets will now show how many of the relevant biobanks they apply to, rather than all biobanks on the directory

- Fixed an issue where non-nested facets were applied by their opposite logic (eg. Male facet showing only Female results)

- Added handling of edge case for Consent Restriction Facet - which is Opt-Out. Hence the behaviour is opposite to the other facets. This required manual calculation of the facet value's cardinality.

    -  Added handling for edge case, of this edge case. Where "No Restrictions" facet value reverts back to follow the default behaviour