### PR TITLE
Simplified Submit Controller SectionsWithDuplicates Method

### DIFF
--- a/src/Api/SubmissionApi/Controllers/SubmitController.cs
+++ b/src/Api/SubmissionApi/Controllers/SubmitController.cs
@@ -72,20 +72,26 @@ namespace Biobanks.SubmissionApi.Controllers
             if (model.Treatments is null) model.Treatments = new List<TreatmentOperationModel>();
             if (model.Samples is null) model.Samples = new List<SampleOperationModel>();
 
+            // Check Total Records Is Within Range (0, max]
             var totalRecords = model.Diagnoses.Count + model.Samples.Count + model.Treatments.Count;
+            var totalMaximum = _config.GetValue<int>("Limits:EntitiesPerSubmission");
 
-            if (totalRecords <= 0) return BadRequest("At least one record must be included in a submission.");
-
-            if (SectionsWithDuplicates(model, out var sections))
-                return BadRequest(
-                    $"This submission contains multiple entries with matching identifiers in the following sections: {string.Join('.', sections)}");
-
-            var maxEntitiesPerSubmission = _config.GetValue<int>("Limits:EntitiesPerSubmission");
-            if (model.Diagnoses.Count + model.Samples.Count + model.Treatments.Count > maxEntitiesPerSubmission)
+            if (totalRecords <= 0)
             {
-                return BadRequest($"This submission contains more than the maximum of {maxEntitiesPerSubmission} records allowed.");
+                return BadRequest("At least one record must be included in a submission.");
+            }
+            else if (totalRecords > totalMaximum)
+            {
+                return BadRequest($"This submission contains more than the maximum of {totalMaximum} records allowed.");
             }
 
+            // Check No Section Contains Duplicate Entries
+            if (SectionsWithDuplicates(model, out var sections))
+            {
+                return BadRequest(
+                    $"This submission contains multiple entries with matching identifiers in the following sections: {string.Join('.', sections)}");
+            }
+                
             var diagnosesUpdates = new List<DiagnosisModel>();
             var samplesUpdates = new List<SampleModel>();
             var treatmentsUpdates = new List<TreatmentModel>();
@@ -349,29 +355,25 @@ namespace Biobanks.SubmissionApi.Controllers
         {
             sections = new List<string>();
 
-            IEqualityComparer<T> GetComparer<T>(ICollection<T> models)
+            if (HasDuplicates(submission.Diagnoses, new DiagnosisOperationModelEqualityComparer()))
             {
-                switch (models)
-                {
-                    case ICollection<DiagnosisOperationModel> d:
-                        return (IEqualityComparer<T>)new DiagnosisOperationModelEqualityComparer();
-                    case ICollection<TreatmentOperationModel> t:
-                        return (IEqualityComparer<T>)new TreatmentOperationModelEqualityComparer();
-                    case ICollection<SampleOperationModel> s:
-                        return (IEqualityComparer<T>)new SampleOperationModelEqualityComparer();
-                    default: throw new InvalidOperationException();
-                }
+                sections.Add("Diagnosis");
+            }
+            if (HasDuplicates(submission.Treatments, new TreatmentOperationModelEqualityComparer()))
+            {
+                sections.Add("Treatment");
+            }
+            if (HasDuplicates(submission.Samples, new SampleOperationModelEqualityComparer()))
+            {
+                sections.Add("Sample");
             }
 
-            bool NoDuplicates<T>(ICollection<T> models)
-                where T : BaseOperationModel
-                => models.Count == models.Distinct(GetComparer(models)).Count();
-
-            if (!NoDuplicates(submission.Diagnoses)) sections.Add("Diagnosis");
-            if (!NoDuplicates(submission.Treatments)) sections.Add("Treatment");
-            if (!NoDuplicates(submission.Samples)) sections.Add("Sample");
-
             return sections.Any();
+        }
+
+        private static bool HasDuplicates<T>(IEnumerable<T> collection, IEqualityComparer<T> comparer) where T : class
+        {
+            return collection.Distinct(comparer).Count() < collection.Count();
         }
 
         private static string IdPropertiesPrefix(object entity)

--- a/src/Api/SubmissionApi/Controllers/SubmitController.cs
+++ b/src/Api/SubmissionApi/Controllers/SubmitController.cs
@@ -86,10 +86,12 @@ namespace Biobanks.SubmissionApi.Controllers
             }
 
             // Check No Section Contains Duplicate Entries
-            if (SectionsWithDuplicates(model, out var sections))
+            var duplicates = SectionsWithDuplicates(model);
+
+            if (duplicates.Any())
             {
                 return BadRequest(
-                    $"This submission contains multiple entries with matching identifiers in the following sections: {string.Join('.', sections)}");
+                    $"This submission contains multiple entries with matching identifiers in the following sections: {string.Join('.', duplicates)}");
             }
                 
             var diagnosesUpdates = new List<DiagnosisModel>();
@@ -351,9 +353,9 @@ namespace Biobanks.SubmissionApi.Controllers
             return BadRequest($"{IdPropertiesPrefix(badEntity)}{errorText}");
         }
 
-        private static bool SectionsWithDuplicates(SubmissionModel submission, out List<string> sections)
+        private static IEnumerable<string> SectionsWithDuplicates(SubmissionModel submission)
         {
-            sections = new List<string>();
+            var sections = new List<string>();
 
             if (HasDuplicates(submission.Diagnoses, new DiagnosisOperationModelEqualityComparer()))
             {
@@ -368,7 +370,7 @@ namespace Biobanks.SubmissionApi.Controllers
                 sections.Add("Sample");
             }
 
-            return sections.Any();
+            return sections;
         }
 
         private static bool HasDuplicates<T>(IEnumerable<T> collection, IEqualityComparer<T> comparer) where T : class

--- a/src/Api/SubmissionApi/EqualityComparers/DiagnosisOperationModelEqualityComparer.cs
+++ b/src/Api/SubmissionApi/EqualityComparers/DiagnosisOperationModelEqualityComparer.cs
@@ -15,9 +15,13 @@ namespace Biobanks.SubmissionApi.EqualityComparers
 
         /// <inheritdoc />
         public int GetHashCode(DiagnosisOperationModel obj)
-            => (obj.Diagnosis.IndividualReferenceId +
+        {
+            var a = (obj.Diagnosis.IndividualReferenceId +
                 obj.Diagnosis.DateDiagnosed +
                 obj.Diagnosis.DiagnosisCode)
                 .GetHashCode();
+
+            return a;
+        }
     }
 }

--- a/src/Api/SubmissionApi/EqualityComparers/DiagnosisOperationModelEqualityComparer.cs
+++ b/src/Api/SubmissionApi/EqualityComparers/DiagnosisOperationModelEqualityComparer.cs
@@ -15,13 +15,9 @@ namespace Biobanks.SubmissionApi.EqualityComparers
 
         /// <inheritdoc />
         public int GetHashCode(DiagnosisOperationModel obj)
-        {
-            var a = (obj.Diagnosis.IndividualReferenceId +
+            => (obj.Diagnosis.IndividualReferenceId +
                 obj.Diagnosis.DateDiagnosed +
                 obj.Diagnosis.DiagnosisCode)
                 .GetHashCode();
-
-            return a;
-        }
     }
 }


### PR DESCRIPTION
- Simplified the SectionsWithDuplicates method that was using two nested functions, where it is clearer and simpler to explicitly type the different sections.

- Cleaned up number of records check in the submit controller, as it wasn't making use of an already defined variable `totalRecords` in places.