### PR TITLE
Edgecase search fixes

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -263,7 +263,7 @@ namespace Biobanks.Web.Controllers
             {
                 Name = FacetList.GetFacetName(GetFacetSlug(x)),
                 Value = GetFacetValue(x)
-            });
+            }).Where(x => !(x.Name is null));
         }
 
         private static string GetFacetValue(string facetId)

--- a/src/Directory/Data/Caching/CacheProvider.cs
+++ b/src/Directory/Data/Caching/CacheProvider.cs
@@ -24,7 +24,8 @@ namespace Directory.Data.Caching
         {
             var val = _cache.Get(cacheKey);
             
-            if(val == null) throw new KeyNotFoundException();
+            if(val == null) throw new KeyNotFoundException(
+                $"{cacheKey} requested but not found.");
 
             return (T)val;
         }

--- a/src/Directory/Search/Dto/Facets/FacetList.cs
+++ b/src/Directory/Search/Dto/Facets/FacetList.cs
@@ -352,13 +352,13 @@ namespace Directory.Search.Dto.Facets
             => FacetDetails.Where(x => x.SearchTypes.Contains(searchType)).ToList();
 
         public static string GetFacetLabel(string facetName)
-            => FacetDetails.First(x => x.Name == facetName)?.Label;
+            => FacetDetails.FirstOrDefault(x => x.Name == facetName)?.Label;
 
         public static string GetFacetSlug(string facetName)
-            => FacetDetails.First(x => x.Name == facetName)?.Slug;
+            => FacetDetails.FirstOrDefault(x => x.Name == facetName)?.Slug;
 
         public static string GetFacetName(string facetSlug)
-            => FacetDetails.First(x => x.Slug == facetSlug)?.Name;
+            => FacetDetails.FirstOrDefault(x => x.Slug == facetSlug)?.Name;
 
         public static SearchType GetSearchType<T>(ISearchResponse<T> searchResponse) where T : class
             => typeof(SearchResponse<CollectionDocument>) == searchResponse.GetType()

--- a/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
+++ b/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
@@ -85,6 +85,11 @@ namespace Directory.Search.Elastic
                         .Size(SizeLimits.SizeMax)
                         .Aggregations(a => BuildCollectionSearchAggregations()));
 
+            if (!searchResult.IsValid)
+                throw new ApplicationException(
+                    $"Search Error: {searchResult.DebugInformation}",
+                    searchResult.OriginalException);
+
             // Collect Biobanks Results
             var biobanks = ExtractBiobankSearchSummaries(searchResult);
 


### PR DESCRIPTION
- We now check the status of a search result to confirm it succeeded before trying to process the results 😲
- Invalid facets in the query string won't crash the site anymore 🎉; we simply ignore them and continue the search with the valid facets (if any) 😎
- When cache keys aren't found, the KeyNotFoundException is now kind enough to specify what the key was🎉