### PR TITLE
Sorting the Reference Data ADAC Tab Dropdown by Alphabetical Order

### DIFF
--- a/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
@@ -153,73 +153,96 @@ namespace Biobanks.Web
             //ADAC Admin
             bundles.Add(new ScriptBundle("~/bundles/adac/disease-statuses").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-disease-statuses.js"));
+                "~/Scripts/ADAC/adac-disease-statuses.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/material-types").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-material-types.js"));
+                "~/Scripts/ADAC/adac-material-types.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/sexes").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-sexes.js"));
+                "~/Scripts/ADAC/adac-sexes.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/country").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-country.js"));
+                "~/Scripts/ADAC/adac-country.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/county").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-county.js"));
+                "~/Scripts/ADAC/adac-county.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/associated-data-types").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-associated-data-types.js"));
+                "~/Scripts/ADAC/adac-associated-data-types.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/associated-data-type-groups").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-associated-data-type-group.js"));
+                "~/Scripts/ADAC/adac-associated-data-type-group.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/registration-reasons").Include(
                  "~/Scripts/bootbox*",
-                 "~/Scripts/ADAC/adac-registration-reasons.js"));
+                 "~/Scripts/ADAC/adac-registration-reasons.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/collection-percentages").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-collection-percentages.js"));
+                "~/Scripts/ADAC/adac-collection-percentages.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/collection-points").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-collection-points.js"));
+                "~/Scripts/ADAC/adac-collection-points.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/sample-collection-modes").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-sample-collection-modes.js"));
+                "~/Scripts/ADAC/adac-sample-collection-modes.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/collection-type").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-collection-type.js"));
+                "~/Scripts/ADAC/adac-collection-type.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/consent-restriction").Include(
                "~/Scripts/bootbox*",
-               "~/Scripts/ADAC/adac-consent-restriction.js"));
+               "~/Scripts/ADAC/adac-consent-restriction.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/hta-status").Include(
                "~/Scripts/bootbox*",
-               "~/Scripts/ADAC/adac-hta-status.js"));
+               "~/Scripts/ADAC/adac-hta-status.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/collection-status").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-collection-status.js"));
+                "~/Scripts/ADAC/adac-collection-status.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/associated-data-procurement-time-frame").Include(
                "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-associated-data-procurement-time-frame.js"));
+                "~/Scripts/ADAC/adac-associated-data-procurement-time-frame.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/service-offering").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-service-offering.js"));
+                "~/Scripts/ADAC/adac-service-offering.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/macro-assessments").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-macro-assessments.js"));
+                "~/Scripts/ADAC/adac-macro-assessments.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/donor-counts").Include(
                "~/Scripts/bootbox*",
-               "~/Scripts/ADAC/adac-donor-counts.js"));
+               "~/Scripts/ADAC/adac-donor-counts.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/preservation-types").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-preservation-types.js"));
+                "~/Scripts/ADAC/adac-preservation-types.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/sop-status").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-sop-status.js"));
+                "~/Scripts/ADAC/adac-sop-status.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/age-ranges").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-age-ranges.js"));
+                "~/Scripts/ADAC/adac-age-ranges.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/access-conditions").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-access-conditions.js"));
+                "~/Scripts/ADAC/adac-access-conditions.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/biobankactivity").Include(
                 "~/Scripts/bootbox*",
                 "~/Scripts/ADAC/adac-biobankactivity.js"));
@@ -244,11 +267,13 @@ namespace Biobanks.Web
                 "~/Scripts/ADAC/adac-historical.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/annual-statistics").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-annual-statistics.js"));
+                "~/Scripts/ADAC/adac-annual-statistics.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/annual-statistic-group").Include(
                 "~/Scripts/bootbox*",
                 "~/Scripts/ADAC/adac-annual-statistic-group.js",
                 "~/Scripts/ADAC/adac-refdata-utility.js"));
+
             bundles.Add(new ScriptBundle("~/bundles/adac/tabs").Include(
                 "~/Scripts/ADAC/adac-tabs.js"));
 

--- a/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
@@ -248,6 +248,8 @@ namespace Biobanks.Web
             bundles.Add(new ScriptBundle("~/bundles/adac/annual-statistic-group").Include(
                 "~/Scripts/bootbox*",
                 "~/Scripts/ADAC/adac-annual-statistic-group.js"));
+            bundles.Add(new ScriptBundle("~/bundles/adac/tabs").Include(
+                "~/Scripts/ADAC/adac-tabs.js"));
 
             // Site Config
             bundles.Add(new ScriptBundle("~/bundles/adac/site-config").Include(

--- a/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
@@ -247,7 +247,8 @@ namespace Biobanks.Web
                 "~/Scripts/ADAC/adac-annual-statistics.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/annual-statistic-group").Include(
                 "~/Scripts/bootbox*",
-                "~/Scripts/ADAC/adac-annual-statistic-group.js"));
+                "~/Scripts/ADAC/adac-annual-statistic-group.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/tabs").Include(
                 "~/Scripts/ADAC/adac-tabs.js"));
 

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -567,6 +567,7 @@
     <Content Include="Scripts\moment-with-locales.min.js" />
     <Content Include="Scripts\moment.js" />
     <Content Include="Scripts\moment.min.js" />
+    <Content Include="Scripts\ADAC\adac-tabs.js" />
     <Content Include="Scripts\Shared\mdd-editor.js" />
     <Content Include="Scripts\ADAC\adac-associated-data-type-group.js" />
     <Content Include="Scripts\ADAC\adac-collection-points.js" />

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-tabs.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-tabs.js
@@ -1,0 +1,20 @@
+﻿
+
+window.addEventListener("DOMContentLoaded", function () {
+    var dropDown = $("#refdropdown");
+    var links = dropDown.find("li");
+    links.sort(function (a, b) {
+
+        if ($(a).text().trim() > $(b).text().trim()) {
+            return 1;
+        }
+        else if ($(a).text().trim() < $(b).text().trim()) {
+            return -1;
+        }
+        else if ($(a).text().trim() === $(b).text().trim()) {
+            return 0;
+        }
+
+    }).appendTo(dropDown);
+})
+

--- a/src/Directory/Biobanks.Web/Views/ADAC/_ADACTabs.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/_ADACTabs.cshtml
@@ -1,8 +1,11 @@
 ﻿@using Directory.Data.Constants;
+@using System.Web.Optimization
 @model string
 
+@Scripts.Render("~/bundles/adac/tabs")
+
 <div class="row">
-	<div class="col-md-12">
+    <div class="col-md-12">
         <ul class="nav nav-tabs">
             <li role="presentation"
                 class="@(Model == "Requests" ? "active" : "true")">
@@ -34,7 +37,7 @@
                     Reference Data
                     <span class="caret"></span>
                 </a>
-                <ul class="dropdown-menu refdata-menu">
+                <ul class="dropdown-menu refdata-menu" id="refdropdown">
                     <li role="presentation"
                         class="@(Model == "Access Conditions" ? "active" : "true")">
                         @Html.ActionLink("Access Conditions", "AccessConditions")
@@ -136,10 +139,10 @@
                         @Html.ActionLink("Material Types", "MaterialTypes")
                     </li>
 
-					<li role="presentation"
-						class="@(Model == $"{@App.Config[ConfigKey.PreservationTypeName]}" ? "active" : "true")">
-						@Html.ActionLink($"{@App.Config[ConfigKey.PreservationTypeName]}", "PreservationTypes")
-					</li>
+                    <li role="presentation"
+                        class="@(Model == $"{@App.Config[ConfigKey.PreservationTypeName]}" ? "active" : "true")">
+                        @Html.ActionLink($"{@App.Config[ConfigKey.PreservationTypeName]}", "PreservationTypes")
+                    </li>
 
                     <li role="presentation"
                         class="@(Model == "Registration Reasons" ? "active" : "true")">
@@ -223,6 +226,13 @@
                 </li>
             }
 
-            </ul>
+        </ul>
     </div>
 </div>
+
+
+
+
+
+
+


### PR DESCRIPTION
The dropdown menu will now dynamically sort the ref data items in alphabetical order, and can account for changes to ref data names by admin users. 