### PR TITLE
A: Improve search typeahead experience to accomodate "other terms"

### DIFF
--- a/src/Directory/Biobanks.Web/Content/Site/Site.css
+++ b/src/Directory/Biobanks.Web/Content/Site/Site.css
@@ -1079,6 +1079,11 @@ div.info div {
     cursor: pointer;
 }
 
+.search-list{
+    border-bottom: 0.5px solid lightgrey; 
+    text-align: left;
+    font-size:medium;
+}
 
 /*Toggle switch*/
 /* The switch - the box around the slider */

--- a/src/Directory/Biobanks.Web/Scripts/Shared/search-diagnosis-type-ahead.js
+++ b/src/Directory/Biobanks.Web/Scripts/Shared/search-diagnosis-type-ahead.js
@@ -46,7 +46,7 @@ $(function() {
         limit: 100,
         templates: {
             suggestion: function (e) {
-                return '<div class="search-list"><br/><b>' + e.desc +
+                return '<div class="search-list"><b>' + e.desc +
                     '</b><div style="font-size:small">' +
                     (!e.other ? "" : ('...' + e.other)) + '</div></div>';
             }

--- a/src/Directory/Biobanks.Web/Scripts/Shared/search-diagnosis-type-ahead.js
+++ b/src/Directory/Biobanks.Web/Scripts/Shared/search-diagnosis-type-ahead.js
@@ -21,7 +21,8 @@ $(function() {
             filter: function (x) {
                 return $.map(x, function (item) {
                     return {
-                        desc: item.Description
+                        desc: item.Description,
+                        other: item.OtherTerms
                     };
                 });
             }
@@ -42,7 +43,14 @@ $(function() {
         name: 'desc',
         displayKey: 'desc',
         source: diseases.ttAdapter(),
-        limit: 100
+        limit: 100,
+        templates: {
+            suggestion: function (e) {
+                return '<div class="search-list"><br/><b>' + e.desc +
+                    '</b><div style="font-size:small">' +
+                    (!e.other ? "" : ('...' + e.other)) + '</div></div>';
+            }
+        }
     }
     );
 });


### PR DESCRIPTION
currently, typeahead suggests (autocompletes) the primary name of a disease status.
Once other terms are present, we should only show one suggestion per primary name (as now), but have a richer results view, something like:

----
Primary name
(other term being autocompleted)
(...other possible terms)
----

This PR doesn't seperate out the other terms being completed from the rest of the other terms (into a separate row). However the other term is highlighted as the user types. So we have:

----
Primary name
(...other terms being autocompleted)
----

![image](https://user-images.githubusercontent.com/26871554/108113502-8477a580-708f-11eb-846d-65c516ee9008.png)

Compare with #117 