### PR TITLE
Fix Data Slider CSS 

### DIFF
--- a/src/Directory/Biobanks.Web/Content/Site/Site.css
+++ b/src/Directory/Biobanks.Web/Content/Site/Site.css
@@ -1080,9 +1080,9 @@ div.info div {
 }
 
 
-/*Toggle switch*/
+/*Checkbox-Toggle switch*/
 /* The switch - the box around the slider */
-.switch {
+.checkbox-toggle-switch {
     position: relative;
     display: inline-block;
     width: 60px;
@@ -1090,14 +1090,14 @@ div.info div {
 }
 
     /* Hide default HTML checkbox */
-    .switch input {
+    .checkbox-toggle-switch input {
         opacity: 0;
         width: 0;
         height: 0;
     }
 
-/* The slider */
-.slider {
+/* The checkbox-toggle-slider */
+.checkbox-toggle-slider {
     position: absolute;
     cursor: pointer;
     top: 0;
@@ -1109,7 +1109,7 @@ div.info div {
     transition: .4s;
 }
 
-    .slider:before {
+    .checkbox-toggle-slider:before {
         position: absolute;
         content: "";
         height: 26px;
@@ -1121,25 +1121,25 @@ div.info div {
         transition: .4s;
     }
 
-input:checked + .slider {
+input:checked + .checkbox-toggle-slider {
     background-color: #2196F3;
 }
 
-input:focus + .slider {
+input:focus + .checkbox-toggle-slider {
     box-shadow: 0 0 1px #2196F3;
 }
 
-input:checked + .slider:before {
+input:checked + .checkbox-toggle-slider:before {
     -webkit-transform: translateX(26px);
     -ms-transform: translateX(26px);
     transform: translateX(26px);
 }
 
 /* Rounded sliders */
-.slider.round {
+.checkbox-toggle-slider.round {
     border-radius: 34px;
 }
 
-    .slider.round:before {
+    .checkbox-toggle-slider.round:before {
         border-radius: 50%;
     }

--- a/src/Directory/Biobanks.Web/Views/Biobank/Publications.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Biobank/Publications.cshtml
@@ -22,9 +22,9 @@
         </div>
 
         @*Enable/Disable Publications*@
-        <label class="switch pull-right">
+        <label class="checkbox-toggle-switch pull-right">
             <input id="IncludePublications" type="checkbox">
-            <span class="slider round"></span>
+            <span class="checkbox-toggle-slider round"></span>
         </label>
 
         <table id="biobank-publications" class="table table-striped table-hover" style="width:100%"></table>


### PR DESCRIPTION
Check any of the data sliders in the directory - recent CSS changes has broken the sliders. The issue appears to be due to PR#99. The fix should be to rename the classes introduced into PR#99 to something else, such as checkbox-toggle-slider and checkbox-toggle-slider-round.

Fixed CSS such that the clash is resolved. And both sides of the effected UI is working properly.

