### PR TITLE
Azure Build triggers

### DIFF
--- a/.azure/pipelines/build.analytics.yml
+++ b/.azure/pipelines/build.analytics.yml
@@ -6,7 +6,11 @@ trigger:
   batch: true
   branches:
     include:
-    - "*"
+    - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
     - src/Analytics/*

--- a/.azure/pipelines/build.dataseed.yml
+++ b/.azure/pipelines/build.dataseed.yml
@@ -2,7 +2,11 @@ trigger:
   batch: true
   branches:
     include:
-      - "*"
+      - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
       - src/Directory/DataSeed/*

--- a/.azure/pipelines/build.directory.yml
+++ b/.azure/pipelines/build.directory.yml
@@ -2,7 +2,11 @@ trigger:
   batch: true
   branches:
     include:
-      - "*"
+      - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
       - src/Directory/*

--- a/.azure/pipelines/build.publications.yml
+++ b/.azure/pipelines/build.publications.yml
@@ -6,7 +6,11 @@ trigger:
   batch: true
   branches:
     include:
-    - "*"
+    - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
     - src/Publications/*

--- a/.azure/pipelines/build.submissions.api.yml
+++ b/.azure/pipelines/build.submissions.api.yml
@@ -6,7 +6,11 @@ trigger:
   batch: true
   branches:
     include:
-    - "*"
+    - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
     - "src/Api/Data/*"

--- a/.azure/pipelines/build.submissions.functions.yml
+++ b/.azure/pipelines/build.submissions.functions.yml
@@ -6,7 +6,11 @@ trigger:
   batch: true
   branches:
     include:
-    - "*"
+    - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
     - "src/LegacyData/*"

--- a/.azure/pipelines/build.submissions.identity.yml
+++ b/.azure/pipelines/build.submissions.identity.yml
@@ -6,7 +6,11 @@ trigger:
   batch: true
   branches:
     include:
-    - "*"
+    - main
+pr:
+  branches:
+    include:
+    - main
   paths:
     include:
     - "src/Api/Common/*"


### PR DESCRIPTION
Azure Build pipelines are now less aggressive, which should simplify things in the meantime while work is done on replacement GitHub workflows, and cause fewer queueing issues for this and other projects using private Azure DevOps agents.