### PR TITLE
AB#32002: Require Azure Boards Work Item references in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 **⚠ DELETE THIS SECTION!**
 
-ℹ Please reference relevant Azure Boards work items in a list below, in the form `AB#<id>`.
+ℹ If there are multiple relevant Azure Boards work items, please reference them in a list below, in the form `AB#<id>`.
 
 ⚠ The Pull Request also cannot be merged unless its title starts with such a reference to the primary work item.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Pull Request Guidance
+
+**⚠ DELETE THIS SECTION!**
+
+ℹ Please reference relevant Azure Boards work items in a list below, in the form `AB#<id>`.
+
+⚠ The Pull Request also cannot be merged unless its title starts with such a reference to the primary work item.
+
+## Overview
+
+Summarise what this Pull Request is for.
+
+## Azure Boards
+
+- `<Work Item 1>`
+
+## Notes
+
+Any further notes on changes not covered above. Delete if not required.

--- a/.github/workflows/pr.check.work-item-ref.yml
+++ b/.github/workflows/pr.check.work-item-ref.yml
@@ -35,9 +35,9 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ℹ Linked Title:
+            **ℹ Linked Title:**
             ${{ github.event.pull_request.title }}
 
-            This bot comment serves to ensure the title work item gets hyperlinked.
+            *This bot comment serves to ensure the title work item gets hyperlinked.*
           edit-mode: replace
 

--- a/.github/workflows/pr.check.work-item-ref.yml
+++ b/.github/workflows/pr.check.work-item-ref.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: dylanvann/check-pull-request-title@v1
         with:
           # Match pull request titles in the form AB#<id>: Title.
-          pattern: "^AB#\d+: "
+          pattern: '^AB#\d+: '

--- a/.github/workflows/pr.check.work-item-ref.yml
+++ b/.github/workflows/pr.check.work-item-ref.yml
@@ -1,0 +1,21 @@
+# https://github.com/DylanVann/check-pull-request-title
+
+name: "Azure Boards Check"
+on:
+  pull_request:
+    types:
+      # Check title when opened.
+      - opened
+      # Check title when new commits are pushed.
+      # Required to use as a status check.
+      - synchronize
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dylanvann/check-pull-request-title@v1
+        with:
+          # Match pull request titles in the form AB#<id>: Title.
+          pattern: "^AB#\d+: "

--- a/.github/workflows/pr.check.work-item-ref.yml
+++ b/.github/workflows/pr.check.work-item-ref.yml
@@ -1,11 +1,12 @@
 # https://github.com/DylanVann/check-pull-request-title
 
-name: "Azure Boards Check"
+name: "Azure Boards Reference"
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
+  # check presence of id in title
   check:
     runs-on: ubuntu-latest
     steps:
@@ -13,3 +14,30 @@ jobs:
         with:
           regex: '^AB#\d+: ' # Match pull request titles in the form AB#<id>: Title.
           github_token: ${{ github.token }} # Default: ${{ github.token }}
+  # if found, comment to ensure it gets linked
+  # only one comment will be made per PR, but will be updated
+  # if the title changes (and continues to pass the check)
+  # in case the work item reference changes.
+  comment:
+    runs-on: ubuntu-latest
+    needs: check # only do this if the check passes
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "ℹ Linked Title:"
+      - name: Create or update Work Item Link
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ℹ Linked Title:
+            ${{ github.event.pull_request.title }}
+
+            This bot comment serves to ensure the title work item gets hyperlinked.
+          edit-mode: replace
+

--- a/.github/workflows/pr.check.work-item-ref.yml
+++ b/.github/workflows/pr.check.work-item-ref.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: dylanvann/check-pull-request-title@v1
+      - uses: dylanvann/check-pull-request-title@v0.1.14
         with:
           # Match pull request titles in the form AB#<id>: Title.
           pattern: '^AB#\d+: '

--- a/.github/workflows/pr.check.work-item-ref.yml
+++ b/.github/workflows/pr.check.work-item-ref.yml
@@ -3,19 +3,13 @@
 name: "Azure Boards Check"
 on:
   pull_request:
-    types:
-      # Check title when opened.
-      - opened
-      # Check title when new commits are pushed.
-      # Required to use as a status check.
-      - synchronize
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: dylanvann/check-pull-request-title@v0.1.14
+      - uses: deepakputhraya/action-pr-title@master
         with:
-          # Match pull request titles in the form AB#<id>: Title.
-          pattern: '^AB#\d+: '
+          regex: '^AB#\d+: ' # Match pull request titles in the form AB#<id>: Title.
+          github_token: ${{ github.token }} # Default: ${{ github.token }}


### PR DESCRIPTION
This PR:
- adds a workflow requiring PR titles to start with an Azure Boards work item reference
- adds a PR template for future PRs to help make them consistent and encourage including certain content (such as Azure Boards work item references)

[AB#32002](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/32002)