### PR TITLE
AB#32082: OntologyTerms created via the Directory UI are flagged as visible

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -99,7 +99,8 @@ namespace Biobanks.Web.ApiControllers
             {
                 Id = model.OntologyTermId,
                 Value = model.Description,
-                OtherTerms = model.OtherTerms
+                OtherTerms = model.OtherTerms,
+                DisplayOnDirectory = true
             });
 
             //Everything went A-OK!
@@ -129,7 +130,8 @@ namespace Biobanks.Web.ApiControllers
             {
                 Id = model.OntologyTermId,
                 Value = model.Description,
-                OtherTerms = model.OtherTerms
+                OtherTerms = model.OtherTerms,
+                DisplayOnDirectory = true
             });
 
             //Everything went A-OK!


### PR DESCRIPTION
## Overview
OntologyTerms created via the Directory UI are flagged with `DisplayOnDirectory` as true

## Azure Boards
- [AB#32082](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/32082)