### PR TITLE
AB#32211: Data Model for Interim Submissions IdentityProvider

### DIFF
--- a/src/Data/BiobanksDbContext.cs
+++ b/src/Data/BiobanksDbContext.cs
@@ -2,6 +2,7 @@
 using Biobanks.Entities.Api.ReferenceData;
 using Biobanks.Entities.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Entities.Shared;
 using Biobanks.Entities.Shared.ReferenceData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
@@ -54,7 +55,7 @@ namespace Biobanks.Data
         public DbSet<StorageTemperature> StorageTemperatures { get; set; }
         #endregion
 
-        #region Application Data: API
+        #region Application Data: Submissions Service
         public DbSet<Submission> Submissions { get; set; }
         public DbSet<Error> Errors { get; set; }
 
@@ -99,7 +100,9 @@ namespace Biobanks.Data
         public DbSet<Annotation> Annotations { get; set; }
         public DbSet<Publication> Publications { get; set; }
         #endregion
-        
+
+        public DbSet<ApiClient> ApiClients { get; set; }
+
         protected override void OnModelCreating(ModelBuilder model)
         {
             // Join Tables

--- a/src/Data/Migrations/20210316085254_ApiClient.Designer.cs
+++ b/src/Data/Migrations/20210316085254_ApiClient.Designer.cs
@@ -4,14 +4,16 @@ using Biobanks.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Biobanks.Data.Migrations
 {
     [DbContext(typeof(BiobanksDbContext))]
-    partial class BiobanksDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210316085254_ApiClient")]
+    partial class ApiClient
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Data/Migrations/20210316085254_ApiClient.cs
+++ b/src/Data/Migrations/20210316085254_ApiClient.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Biobanks.Data.Migrations
+{
+    public partial class ApiClient : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiClients",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClientId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ClientSecretHash = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiClients", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ApiClientOrganisation",
+                columns: table => new
+                {
+                    ApiClientsId = table.Column<int>(type: "int", nullable: false),
+                    OrganisationsOrganisationId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiClientOrganisation", x => new { x.ApiClientsId, x.OrganisationsOrganisationId });
+                    table.ForeignKey(
+                        name: "FK_ApiClientOrganisation_ApiClients_ApiClientsId",
+                        column: x => x.ApiClientsId,
+                        principalTable: "ApiClients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ApiClientOrganisation_Organisations_OrganisationsOrganisationId",
+                        column: x => x.OrganisationsOrganisationId,
+                        principalTable: "Organisations",
+                        principalColumn: "OrganisationId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiClientOrganisation_OrganisationsOrganisationId",
+                table: "ApiClientOrganisation",
+                column: "OrganisationsOrganisationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApiClientOrganisation");
+
+            migrationBuilder.DropTable(
+                name: "ApiClients");
+        }
+    }
+}

--- a/src/Directory/Data/BiobanksDbContext.cs
+++ b/src/Directory/Data/BiobanksDbContext.cs
@@ -3,6 +3,7 @@ using Biobanks.Entities.Api;
 using Biobanks.Entities.Api.ReferenceData;
 using Biobanks.Entities.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Entities.Shared;
 using Biobanks.Entities.Shared.ReferenceData;
 
 namespace Biobanks.Directory.Data
@@ -116,6 +117,8 @@ namespace Biobanks.Directory.Data
         public DbSet<LiveSample> Samples { get; set; }
         public DbSet<StagedSample> StagedSamples { get; set; }
         public DbSet<StagedSampleDelete> StagedSampleDeletes { get; set; }
+
+        public DbSet<ApiClient> ApiClients { get; set; }
 
         public BiobanksDbContext() : this("Biobanks") { }
         

--- a/src/Directory/Data/BiobanksDbContext.cs
+++ b/src/Directory/Data/BiobanksDbContext.cs
@@ -129,6 +129,16 @@ namespace Biobanks.Directory.Data
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<ApiClient>()
+                .HasMany(c => c.Organisations)
+                .WithMany(o => o.ApiClients)
+                .Map(join =>
+                {
+                    join.MapLeftKey("ApiClientsId");
+                    join.MapRightKey("OrganisationsOrganisationId");
+                    join.ToTable("ApiClientOrganisation");
+                });
+
             modelBuilder.Entity<Collection>()
                 .Property(f => f.StartDate)
                 .HasColumnType("datetime2");

--- a/src/Entities/Data/Organisation.cs
+++ b/src/Entities/Data/Organisation.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Entities.Shared;
 
 namespace Biobanks.Entities.Data
 {
@@ -74,5 +75,7 @@ namespace Biobanks.Entities.Data
         //Collections
         //ServiceOfferings
         //contacts?
+
+        public virtual ICollection<ApiClient> ApiClients { get; set; }
     }
 }

--- a/src/Entities/Shared/ApiClient.cs
+++ b/src/Entities/Shared/ApiClient.cs
@@ -1,11 +1,19 @@
-﻿namespace Biobanks.Entities.Shared
+﻿using Biobanks.Entities.Data;
+
+using System.Collections.Generic;
+
+namespace Biobanks.Entities.Shared
 {
     public class ApiClient
     {
         public int Id { get; set; }
 
+        public string Name { get; set; }
+
         public string ClientId { get; set; }
 
         public string ClientSecretHash { get; set; }
+
+        public virtual ICollection<Organisation> Organisations { get; set; }
     }
 }

--- a/src/Entities/Shared/ApiClient.cs
+++ b/src/Entities/Shared/ApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using Biobanks.Entities.Data;
 
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Biobanks.Entities.Shared
 {
@@ -10,8 +11,10 @@ namespace Biobanks.Entities.Shared
 
         public string Name { get; set; }
 
+        [Required]
         public string ClientId { get; set; }
 
+        [Required]
         public string ClientSecretHash { get; set; }
 
         public virtual ICollection<Organisation> Organisations { get; set; }

--- a/src/Entities/Shared/ApiClient.cs
+++ b/src/Entities/Shared/ApiClient.cs
@@ -1,0 +1,11 @@
+﻿namespace Biobanks.Entities.Shared
+{
+    public class ApiClient
+    {
+        public int Id { get; set; }
+
+        public string ClientId { get; set; }
+
+        public string ClientSecretHash { get; set; }
+    }
+}


### PR DESCRIPTION
## Overview

Prerequisite data model changes for improving the Submissions Service IdentityProvider.

This PR is just the model changes.

This will then allow the Submissions Service's Identity management to be inlined, and run off the central database rather than a whole separate ASP.NET Identity context. This also paves the way for fixing issues with the current implementation.

## Azure Boards

- [AB#32211](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/32211)