### PR TITLE
AB#32498: Submissions Token Provider

### DIFF
--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -6,6 +6,10 @@
     <RootNamespace>Biobanks.Data</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0">

--- a/src/Submissions/Api/Api.csproj
+++ b/src/Submissions/Api/Api.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="UoN.AspNetCore.VersionMiddleware" Version="1.1.1" />
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="5.1.23" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="5.1.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Submissions/Api/Api.csproj
+++ b/src/Submissions/Api/Api.csproj
@@ -9,6 +9,10 @@
     <UserSecretsId>216e442f-ab1c-4cb2-8e0e-ed462d282d2b</UserSecretsId>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="swagger.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Submissions/Api/Auth/AuthPolicies.cs
+++ b/src/Submissions/Api/Auth/AuthPolicies.cs
@@ -1,21 +1,26 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Biobanks.Submissions.Api.Auth
 {
     public static class AuthPolicies
     {
-        public static AuthorizationPolicy BuildDefaultJwtPolicy()
+        private static AuthorizationPolicy IsAuthenticated
             => new AuthorizationPolicyBuilder()
                 .RequireAuthenticatedUser()
-                .RequireAssertion(
-                    ctx => ctx.User.HasClaim(claim => claim.Type == CustomClaimTypes.BiobankId)
-                           || ctx.User.IsInRole(CustomRoles.SuperAdmin))
                 .Build();
 
-        public static AuthorizationPolicy RequireSuperAdminRole()
+        public static AuthorizationPolicy IsTokenAuthenticated
             => new AuthorizationPolicyBuilder()
-            .RequireAuthenticatedUser()
-            .RequireRole(CustomRoles.SuperAdmin)
-            .Build();
+                .Combine(IsAuthenticated)
+                .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
+                .RequireClaim(CustomClaimTypes.BiobankId)
+                .Build();
+
+        public static AuthorizationPolicy IsBasicAuthenticated
+            => new AuthorizationPolicyBuilder()
+                .Combine(IsAuthenticated)
+                .AddAuthenticationSchemes(BasicAuthConstants.AuthenticationScheme)
+                .Build();
     }
 }

--- a/src/Submissions/Api/Auth/AuthPolicies.cs
+++ b/src/Submissions/Api/Auth/AuthPolicies.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace Biobanks.Submissions.Api.Auth
 {
+    /// <summary>
+    /// ASP.NET Core Authorization Policy Definitions
+    /// </summary>
     public static class AuthPolicies
     {
         private static AuthorizationPolicy IsAuthenticated
@@ -12,6 +15,9 @@ namespace Biobanks.Submissions.Api.Auth
                 .RequireAuthenticatedUser()
                 .Build();
 
+        /// <summary>
+        /// Requires that a request is authenticated via Bearer Token
+        /// </summary>
         public static AuthorizationPolicy IsTokenAuthenticated
             => new AuthorizationPolicyBuilder()
                 .Combine(IsAuthenticated)
@@ -19,6 +25,9 @@ namespace Biobanks.Submissions.Api.Auth
                 .RequireClaim(CustomClaimTypes.BiobankId)
                 .Build();
 
+        /// <summary>
+        /// Requires that a request is authenticated via Basic Auth
+        /// </summary>
         public static AuthorizationPolicy IsBasicAuthenticated
             => new AuthorizationPolicyBuilder()
                 .Combine(IsAuthenticated)

--- a/src/Submissions/Api/Auth/AuthPolicies.cs
+++ b/src/Submissions/Api/Auth/AuthPolicies.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using Biobanks.Submissions.Api.Auth.Basic;
+
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Biobanks.Submissions.Api.Auth
@@ -20,7 +22,7 @@ namespace Biobanks.Submissions.Api.Auth
         public static AuthorizationPolicy IsBasicAuthenticated
             => new AuthorizationPolicyBuilder()
                 .Combine(IsAuthenticated)
-                .AddAuthenticationSchemes(BasicAuthConstants.AuthenticationScheme)
+                .AddAuthenticationSchemes(BasicAuthDefaults.AuthenticationScheme)
                 .Build();
     }
 }

--- a/src/Submissions/Api/Auth/Basic/BasicAuthDefaults.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthDefaults.cs
@@ -1,7 +1,13 @@
 ﻿namespace Biobanks.Submissions.Api.Auth.Basic
 {
+    /// <summary>
+    /// Default Options values for Basic Auth
+    /// </summary>
     public static class BasicAuthDefaults
     {
+        /// <summary>
+        /// Default Authentication Scheme name
+        /// </summary>
         public const string AuthenticationScheme = "Basic";
     }
 }

--- a/src/Submissions/Api/Auth/Basic/BasicAuthDefaults.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthDefaults.cs
@@ -1,0 +1,7 @@
+﻿namespace Biobanks.Submissions.Api.Auth.Basic
+{
+    public static class BasicAuthDefaults
+    {
+        public const string AuthenticationScheme = "Basic";
+    }
+}

--- a/src/Submissions/Api/Auth/Basic/BasicAuthExtensions.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthExtensions.cs
@@ -11,17 +11,40 @@ namespace Biobanks.Submissions.Api.Auth.Basic
     // though that abstracts the credential checking into a service
     // and genericises these extensions to specify the service
 
+    /// <summary>
+    /// AuthenticationBuilder Extensions for Basic Auth
+    /// </summary>
     public static class BasicAuthExtensions
     {
+        /// <summary>
+        /// Add Basic Authentication to the ASP.NET Core Authentication Middleware
+        /// </summary>
+        /// <param name="builder"></param>
         public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder)
             => AddBasic(builder, BasicAuthDefaults.AuthenticationScheme, _ => { });
 
+        /// <summary>
+        /// Add Basic Authentication to the ASP.NET Core Authentication Middleware
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="authenticationScheme"></param>
         public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder, string authenticationScheme)
             => AddBasic(builder, authenticationScheme, _ => { });
-        
+
+        /// <summary>
+        /// Add Basic Authentication to the ASP.NET Core Authentication Middleware
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configureOptions"></param>
         public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder, Action<BasicAuthSchemeOptions> configureOptions)
             => AddBasic(builder, BasicAuthDefaults.AuthenticationScheme, configureOptions);
-        
+
+        /// <summary>
+        /// Add Basic Authentication to the ASP.NET Core Authentication Middleware
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="authenticationScheme"></param>
+        /// <param name="configureOptions"></param>
         public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder, string authenticationScheme, Action<BasicAuthSchemeOptions> configureOptions)
         {
             builder.Services.AddSingleton<IPostConfigureOptions<BasicAuthSchemeOptions>, BasicAuthPostConfigureOptions>();

--- a/src/Submissions/Api/Auth/Basic/BasicAuthExtensions.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using System;
+
+namespace Biobanks.Submissions.Api.Auth.Basic
+{
+    // based on
+    // https://joonasw.net/view/creating-auth-scheme-in-aspnet-core-2
+    // though that abstracts the credential checking into a service
+    // and genericises these extensions to specify the service
+
+    public static class BasicAuthExtensions
+    {
+        public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder)
+            => AddBasic(builder, BasicAuthDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder, string authenticationScheme)
+            => AddBasic(builder, authenticationScheme, _ => { });
+        
+        public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder, Action<BasicAuthSchemeOptions> configureOptions)
+            => AddBasic(builder, BasicAuthDefaults.AuthenticationScheme, configureOptions);
+        
+        public static AuthenticationBuilder AddBasic(this AuthenticationBuilder builder, string authenticationScheme, Action<BasicAuthSchemeOptions> configureOptions)
+        {
+            builder.Services.AddSingleton<IPostConfigureOptions<BasicAuthSchemeOptions>, BasicAuthPostConfigureOptions>();
+
+            return builder.AddScheme<BasicAuthSchemeOptions, BasicAuthHandler>(
+                authenticationScheme, configureOptions);
+        }
+    }
+}

--- a/src/Submissions/Api/Auth/Basic/BasicAuthHandler.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthHandler.cs
@@ -133,7 +133,7 @@ namespace Biobanks.Submissions.Api.Auth.Basic
 
         protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
         {
-            Response.Headers["WWW-Authenticate"] = $"{Scheme} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
+            Response.Headers["WWW-Authenticate"] = $"{Scheme.Name} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
             await base.HandleChallengeAsync(properties);
         }
     }

--- a/src/Submissions/Api/Auth/Basic/BasicAuthHandler.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthHandler.cs
@@ -14,14 +14,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Biobanks.Submissions.Api.Auth
+namespace Biobanks.Submissions.Api.Auth.Basic
 {
-    internal class BasicAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    internal class BasicAuthHandler : AuthenticationHandler<BasicAuthSchemeOptions>
     {
         private readonly BiobanksDbContext _db;
 
         public BasicAuthHandler(
-            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            IOptionsMonitor<BasicAuthSchemeOptions> options,
             ILoggerFactory logger,
             UrlEncoder encoder,
             ISystemClock clock,
@@ -129,6 +129,12 @@ namespace Biobanks.Submissions.Api.Auth
             {
                 return AuthenticateResult.Fail(e.Message);
             }
+        }
+
+        protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
+        {
+            Response.Headers["WWW-Authenticate"] = $"{Scheme} realm=\"{Options.Realm}\", charset=\"UTF-8\"";
+            await base.HandleChallengeAsync(properties);
         }
     }
 }

--- a/src/Submissions/Api/Auth/Basic/BasicAuthParsingException.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthParsingException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Biobanks.Submissions.Api.Auth
+namespace Biobanks.Submissions.Api.Auth.Basic
 {
     internal class BasicAuthParsingException : Exception
     {

--- a/src/Submissions/Api/Auth/Basic/BasicAuthSchemeOptions.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthSchemeOptions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+using System;
+
+namespace Biobanks.Submissions.Api.Auth.Basic
+{
+    public class BasicAuthSchemeOptions : AuthenticationSchemeOptions
+    {
+        public string Realm { get; set; }
+    }
+
+    /// <summary>
+    /// This is used to make Realm above mandatory as per the Basic Authentication spec https://tools.ietf.org/html/rfc7617
+    /// </summary>
+    public class BasicAuthPostConfigureOptions : IPostConfigureOptions<BasicAuthSchemeOptions>
+    {
+        public void PostConfigure(string name, BasicAuthSchemeOptions options)
+        {
+            if (string.IsNullOrEmpty(options.Realm))
+            {
+                throw new InvalidOperationException("Realm must be provided in options");
+            }
+        }
+    }
+}

--- a/src/Submissions/Api/Auth/Basic/BasicAuthSchemeOptions.cs
+++ b/src/Submissions/Api/Auth/Basic/BasicAuthSchemeOptions.cs
@@ -5,8 +5,14 @@ using System;
 
 namespace Biobanks.Submissions.Api.Auth.Basic
 {
+    /// <summary>
+    /// AuthenticationScheme Options for Basic Auth
+    /// </summary>
     public class BasicAuthSchemeOptions : AuthenticationSchemeOptions
     {
+        /// <summary>
+        /// Authentication Scheme Realm - required by Basic Auth
+        /// </summary>
         public string Realm { get; set; }
     }
 
@@ -15,6 +21,11 @@ namespace Biobanks.Submissions.Api.Auth.Basic
     /// </summary>
     public class BasicAuthPostConfigureOptions : IPostConfigureOptions<BasicAuthSchemeOptions>
     {
+        /// <summary>
+        /// Runs after BasicAuthSchemeOptions Configuration
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="options"></param>
         public void PostConfigure(string name, BasicAuthSchemeOptions options)
         {
             if (string.IsNullOrEmpty(options.Realm))

--- a/src/Submissions/Api/Auth/BasicAuthConstants.cs
+++ b/src/Submissions/Api/Auth/BasicAuthConstants.cs
@@ -1,7 +1,0 @@
-﻿namespace Biobanks.Submissions.Api.Auth
-{
-    public static class BasicAuthConstants
-    {
-        public const string AuthenticationScheme = "BasicAuthentication";
-    }
-}

--- a/src/Submissions/Api/Auth/BasicAuthConstants.cs
+++ b/src/Submissions/Api/Auth/BasicAuthConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Biobanks.Submissions.Api.Auth
+{
+    public static class BasicAuthConstants
+    {
+        public const string AuthenticationScheme = "BasicAuthentication";
+    }
+}

--- a/src/Submissions/Api/Auth/BasicAuthHandler.cs
+++ b/src/Submissions/Api/Auth/BasicAuthHandler.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+using Biobanks.Data;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Biobanks.Submissions.Api.Auth
+{
+    internal class BasicAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        private readonly BiobanksDbContext _db;
+
+        public BasicAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            ISystemClock clock,
+            BiobanksDbContext db)
+            : base(options, logger, encoder, clock)
+        {
+            _db = db;
+        }
+
+        private (string username, string password) ParseBasicAuthHeader(string authorizationHeader)
+        {
+            AuthenticationHeaderValue.TryParse(authorizationHeader, out var header);
+
+            if (string.IsNullOrWhiteSpace(header?.Parameter))
+            {
+                const string noCredentialsMessage = "No Credentials.";
+                Logger.LogError(noCredentialsMessage);
+                throw new BasicAuthParsingException(noCredentialsMessage);
+            }
+
+            List<string> credentialsParts;
+
+            try
+            {
+                // decode the header parameter
+                credentialsParts = Encoding.UTF8.GetString(
+                        Convert.FromBase64String(header.Parameter))
+                    .Split(":", 2) // split at the first colon only
+                    .ToList();
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, $"Failed to decode credentials: {header.Parameter}.");
+
+                throw new BasicAuthParsingException(
+                    $"Failed to decode credentials: {header.Parameter}.",
+                    e);
+            }
+
+            if (credentialsParts.Count < 2)
+            {
+                const string invalidCredentials = "Invalid credentials: missing delimiter.";
+                Logger.LogError(invalidCredentials);
+                throw new BasicAuthParsingException(invalidCredentials);
+            }
+
+            return (credentialsParts[0], credentialsParts[1]);
+        }
+
+        private async Task<ClaimsPrincipal> Authenticate(string clientId, string clientSecret)
+        {
+            var client = await _db.ApiClients.AsNoTracking()
+                .Include(x => x.Organisations)
+                .SingleOrDefaultAsync(x => x.ClientId == clientId);
+
+            if (client is null) return null;
+
+            // Secret validation is straightforward as we expect secrets to be suitably complex
+            // This is supported by our secret generation library code
+            // and is suitably secure as per: https://github.com/IdentityServer/IdentityServer4/issues/284
+            if (clientSecret.Sha256() != client.ClientSecretHash)
+                return null;
+
+            // Successful Credentials Validation - create a ClaimsPrincipal
+
+            // Populate Claims
+            var claims = client.Organisations
+                .Select(o => new Claim(CustomClaimTypes.BiobankId, o.OrganisationId.ToString())) // TODO: is this the correct ID that clients will be submitting?
+                .ToList();
+            claims.Add(new Claim(CustomClaimTypes.ClientId, clientId));
+
+            // Create the Identity and Principal
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            return new ClaimsPrincipal(identity);
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey("Authorization"))
+                return AuthenticateResult.Fail("Missing Authorization Header");
+
+            try
+            {
+                var (clientId, clientSecret) = ParseBasicAuthHeader(Request.Headers["Authorization"]);
+
+                var claimsPrincipal = await Authenticate(clientId, clientSecret);
+
+                if (claimsPrincipal is not null)
+                {
+                    Logger.LogInformation($"Credentials validated for Client: {clientId}");
+
+                    return AuthenticateResult.Success(new AuthenticationTicket(
+                        claimsPrincipal,
+                        Scheme.Name
+                    ));
+                }
+                else
+                {
+                    Logger.LogInformation($"Credentials failed validation for Client: {clientId}");
+                    return AuthenticateResult.Fail("Invalid credentials.");
+                }
+
+            }
+            catch (BasicAuthParsingException e)
+            {
+                return AuthenticateResult.Fail(e.Message);
+            }
+        }
+    }
+}

--- a/src/Submissions/Api/Auth/BasicAuthParsingException.cs
+++ b/src/Submissions/Api/Auth/BasicAuthParsingException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Biobanks.Submissions.Api.Auth
+{
+    internal class BasicAuthParsingException : Exception
+    {
+        public BasicAuthParsingException(string message) : base(message) { }
+
+        public BasicAuthParsingException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Submissions/Api/Auth/Crypto.cs
+++ b/src/Submissions/Api/Auth/Crypto.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.IdentityModel.Tokens;
+
+using System;
+
+namespace Biobanks.Submissions.Api.Auth
+{
+    public static class Crypto
+    {
+        public static SymmetricSecurityKey GenerateSigningKey(string secret)
+            => new SymmetricSecurityKey(Base64UrlEncoder.DecodeBytes(secret));
+
+        public static string GenerateSecret()
+        {
+            // Secret should be a Base64 string for easy byte encoding
+            // It also needs to have a minimum length of
+            // 24 (encoded) characters
+            // to ensure the Security Key is at least 128bit strong
+
+            // TODO: use IdentityModel.CryptoRandom
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Submissions/Api/Auth/Crypto.cs
+++ b/src/Submissions/Api/Auth/Crypto.cs
@@ -4,11 +4,21 @@ using System;
 
 namespace Biobanks.Submissions.Api.Auth
 {
+    /// <summary>
+    /// Cryptography helpers for Identity purposes
+    /// </summary>
     public static class Crypto
     {
+        /// <summary>
+        /// Generate a Signing Key from a Secret, that can be used to sign / verify JWTs
+        /// </summary>
+        /// <param name="secret"></param>
         public static SymmetricSecurityKey GenerateSigningKey(string secret)
             => new SymmetricSecurityKey(Base64UrlEncoder.DecodeBytes(secret));
-
+        
+        /// <summary>
+        /// Generate a random minimum 128bit strong Secret of suitable entropy
+        /// </summary>
         public static string GenerateSecret()
         {
             // Secret should be a Base64 string for easy byte encoding

--- a/src/Submissions/Api/Auth/CustomClaimTypes.cs
+++ b/src/Submissions/Api/Auth/CustomClaimTypes.cs
@@ -3,5 +3,6 @@
     public static class CustomClaimTypes
     {
         public const string BiobankId = "BiobankId";
+        public const string ClientId = "ClientId";
     }
 }

--- a/src/Submissions/Api/Auth/CustomClaimTypes.cs
+++ b/src/Submissions/Api/Auth/CustomClaimTypes.cs
@@ -1,8 +1,18 @@
 ﻿namespace Biobanks.Submissions.Api.Auth
 {
+    /// <summary>
+    /// Custom Types used for Claims
+    /// </summary>
     public static class CustomClaimTypes
     {
+        /// <summary>
+        /// Biobank Internal ID that the claim represents access to
+        /// </summary>
         public const string BiobankId = "BiobankId";
+
+        /// <summary>
+        /// Claim representing the API Client ID of the holder
+        /// </summary>
         public const string ClientId = "ClientId";
     }
 }

--- a/src/Submissions/Api/Auth/CustomRoles.cs
+++ b/src/Submissions/Api/Auth/CustomRoles.cs
@@ -1,4 +1,4 @@
-﻿namespace Biobanks.Submissions.Api.Auth
+namespace Biobanks.Submissions.Api.Auth
 {
     public static class CustomRoles
     {

--- a/src/Submissions/Api/Auth/CustomRoles.cs
+++ b/src/Submissions/Api/Auth/CustomRoles.cs
@@ -1,7 +1,13 @@
 namespace Biobanks.Submissions.Api.Auth
 {
+    /// <summary>
+    /// Custom Identity Roles used in the Application
+    /// </summary>
     public static class CustomRoles
     {
+        /// <summary>
+        /// Represents the highest level of User
+        /// </summary>
         public const string SuperAdmin = "SuperAdmin";
     }
 }

--- a/src/Submissions/Api/Auth/JwtBearerConstants.cs
+++ b/src/Submissions/Api/Auth/JwtBearerConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace Biobanks.Submissions.Api.Auth
+{
+    public static class JwtBearerConstants
+    {
+        public const string TokenIssuer = "biobankinguk-submissions-api";
+        public const string TokenAudience = TokenIssuer;
+    }
+}

--- a/src/Submissions/Api/Auth/JwtBearerConstants.cs
+++ b/src/Submissions/Api/Auth/JwtBearerConstants.cs
@@ -1,8 +1,18 @@
 ﻿namespace Biobanks.Submissions.Api.Auth
 {
+    /// <summary>
+    /// Constant values used for configuring JWT Bearer Auth
+    /// </summary>
     public static class JwtBearerConstants
     {
+        /// <summary>
+        /// The token issuer
+        /// </summary>
         public const string TokenIssuer = "biobankinguk-submissions-api";
+
+        /// <summary>
+        /// The intended token audience
+        /// </summary>
         public const string TokenAudience = TokenIssuer;
     }
 }

--- a/src/Submissions/Api/Auth/SecurityRequirementsOperationFilter.cs
+++ b/src/Submissions/Api/Auth/SecurityRequirementsOperationFilter.cs
@@ -8,8 +8,9 @@ using System.Linq;
 
 namespace Biobanks.Submissions.Api.Auth
 {
-    // These filters tell Swagger which security definitions (e.g. Basic Auth...) apply to which Authorization Policies
-
+    /// <summary>
+    /// Swashbuckle Filter to apply OpenAPI Security Definitions to particular matching Controller Actions
+    /// </summary>
     public class SecurityRequirementsOperationFilter : IOperationFilter
     {
         private static Dictionary<string, string> _policySchemes = new()
@@ -21,6 +22,11 @@ namespace Biobanks.Submissions.Api.Auth
         private IEnumerable<string> GetDistinctAuthorizationPolicyNames(object[] attributes)
             => attributes.OfType<AuthorizeAttribute>().Select(a => a.Policy).Distinct();
 
+        /// <summary>
+        /// Apply OpenAPI Security Requirements based on some filtering logic
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <param name="context"></param>
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
             // TODO: if we ever add any public Controller actions we'll need to account for [AllowAnonymous]

--- a/src/Submissions/Api/Auth/SecurityRequirementsOperationFilter.cs
+++ b/src/Submissions/Api/Auth/SecurityRequirementsOperationFilter.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Biobanks.Submissions.Api.Auth
+{
+    // These filters tell Swagger which security definitions (e.g. Basic Auth...) apply to which Authorization Policies
+
+    public class SecurityRequirementsOperationFilter : IOperationFilter
+    {
+        private static Dictionary<string, string> _policySchemes = new()
+        {
+            [nameof(AuthPolicies.IsTokenAuthenticated)] = "jwtbearer",
+            [nameof(AuthPolicies.IsBasicAuthenticated)] = "basic"
+        };
+
+        private IEnumerable<string> GetDistinctAuthorizationPolicyNames(object[] attributes)
+            => attributes.OfType<AuthorizeAttribute>().Select(a => a.Policy).Distinct();
+
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            // TODO: if we ever add any public Controller actions we'll need to account for [AllowAnonymous]
+
+            // Policy names map to Authentication Schemes
+            var authPolicies =
+                GetDistinctAuthorizationPolicyNames(
+                    // get attributes on the method
+                    context.MethodInfo.GetCustomAttributes(true))
+                .Union(
+                    // get attributes on the parent class
+                    GetDistinctAuthorizationPolicyNames(
+                        context.MethodInfo.ReflectedType.GetCustomAttributes(true)))
+                .ToList();
+
+            // always use the default
+            if (!authPolicies.Any()) authPolicies = new() { nameof(AuthPolicies.IsTokenAuthenticated) };
+
+            // saves adding these per Endpoint!
+            // TODO: allow overriding on the Controller Action?
+            operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+            operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
+
+            // Generate a Security Requirement for each policy we care about
+            operation.Security = authPolicies
+                // map policies to auth schemes
+                .Select(policyName =>
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = _policySchemes.GetValueOrDefault(policyName)
+                        }
+                    })
+                // filter out policies we don't care about
+                .Where(x => x is not null)
+                // filter out duplicates
+                .ToHashSet()
+                // turn each unique scheme into a security requirement
+                .Select(scheme =>
+                    new OpenApiSecurityRequirement
+                    {
+                        [scheme] = new List<string>()
+                    })
+                .ToList();
+
+        }
+    }
+}

--- a/src/Submissions/Api/Auth/StringCryptoExtensions.cs
+++ b/src/Submissions/Api/Auth/StringCryptoExtensions.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace Biobanks.Submissions.Api.Auth
 {
+    /// <summary>
+    /// Cryptography related Extension Methods for string
+    /// </summary>
     public static class StringCryptoExtensions
     {
         /// <summary>

--- a/src/Submissions/Api/Auth/StringCryptoExtensions.cs
+++ b/src/Submissions/Api/Auth/StringCryptoExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.IdentityModel.Tokens;
+
 using System.Security.Cryptography;
 using System.Text;
 
@@ -6,14 +7,15 @@ namespace Biobanks.Submissions.Api.Auth
 {
     public static class StringCryptoExtensions
     {
+        /// <summary>
+        /// Hash a string using SHA256 and Base64 URL encode it
+        /// </summary>
+        /// <param name="input"></param>
         public static string Sha256(this string input)
         {
-
-            using (SHA256 sha256 = SHA256.Create())
-            {
-                byte[] bytes = Encoding.UTF8.GetBytes(input);
-                return Convert.ToBase64String(sha256.ComputeHash(bytes));
-            }
+            using SHA256 sha256 = SHA256.Create();
+            byte[] bytes = Encoding.UTF8.GetBytes(input);
+            return Base64UrlEncoder.Encode(sha256.ComputeHash(bytes));
         }
     }
 }

--- a/src/Submissions/Api/Auth/StringCryptoExtensions.cs
+++ b/src/Submissions/Api/Auth/StringCryptoExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Biobanks.Submissions.Api.Auth
+{
+    public static class StringCryptoExtensions
+    {
+        public static string Sha256(this string input)
+        {
+
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(input);
+                return Convert.ToBase64String(sha256.ComputeHash(bytes));
+            }
+        }
+    }
+}

--- a/src/Submissions/Api/Config/JwtBearerConfig.cs
+++ b/src/Submissions/Api/Config/JwtBearerConfig.cs
@@ -1,7 +1,13 @@
 ﻿namespace Biobanks.Submissions.Api.Config
 {
+    /// <summary>
+    /// Configuration Options class for JWT Bearer Token usage
+    /// </summary>
     public class JwtBearerConfig
     {
+        /// <summary>
+        /// The Secret used to sign / verify JWTs
+        /// </summary>
         public string Secret { get; set; }
     }
 }

--- a/src/Submissions/Api/Config/JwtBearerConfig.cs
+++ b/src/Submissions/Api/Config/JwtBearerConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace Biobanks.Submissions.Api.Config
+{
+    public class JwtBearerConfig
+    {
+        public string Secret { get; set; }
+    }
+}

--- a/src/Submissions/Api/Controllers/Domain/CommitController.cs
+++ b/src/Submissions/Api/Controllers/Domain/CommitController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Biobanks.Submissions.Api.Auth;
 using Biobanks.Submissions.Api.Services.Contracts;
@@ -7,7 +8,6 @@ using Biobanks.Submissions.Core.Services.Contracts;
 
 using Hangfire;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace Biobanks.Submissions.Api.Controllers.Domain
@@ -57,7 +57,7 @@ namespace Biobanks.Submissions.Api.Controllers.Domain
             var submissionsInProgress = await _submissionService.ListSubmissionsInProgress(biobankId);
             if (submissionsInProgress.Any())
             {
-                return BadRequest(JsonConvert.SerializeObject(submissionsInProgress));
+                return BadRequest(JsonSerializer.Serialize(submissionsInProgress));
             }
 
             BackgroundJob.Enqueue(() => _commitService.CommitStagedData(type.Equals("replace", StringComparison.OrdinalIgnoreCase), biobankId));

--- a/src/Submissions/Api/Controllers/ErrorController.cs
+++ b/src/Submissions/Api/Controllers/ErrorController.cs
@@ -40,7 +40,6 @@ namespace Biobanks.Submissions.Api.Controllers
         /// <returns>A paginated list of errors.</returns>
         [HttpGet]
         [SwaggerResponse(200, Type = typeof(PaginatedErrorsModel))]
-        [SwaggerResponse(403, "Access to the requested submission denied.")]
         [SwaggerResponse(404, "No submission found with the specified id.")]
         [SwaggerResponse(400, "Offset exceeds the total records available.")]
         public async Task<IActionResult> ListErrors(int submissionId, [FromQuery]PaginationParams paging)
@@ -85,7 +84,6 @@ namespace Biobanks.Submissions.Api.Controllers
         /// <returns>A single error.</returns>
         [HttpGet("{errorId}")]
         [SwaggerResponse(200, Type = typeof(ErrorModel))]
-        [SwaggerResponse(403, "Access to the requested submission denied.")]
         [SwaggerResponse(404, "No error found with the specified id matching the specified submission.")]
         public async Task<IActionResult> GetError(int submissionId, int errorId)
         {

--- a/src/Submissions/Api/Controllers/StatusController.cs
+++ b/src/Submissions/Api/Controllers/StatusController.cs
@@ -44,7 +44,6 @@ namespace Biobanks.Submissions.Api.Controllers
         /// <returns>A paginated list of submission summaries.</returns>
         [HttpGet("biobank/{biobankId}")]
         [SwaggerResponse(200, Type = typeof(PaginatedSubmissionSummariesModel))]
-        [SwaggerResponse(403, "Access to the requested submission denied.")]
         [SwaggerResponse(400, "Offset exceeds the total records available.")]
         [SwaggerResponse(400, "The parameters 'Since' and 'N' are mutually exclusive.")]
         public async Task<IActionResult> List(int biobankId, [FromQuery]SubmissionPaginationParams paging)
@@ -94,7 +93,6 @@ namespace Biobanks.Submissions.Api.Controllers
         /// <returns>A summary of the specified submission</returns>
         [HttpGet("{submissionId}")]
         [SwaggerResponse(200, Type = typeof(SubmissionSummaryModel))]
-        [SwaggerResponse(403, "Access to the requested submission denied.")]
         [SwaggerResponse(404, "No submission found with the specified id.")]
         public async Task<IActionResult> Get(int submissionId)
         {

--- a/src/Submissions/Api/Controllers/SubmitController.cs
+++ b/src/Submissions/Api/Controllers/SubmitController.cs
@@ -58,7 +58,6 @@ namespace Biobanks.Submissions.Api.Controllers
         [SwaggerResponse(202, Type = typeof(SubmissionSummaryModel))]
         [SwaggerResponse(400, "Request body expected.")]
         [SwaggerResponse(400, "Invalid request body provided.")]
-        [SwaggerResponse(403, "Access to post to the requested biobank denied.")]
         [SwaggerResponse(409, "Newer record exists.")]
         public async Task<IActionResult> Post(int biobankId, [FromBody] SubmissionModel model)
         {

--- a/src/Submissions/Api/Controllers/SubmitController.cs
+++ b/src/Submissions/Api/Controllers/SubmitController.cs
@@ -1,18 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using AutoMapper;
+﻿using AutoMapper;
+
 using Biobanks.Submissions.Api.Auth;
-using Biobanks.Submissions.Core.Models;
-using Biobanks.Submissions.Core.Types;
 using Biobanks.Submissions.Api.EqualityComparers;
 using Biobanks.Submissions.Api.Models;
+using Biobanks.Submissions.Core.Models;
 using Biobanks.Submissions.Core.Services.Contracts;
+using Biobanks.Submissions.Core.Types;
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
+
 using Swashbuckle.AspNetCore.Annotations;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace Biobanks.Submissions.Api.Controllers
 {
@@ -92,7 +96,7 @@ namespace Biobanks.Submissions.Api.Controllers
                 return BadRequest(
                     $"This submission contains multiple entries with matching identifiers in the following sections: {string.Join('.', duplicates)}");
             }
-                
+
             var diagnosesUpdates = new List<DiagnosisModel>();
             var samplesUpdates = new List<SampleModel>();
             var treatmentsUpdates = new List<TreatmentModel>();
@@ -219,7 +223,7 @@ namespace Biobanks.Submissions.Api.Controllers
                     await _blobWriteService.StoreObjectAsJsonAsync("submission-payload", diagnosesUpdates);
 
                 await _queueWriteService.PushAsync("operations",
-                    JsonConvert.SerializeObject(
+                    JsonSerializer.Serialize(
                         new OperationsQueueItem
                         {
                             SubmissionId = submission.Id,
@@ -239,7 +243,7 @@ namespace Biobanks.Submissions.Api.Controllers
                     await _blobWriteService.StoreObjectAsJsonAsync("submission-payload", diagnosesDeletes);
 
                 await _queueWriteService.PushAsync("operations",
-                    JsonConvert.SerializeObject(
+                    JsonSerializer.Serialize(
                         new OperationsQueueItem
                         {
                             SubmissionId = submission.Id,
@@ -259,7 +263,7 @@ namespace Biobanks.Submissions.Api.Controllers
                     await _blobWriteService.StoreObjectAsJsonAsync("submission-payload", samplesUpdates);
 
                 await _queueWriteService.PushAsync("operations",
-                    JsonConvert.SerializeObject(
+                    JsonSerializer.Serialize(
                         new OperationsQueueItem
                         {
                             SubmissionId = submission.Id,
@@ -279,7 +283,7 @@ namespace Biobanks.Submissions.Api.Controllers
                     await _blobWriteService.StoreObjectAsJsonAsync("submission-payload", samplesDeletes);
 
                 await _queueWriteService.PushAsync("operations",
-                    JsonConvert.SerializeObject(
+                    JsonSerializer.Serialize(
                         new OperationsQueueItem
                         {
                             SubmissionId = submission.Id,
@@ -299,7 +303,7 @@ namespace Biobanks.Submissions.Api.Controllers
                     await _blobWriteService.StoreObjectAsJsonAsync("submission-payload", treatmentsUpdates);
 
                 await _queueWriteService.PushAsync("operations",
-                    JsonConvert.SerializeObject(
+                    JsonSerializer.Serialize(
                         new OperationsQueueItem
                         {
                             SubmissionId = submission.Id,
@@ -320,7 +324,7 @@ namespace Biobanks.Submissions.Api.Controllers
                     await _blobWriteService.StoreObjectAsJsonAsync("submission-payload", treatmentsDeletes);
 
                 await _queueWriteService.PushAsync("operations",
-                    JsonConvert.SerializeObject(
+                    JsonSerializer.Serialize(
                         new OperationsQueueItem
                         {
                             SubmissionId = submission.Id,

--- a/src/Submissions/Api/Controllers/TokenController.cs
+++ b/src/Submissions/Api/Controllers/TokenController.cs
@@ -35,7 +35,6 @@ namespace Biobanks.Submissions.Api.Controllers
         /// <returns>A paginated list of submission summaries.</returns>
         [HttpGet]
         [SwaggerResponse(200)]
-        [SwaggerResponse(401, Description = "Unauthorized. The credentials provided failed authentication.")]
         public async Task<string> Get()
         {
             // prep claims (since we need to add the "sub" claim for JWT)

--- a/src/Submissions/Api/Controllers/TokenController.cs
+++ b/src/Submissions/Api/Controllers/TokenController.cs
@@ -1,0 +1,59 @@
+﻿using Biobanks.Submissions.Api.Auth;
+using Biobanks.Submissions.Api.Config;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Biobanks.Submissions.Api.Controllers
+{
+    [Route("[controller]")]
+    [ApiController]
+    [Authorize(Policy = nameof(AuthPolicies.IsBasicAuthenticated))]
+    public class TokenController : ControllerBase
+    {
+        private readonly JwtBearerConfig _config;
+
+        public TokenController(IOptions<JwtBearerConfig> config)
+        {
+            _config = config.Value;
+        }
+
+        [HttpGet]
+        // TODO: Swaggger annotations
+        public async Task<string> Get()
+        {
+            // prep claims (since we need to add the "sub" claim for JWT)
+            var claimsPrincipal = new ClaimsPrincipal(User.Identity);
+            var claims = new List<Claim>();
+            claims.AddRange(claimsPrincipal.Claims);
+
+            // the subject is the Client ID
+            claims.Add(new Claim(
+                "sub",
+                claimsPrincipal.FindFirst(
+                    x => x.Type == CustomClaimTypes.ClientId).Value));
+
+            var token = new JwtSecurityToken(
+                issuer: JwtBearerConstants.TokenIssuer,
+                audience: JwtBearerConstants.TokenAudience,
+                claims: claims,
+                notBefore: DateTime.UtcNow,
+                expires: null,
+                signingCredentials: new SigningCredentials(
+                    Crypto.GenerateSigningKey(_config.Secret),
+                    SecurityAlgorithms.HmacSha256)
+            );
+
+            return new JwtSecurityTokenHandler()
+                .WriteToken(token);
+        }
+    }
+}

--- a/src/Submissions/Api/Controllers/TokenController.cs
+++ b/src/Submissions/Api/Controllers/TokenController.cs
@@ -53,7 +53,7 @@ namespace Biobanks.Submissions.Api.Controllers
                 audience: JwtBearerConstants.TokenAudience,
                 claims: claims,
                 notBefore: DateTime.UtcNow,
-                expires: null,
+                expires: DateTime.Now.AddDays(1),
                 signingCredentials: new SigningCredentials(
                     Crypto.GenerateSigningKey(_config.Secret),
                     SecurityAlgorithms.HmacSha256)

--- a/src/Submissions/Api/Controllers/TokenController.cs
+++ b/src/Submissions/Api/Controllers/TokenController.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
+using Swashbuckle.AspNetCore.Annotations;
+
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
@@ -26,8 +28,14 @@ namespace Biobanks.Submissions.Api.Controllers
             _config = config.Value;
         }
 
+        /// <summary>
+        /// Request an Submissions API Access JWT for a set of client credentials.
+        /// </summary>
+        /// <example>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ</example>
+        /// <returns>A paginated list of submission summaries.</returns>
         [HttpGet]
-        // TODO: Swaggger annotations
+        [SwaggerResponse(200)]
+        [SwaggerResponse(401, Description = "Unauthorized. The credentials provided failed authentication.")]
         public async Task<string> Get()
         {
             // prep claims (since we need to add the "sub" claim for JWT)

--- a/src/Submissions/Api/Controllers/TokenController.cs
+++ b/src/Submissions/Api/Controllers/TokenController.cs
@@ -12,10 +12,12 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
 namespace Biobanks.Submissions.Api.Controllers
 {
+    /// <summary>
+    /// Controller for Token issuing
+    /// </summary>
     [Route("[controller]")]
     [ApiController]
     [Authorize(Policy = nameof(AuthPolicies.IsBasicAuthenticated))]
@@ -23,6 +25,7 @@ namespace Biobanks.Submissions.Api.Controllers
     {
         private readonly JwtBearerConfig _config;
 
+        /// <inheritdoc />
         public TokenController(IOptions<JwtBearerConfig> config)
         {
             _config = config.Value;
@@ -35,7 +38,7 @@ namespace Biobanks.Submissions.Api.Controllers
         /// <returns>A paginated list of submission summaries.</returns>
         [HttpGet]
         [SwaggerResponse(200)]
-        public async Task<string> Get()
+        public string Get()
         {
             // prep claims (since we need to add the "sub" claim for JWT)
             var claimsPrincipal = new ClaimsPrincipal(User.Identity);

--- a/src/Submissions/Api/Filters/HangfireDashboardAuthorizationFilter.cs
+++ b/src/Submissions/Api/Filters/HangfireDashboardAuthorizationFilter.cs
@@ -9,6 +9,7 @@ namespace Biobanks.Submissions.Api.Filters
         /// <inheritdoc />
         public bool Authorize(DashboardContext ctx)
         {
+            // TODO: How does this even work?
             return ctx.GetHttpContext().User.IsInRole(CustomRoles.SuperAdmin);
         }
     }

--- a/src/Submissions/Api/MappingProfiles/ErrorProfile.cs
+++ b/src/Submissions/Api/MappingProfiles/ErrorProfile.cs
@@ -1,7 +1,9 @@
 ﻿using AutoMapper;
+
 using Biobanks.Entities.Api;
 using Biobanks.Submissions.Api.Models;
-using Newtonsoft.Json.Linq;
+
+using System.Text.Json;
 
 namespace Biobanks.Submissions.Api.MappingProfiles
 {
@@ -15,17 +17,13 @@ namespace Biobanks.Submissions.Api.MappingProfiles
                 .ForMember(
                     dest => dest.RecordIdentifiers,
                     opts => opts.MapFrom(
-                            src => JObject.Parse(src.RecordIdentifiers)
-                        )
-                    );
+                            src => JsonDocument.Parse(src.RecordIdentifiers, default)));
 
             CreateMap<ErrorModel, Error>()
                 .ForMember(
                     dest => dest.RecordIdentifiers,
                     opts => opts.MapFrom(
-                            src => src.RecordIdentifiers.ToString()
-                        )
-                    );
+                            src => src.RecordIdentifiers.ToString()));
         }
     }
 }

--- a/src/Submissions/Api/Models/ErrorModel.cs
+++ b/src/Submissions/Api/Models/ErrorModel.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json;
 
 namespace Biobanks.Submissions.Api.Models
 {
@@ -20,6 +20,6 @@ namespace Biobanks.Submissions.Api.Models
         /// <summary>
         /// Unique identifiers of the record to which the error relates.
         /// </summary>
-        public JObject RecordIdentifiers { get; set; }
+        public JsonDocument RecordIdentifiers { get; set; }
     }
 }

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -1,4 +1,4 @@
-using Biobanks.Submissions.Api.Auth;
+﻿using Biobanks.Submissions.Api.Auth;
 using Biobanks.Submissions.Api.Auth.Basic;
 using Biobanks.Submissions.Api.Config;
 using Biobanks.Submissions.Api.Filters;
@@ -23,7 +23,8 @@ using Microsoft.Extensions.PlatformAbstractions;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 
-using System;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Serialization;
@@ -106,16 +107,32 @@ namespace Biobanks.Submissions.Api
 
                 .AddSwaggerGen(opts =>
                     {
+                        // Docs details
                         opts.SwaggerDoc("v1",
                             new OpenApiInfo
                             {
-                                Title = "UKCRC Tissue Directory API",
+                                Title = "BiobankingUK Submissions API",
                                 Version = "v1"
                             });
 
+                        // Doc generation sources
+                        opts.EnableAnnotations();
                         opts.IncludeXmlComments(Path.Combine(
                             PlatformServices.Default.Application.ApplicationBasePath,
                             Configuration["Swagger:Filename"]));
+
+                        // Auth configuration
+                        opts.AddSecurityDefinition("basic", new OpenApiSecurityScheme
+                        {
+                            Type = SecuritySchemeType.Http,
+                            Scheme = "basic"
+                        });
+                        opts.AddSecurityDefinition("jwtbearer", new OpenApiSecurityScheme
+                        {
+                            Type = SecuritySchemeType.Http,
+                            Scheme = "bearer",
+                            BearerFormat = "JWT"
+                        });
                     })
 
                 .AddAutoMapper(
@@ -171,8 +188,8 @@ namespace Biobanks.Submissions.Api
                 .UseSwaggerUI(c =>
                 {
                     c.RoutePrefix = string.Empty; // serve swagger ui from root ;)
-                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "v1 Docs");
-                    c.SupportedSubmitMethods(); // don't allow "try it out" as the token auth doesn't work
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
+                    c.SupportedSubmitMethods(SubmitMethod.Get);
                 })
 
                 // Everything past this point is routed and subject to Auth

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Biobanks.Submissions.Api.Auth;
+using Biobanks.Submissions.Api.Auth;
+using Biobanks.Submissions.Api.Auth.Basic;
 using Biobanks.Submissions.Api.Config;
 using Biobanks.Submissions.Api.Filters;
 using Biobanks.Submissions.Api.Services;
@@ -11,7 +12,6 @@ using ClacksMiddleware.Extensions;
 
 using Hangfire;
 
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -81,7 +81,7 @@ namespace Biobanks.Submissions.Api
                         RequireExpirationTime = false
                     };
                 })
-                .AddScheme<AuthenticationSchemeOptions, BasicAuthHandler>(BasicAuthConstants.AuthenticationScheme, null);
+                .AddBasic(opts => opts.Realm = "biobankinguk-submissions-accesstoken");
 
             services
                 .AddOptions()

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -133,6 +133,7 @@ namespace Biobanks.Submissions.Api
                             Scheme = "bearer",
                             BearerFormat = "JWT"
                         });
+                        opts.OperationFilter<SecurityRequirementsOperationFilter>();
                     })
 
                 .AddAutoMapper(

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -79,7 +79,7 @@ namespace Biobanks.Submissions.Api
                         ValidIssuer = JwtBearerConstants.TokenIssuer,
                         ValidateIssuerSigningKey = true,
                         IssuerSigningKey = Crypto.GenerateSigningKey(jwtConfig.Secret),
-                        RequireExpirationTime = false
+                        RequireExpirationTime = true
                     };
                 })
                 .AddBasic(opts => opts.Realm = "biobankinguk-submissions-accesstoken");

--- a/src/Submissions/Api/Utils.cs
+++ b/src/Submissions/Api/Utils.cs
@@ -4,8 +4,20 @@ using Biobanks.Submissions.Core.Types;
 
 namespace Biobanks.Submissions.Api
 {
+    /// <summary>
+    /// General Utility methods
+    /// </summary>
     public static class Utils
     {
+        /// <summary>
+        /// Calculate Pagination properties of a given model which supports them
+        /// </summary>
+        /// <typeparam name="T">Type of the Paginated Model</typeparam>
+        /// <param name="paginatedResourceUri"></param>
+        /// <param name="paging"></param>
+        /// <param name="count"></param>
+        /// <param name="total"></param>
+        /// <param name="model"></param>
         public static void Paginate<T>(
             Uri paginatedResourceUri,
             PaginationParams paging,

--- a/src/Submissions/AzFunctions/AzFunctions.csproj
+++ b/src/Submissions/AzFunctions/AzFunctions.csproj
@@ -6,6 +6,10 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />

--- a/src/Submissions/AzFunctions/Functions/SubmissionStagingFunction.cs
+++ b/src/Submissions/AzFunctions/Functions/SubmissionStagingFunction.cs
@@ -9,11 +9,12 @@ using Biobanks.Submissions.Core.Types;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-using Newtonsoft.Json;
+
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Biobanks.Submissions.AzFunctions
@@ -63,14 +64,14 @@ namespace Biobanks.Submissions.AzFunctions
         public async Task Run(
             [QueueTrigger("operations")] string messageBody,
             FunctionContext context, // out of process context
-            // QueueTrigger metadata
+                                     // QueueTrigger metadata
             string id,
             string popReceipt)
         {
             var log = context.GetLogger("Submissions_Staging");
 
             const string storageContainer = "submission-payload";
-            var message = JsonConvert.DeserializeObject<OperationsQueueItem>(messageBody);
+            var message = JsonSerializer.Deserialize<OperationsQueueItem>(messageBody);
             var blobContents = await _blobReader.GetObjectFromJsonAsync(storageContainer, message.BlobId);
             var biobankId = message.BiobankId;
 
@@ -80,7 +81,7 @@ namespace Biobanks.Submissions.AzFunctions
             log.LogInformation($"BlobType: {message.BlobType}");
             log.LogInformation(blobContents);
 
-            var blobject = JsonConvert.DeserializeObject(blobContents, blobType);
+            var blobject = JsonSerializer.Deserialize(blobContents, blobType);
             var subId = message.SubmissionId;
 
             log.LogInformation($"blobject type: {blobject.GetType()}");

--- a/src/Submissions/Core.AzureStorage/AzureBlobWriteService.cs
+++ b/src/Submissions/Core.AzureStorage/AzureBlobWriteService.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
 using Biobanks.Submissions.Core.Services.Contracts;
-
-using Newtonsoft.Json;
 
 namespace Biobanks.Submissions.Core.AzureStorage
 {
@@ -26,7 +25,7 @@ namespace Biobanks.Submissions.Core.AzureStorage
         /// <inheritdoc />
         public async Task<Guid> StoreObjectAsJsonAsync(string container, object obj)
         {
-            var json = JsonConvert.SerializeObject(obj);
+            var json = JsonSerializer.Serialize(obj);
             return await StoreTextAsync(container, json, "application/json");
         }
 

--- a/src/Submissions/Core.AzureStorage/Core.AzureStorage.csproj
+++ b/src/Submissions/Core.AzureStorage/Core.AzureStorage.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.6.0" />

--- a/src/Submissions/Core.AzureStorage/Core.AzureStorage.csproj
+++ b/src/Submissions/Core.AzureStorage/Core.AzureStorage.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Submissions/Core/Core.csproj
+++ b/src/Submissions/Core/Core.csproj
@@ -6,6 +6,10 @@
     <AssemblyName>Biobanks.Submissions.Core</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="5.0.23" />

--- a/src/Submissions/Core/Services/DiagnosisWriteService.cs
+++ b/src/Submissions/Core/Services/DiagnosisWriteService.cs
@@ -1,16 +1,18 @@
-﻿using System;
+﻿using Biobanks.Data;
+using Biobanks.Entities.Api;
+using Biobanks.Submissions.Core.Dto;
+using Biobanks.Submissions.Core.Exceptions;
+using Biobanks.Submissions.Core.Extensions;
+using Biobanks.Submissions.Core.Services.Contracts;
+
+using Microsoft.EntityFrameworkCore;
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Biobanks.Entities.Api;
-using Biobanks.Submissions.Core.Exceptions;
-using Biobanks.Submissions.Core.Extensions;
-using Biobanks.Submissions.Core.Dto;
-using Biobanks.Submissions.Core.Services.Contracts;
-using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
-using Biobanks.Data;
 
 namespace Biobanks.Submissions.Core.Services
 {
@@ -71,7 +73,7 @@ namespace Biobanks.Submissions.Core.Services
                         resultsWithIdentifiers.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = result.ErrorMessage,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,
@@ -110,7 +112,7 @@ namespace Biobanks.Submissions.Core.Services
                         validationResults.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = exception.Message,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,
@@ -165,7 +167,7 @@ namespace Biobanks.Submissions.Core.Services
                         resultsWithIdentifiers.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = result.ErrorMessage,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,

--- a/src/Submissions/Core/Services/SampleWriteService.cs
+++ b/src/Submissions/Core/Services/SampleWriteService.cs
@@ -1,16 +1,18 @@
-﻿using System;
+﻿using Biobanks.Data;
+using Biobanks.Entities.Api;
+using Biobanks.Submissions.Core.Dto;
+using Biobanks.Submissions.Core.Exceptions;
+using Biobanks.Submissions.Core.Extensions;
+using Biobanks.Submissions.Core.Services.Contracts;
+
+using Microsoft.EntityFrameworkCore;
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Biobanks.Entities.Api;
-using Biobanks.Submissions.Core.Exceptions;
-using Biobanks.Submissions.Core.Extensions;
-using Biobanks.Submissions.Core.Dto;
-using Biobanks.Submissions.Core.Services.Contracts;
-using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
-using Biobanks.Data;
 
 namespace Biobanks.Submissions.Core.Services
 {
@@ -30,7 +32,7 @@ namespace Biobanks.Submissions.Core.Services
             => samples.Where(
                 x => x.OrganisationId == dto.OrganisationId &&
                      x.IndividualReferenceId.Equals(dto.IndividualReferenceId, StringComparison.OrdinalIgnoreCase) &&
-                     x.Barcode.Equals(dto.Barcode, StringComparison.OrdinalIgnoreCase) && 
+                     x.Barcode.Equals(dto.Barcode, StringComparison.OrdinalIgnoreCase) &&
                      (x.CollectionName ?? string.Empty).Equals(dto.CollectionName ?? string.Empty, StringComparison.OrdinalIgnoreCase));
 
         private static IEnumerable<LiveSample> GetLiveSamplesFromDto(SampleIdDto dto,
@@ -38,7 +40,7 @@ namespace Biobanks.Submissions.Core.Services
             => samples.Where(
                 x => x.OrganisationId == dto.OrganisationId &&
                      x.IndividualReferenceId.Equals(dto.IndividualReferenceId, StringComparison.OrdinalIgnoreCase) &&
-                     x.Barcode.Equals(dto.Barcode, StringComparison.OrdinalIgnoreCase) && 
+                     x.Barcode.Equals(dto.Barcode, StringComparison.OrdinalIgnoreCase) &&
                      (x.CollectionName ?? string.Empty).Equals(dto.CollectionName ?? string.Empty, StringComparison.OrdinalIgnoreCase));
 
         public async Task ProcessSamples(IEnumerable<SampleDto> dto)
@@ -71,7 +73,7 @@ namespace Biobanks.Submissions.Core.Services
                         resultsWithIdentifiers.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = result.ErrorMessage,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,
@@ -109,7 +111,7 @@ namespace Biobanks.Submissions.Core.Services
                         validationResults.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = exception.Message,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,
@@ -150,7 +152,7 @@ namespace Biobanks.Submissions.Core.Services
                 .AsNoTracking()
                 .ToListAsync();
 
-            foreach(var incomingDto in sampleIdDtos)
+            foreach (var incomingDto in sampleIdDtos)
             {
                 //controller should have done this, but: model validate the dto
                 var vcontext = new ValidationContext(dto);
@@ -163,7 +165,7 @@ namespace Biobanks.Submissions.Core.Services
                         resultsWithIdentifiers.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = result.ErrorMessage,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,

--- a/src/Submissions/Core/Services/TreatmentWriteService.cs
+++ b/src/Submissions/Core/Services/TreatmentWriteService.cs
@@ -1,16 +1,18 @@
-﻿using System;
+﻿using Biobanks.Data;
+using Biobanks.Entities.Api;
+using Biobanks.Submissions.Core.Dto;
+using Biobanks.Submissions.Core.Exceptions;
+using Biobanks.Submissions.Core.Extensions;
+using Biobanks.Submissions.Core.Services.Contracts;
+
+using Microsoft.EntityFrameworkCore;
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Biobanks.Entities.Api;
-using Biobanks.Submissions.Core.Exceptions;
-using Biobanks.Submissions.Core.Extensions;
-using Biobanks.Submissions.Core.Dto;
-using Biobanks.Submissions.Core.Services.Contracts;
-using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
-using Biobanks.Data;
 
 namespace Biobanks.Submissions.Core.Services
 {
@@ -29,7 +31,7 @@ namespace Biobanks.Submissions.Core.Services
             IEnumerable<StagedTreatment> treatments)
             => treatments.Where(
                 x => x.OrganisationId == dto.OrganisationId &&
-                x.DateTreated == dto.DateTreated &&     
+                x.DateTreated == dto.DateTreated &&
                 x.IndividualReferenceId.Equals(dto.IndividualReferenceId, StringComparison.OrdinalIgnoreCase) &&
                 x.TreatmentCodeId.Equals(dto.TreatmentCode, StringComparison.OrdinalIgnoreCase));
 
@@ -71,7 +73,7 @@ namespace Biobanks.Submissions.Core.Services
                         resultsWithIdentifiers.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = result.ErrorMessage,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,
@@ -110,7 +112,7 @@ namespace Biobanks.Submissions.Core.Services
                         validationResults.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = exception.Message,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,
@@ -119,7 +121,7 @@ namespace Biobanks.Submissions.Core.Services
                             })
                         });
                     }
-                        
+
                     continue;
                 }
 
@@ -165,7 +167,7 @@ namespace Biobanks.Submissions.Core.Services
                         resultsWithIdentifiers.Add(new BiobanksValidationResult
                         {
                             ErrorMessage = result.ErrorMessage,
-                            RecordIdentifiers = JsonConvert.SerializeObject(new
+                            RecordIdentifiers = JsonSerializer.Serialize(new
                             {
                                 incomingDto.OrganisationId,
                                 incomingDto.IndividualReferenceId,


### PR DESCRIPTION
## Overview

This pull request inlines the older IdentityProvider app used for the Submissions service, into a single `/token` endpoint on the Submissions API.

It vastly improves the robustness of the token auth used by the Submissions API without radically changing the approach.

## Azure Boards

- [AB#32498](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/32498)

## Notes

Builds on the work completed in #148 

- Increases robustness of BasicAuth handling
- BasicAuth credentials are separate from User identities, but are foreign keyed to Organisations in the central database
- The Token issuing endpoint `/token` requires BasicAuth
- ALL other Submissions API endpoints require a valid, non-expired token.
- Tokens now expire (after 1 day currently).
- Using an expired token will trigger a 401 Bearer challenge; clients receiving this should proceed to the `/token` endpoint to request a new token with their valid credentials.
- Swagger now documents required Auth Scheme, and allows authenticated "Try it out" on `GET` requests.
- The Submissions API and associated worker services now use `System.Text.Json`