### PR TITLE
AB#32774: Netstandard Directory fix, Directory build warnings

### DIFF
--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -187,6 +187,9 @@
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ComponentModel.Annotations.4.4.1\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1014,7 +1014,7 @@ namespace Biobanks.Web.Controllers
                     .Result
                 )
                 .ToList();
-            if (await _biobankReadService.GetSiteConfigStatus("site.display.preservation.percent") == true)
+            if (await _biobankReadService.GetSiteConfigStatus("site.display.preservation.percent"))
             {
                 return View(new CollectionPercentagesModel()
                 {
@@ -1025,8 +1025,6 @@ namespace Biobanks.Web.Controllers
             {
                 return RedirectToAction("LockedRef");
             }
-
-            return RedirectToAction("CollectionPercentages");
         }
 
         #endregion
@@ -1324,7 +1322,7 @@ namespace Biobanks.Web.Controllers
         #region RefData: County
         public async Task<ActionResult> County()
         {
-            if (await _biobankReadService.GetSiteConfigStatus("site.display.counties") == true)
+            if (await _biobankReadService.GetSiteConfigStatus("site.display.counties"))
             {
                 var countries = await _biobankReadService.ListCountriesAsync();
 
@@ -1353,8 +1351,6 @@ namespace Biobanks.Web.Controllers
             {
                 return RedirectToAction("LockedRef");
             }
-
-            return RedirectToAction("County");
         }
 
         #endregion

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -550,13 +550,11 @@ namespace Biobanks.Web.Controllers
             return View(
                 (await _biobankReadService.ListFundersAsync(string.Empty))
                     .Select(x =>
-
-                        Task.Run(async () => new FunderModel
+                        new FunderModel
                         {
                             FunderId = x.Id,
                             Name = x.Value
-                        }).Result)
-
+                        })
                     .ToList()
                 );
         }
@@ -1480,7 +1478,7 @@ namespace Biobanks.Web.Controllers
         #region Site Configuration
 
         #region Homepage Config
-        public async Task<ActionResult> HomepageConfig()
+        public ActionResult HomepageConfig()
         {
             return View(new HomepageContentModel
             {
@@ -1531,7 +1529,7 @@ namespace Biobanks.Web.Controllers
         #endregion
 
         #region Termpage Config
-        public async Task<ActionResult> TermpageConfig()
+        public ActionResult TermpageConfig()
         {
             return View(new TermPageModel
             {
@@ -1606,7 +1604,7 @@ namespace Biobanks.Web.Controllers
         #endregion
 
         #region Register Biobank and Network Pages Config
-        public async Task<ActionResult> RegisterPagesConfig()
+        public ActionResult RegisterPagesConfig()
         {
             return View(new RegisterConfigModel
             {

--- a/src/Directory/Biobanks.Web/Controllers/HomeController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/HomeController.cs
@@ -31,7 +31,7 @@ namespace Biobanks.Web.Controllers
         }
 
         // GET: Home
-        public async Task<ActionResult> Index()
+        public ActionResult Index()
         {
             return View(new HomepageContentModel
             {

--- a/src/Directory/Biobanks.Web/Filters/HangfireAuthorisationFilter.cs
+++ b/src/Directory/Biobanks.Web/Filters/HangfireAuthorisationFilter.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Web;
 using Hangfire.Dashboard;
 
 namespace Biobanks.Web.Filters
 {
+    [Obsolete]
     public class HangFireAuthorizationFilter : IAuthorizationFilter
     {
         public bool Authorize(IDictionary<string, object> owinEnvironment)

--- a/src/Directory/Biobanks.Web/HangfireJobActivator/HangfireWindsorJobActivator.cs
+++ b/src/Directory/Biobanks.Web/HangfireJobActivator/HangfireWindsorJobActivator.cs
@@ -26,6 +26,7 @@ namespace Biobanks.Web.HangfireJobActivator
             return _kernel.Resolve(jobType);
         }
 
+        [Obsolete]
         public override JobActivatorScope BeginScope()
         {
             return new HangfireIocJobActivatorScope(this, _kernel);

--- a/src/Directory/Biobanks.Web/Startup.cs
+++ b/src/Directory/Biobanks.Web/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Web.Http.Dispatcher;
 using System.Web.Mvc;
 using Biobanks.Web.Filters;
@@ -17,6 +18,8 @@ namespace Biobanks.Web
         //http://tech.trailmax.info/2014/09/aspnet-identity-and-ioc-container-registration/
         internal static IDataProtectionProvider DataProtectionProvider { get; private set; }
 
+        [Obsolete("Sections of this method contain Obselete usages. Reference the comments for details")]
+        // Hangfire AuthorizationFilters
         public void Configuration(IAppBuilder app)
         {
             DataProtectionProvider = app.GetDataProtectionProvider();
@@ -39,7 +42,8 @@ namespace Biobanks.Web
             JobActivator.Current = new HangfireWindsorJobActivator(windsorContainer.Kernel);
 
             // Make sure only SuperUsers can access the Hangfire dashboard.
-            app.UseHangfireDashboard("/hangfire", new DashboardOptions { AuthorizationFilters = new[] { new HangFireAuthorizationFilter() } });
+            app.UseHangfireDashboard("/hangfire", new DashboardOptions {
+                AuthorizationFilters = new[] { new HangFireAuthorizationFilter() } });
 
             // Start the Hangfire services.
             app.UseHangfireDashboard();

--- a/src/Directory/Biobanks.Web/Web.Release.config
+++ b/src/Directory/Biobanks.Web/Web.Release.config
@@ -2,6 +2,6 @@
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <system.web>
-    <compilation debug="false" xdt:Transform="Replace" xdt:Locator="Match(debug)" />
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
   </system.web>
 </configuration>

--- a/src/Directory/Biobanks.Web/Web.config
+++ b/src/Directory/Biobanks.Web/Web.config
@@ -14,7 +14,7 @@
     
     <!-- Directory Properties -->
     <add key="AnnualStatsStartYear" value="2015" />
-    <add key="AppCulture" value="en-GB"/>
+    <add key="AppCulture" value="en-GB" />
     
     <!-- Styling Customizations -->
     <add key="PageTitle" value="Biobanking Directory" />

--- a/src/Directory/Biobanks.Web/packages.config
+++ b/src/Directory/Biobanks.Web/packages.config
@@ -68,6 +68,7 @@
   <package id="Postal.Mvc5" version="1.2.0" targetFramework="net48" />
   <package id="RazorEngine" version="3.10.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.7.1" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />

--- a/src/Directory/Data/Repositories/GenericEFRepository.cs
+++ b/src/Directory/Data/Repositories/GenericEFRepository.cs
@@ -12,8 +12,6 @@ namespace Biobanks.Directory.Data.Repositories
         private readonly BiobanksDbContext _context;
         private readonly DbSet<TEntity> _dbSet;
 
-        private bool _isDisposed = false;
-
         public GenericEFRepository(BiobanksDbContext context)
         {
             _context = context;
@@ -138,14 +136,5 @@ namespace Biobanks.Directory.Data.Repositories
         {
             return await _context.SaveChangesAsync();
         }
-
-        //public void Dispose()
-        //{
-        //    if (!_isDisposed)
-        //    {
-        //        _isDisposed = true;
-        //        _context.Dispose();
-        //    }
-        //}
     }
 }

--- a/src/Directory/Search/Elastic/ElasticCapabilitySearchProvider.cs
+++ b/src/Directory/Search/Elastic/ElasticCapabilitySearchProvider.cs
@@ -50,14 +50,14 @@ namespace Biobanks.Search.Elastic
         }
 
         /// <inheritdoc />
-        public async Task<List<int>> ListIds()
+        public Task<List<int>> ListIds()
         {
             var results = _client.Search<CapabilityDocument>(s => s
                 .MatchAll()
                 .Source(false) //don't care about the document, just its index id in the metadata
                 .Size(SizeLimits.SizeMax));
 
-            return results.Hits.Select(x => int.Parse(x.Id)).ToList();
+            return Task.FromResult(results.Hits.Select(x => int.Parse(x.Id)).ToList());
         }
 
         /// <inheritdoc />

--- a/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
+++ b/src/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
@@ -50,14 +50,14 @@ namespace Biobanks.Search.Elastic
         }
 
         /// <inheritdoc />
-        public async Task<List<int>> ListIds()
+        public Task<List<int>> ListIds()
         {
             var results = _client.Search<CollectionDocument>(s => s
                 .MatchAll()
                 .Source(false) //don't care about the document, just its index id in the metadata
                 .Size(SizeLimits.SizeMax));
 
-            return results.Hits.Select(x => int.Parse(x.Id)).ToList();
+            return Task.FromResult(results.Hits.Select(x => int.Parse(x.Id)).ToList());
         }
 
         /// <inheritdoc />

--- a/src/Directory/Search/Search.csproj
+++ b/src/Directory/Search/Search.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>Biobanks.Search</RootNamespace>
     <AssemblyName>Biobanks.Search</AssemblyName>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Directory/Search/packages.lock.json
+++ b/src/Directory/Search/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETStandard,Version=v2.0": {
+    ".NETFramework,Version=v4.8": {
       "Microsoft.CSharp": {
         "type": "Direct",
         "requested": "[4.7.0, )",
@@ -17,15 +17,6 @@
           "Elasticsearch.Net": "7.8.1"
         }
       },
-      "NETStandard.Library": {
-        "type": "Direct",
-        "requested": "[2.0.3, )",
-        "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0"
-        }
-      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.3, )",
@@ -39,20 +30,8 @@
         "dependencies": {
           "Microsoft.CSharp": "4.6.0",
           "System.Buffers": "4.5.0",
-          "System.Diagnostics.DiagnosticSource": "4.5.1",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0"
+          "System.Diagnostics.DiagnosticSource": "4.5.1"
         }
-      },
-      "Microsoft.NETCore.Platforms": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-      },
-      "Microsoft.NETCore.Targets": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -63,102 +42,6 @@
         "type": "Transitive",
         "resolved": "4.5.1",
         "contentHash": "zCno/m44ymWhgLFh7tELDG9587q0l/EynPM0m4KgLaWQbz/TEKvNRX2YT5ip2qXW/uayifQ2ZqbnErsKJ4lYrQ=="
-      },
-      "System.IO": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
-      },
-      "System.Reflection": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "KMiAFoW7MfJGa9nDFNcfu+FpEdiHpWgTcS2HdMpDvt9saK3y/G4GwprPyzqjFH9NTaGPQeWNHU+iDlDILj96aQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit.ILGeneration": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5RXItQz5As4xN2/YUDxdpsEkMhvw3e6aNveFXUn4Hl/udNTCNhnKp8lT9fnc3MhvGKh1baak5CovpuQUXHAlIA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
-        }
-      },
-      "System.Text.Encoding": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Threading.Tasks": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "LbSxKEdOUhVe8BezB/9uOGGppt+nZf6e1VFyw6v3DN6lqitm0OSn2uXMOdtP0M3W4iMcqcivm2J6UgqiwwnXiA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
       }
     }
   }

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -855,7 +855,7 @@ namespace Biobanks.Services
 
                 return sets;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }


### PR DESCRIPTION
## Overview

This PR fixes ASP.NET 4.8 runtime issues with netstandard references.

- An explicit reference to the correct version of `System.ComponentModel.Annotations` was required.
- `Directory.Search` was having issues with it's dependencies being published, so have reverted to net48
  - it's only a Directory dependency anyway, not shared like `Entities`.

While I was fixing a Directory build issue, I also resolved outstanding MSBuild warnings on the Directory solution.

## Azure Boards

- [AB#32774](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/32774)