### PR TITLE
AB#32739: Terms page still displays terms for collections from suspended biobanks

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/TermController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/TermController.cs
@@ -31,7 +31,7 @@ namespace Biobanks.Web.Controllers
 
             // List of Unique Diagnoses With Sample Sets
             var ontologyTerms = (await _biobankReadService.ListCollectionsAsync())
-                .Where(x => x.SampleSets.Any() && x.OntologyTerm.DisplayOnDirectory)
+                .Where(x => x.SampleSets.Any() && x.OntologyTerm.DisplayOnDirectory && !x.Organisation.IsSuspended)
                 .GroupBy(x => x.OntologyTermId)
                 .Select(x => x.First().OntologyTerm);
 


### PR DESCRIPTION
## Overview
When an org is suspended, any valid collections which belong to it should no longer cause the terms page to display it (a term should still appear if another collection belonging to a non suspended org is added)

