### PR TITLE
AB#32907: Other terms UI (disease statuses)

### DIFF
--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -1,17 +1,18 @@
-function DiseaseStatus(ontologyTermId, description, otherTerms) {
+function DiseaseStatus(ontologyTermId, description, otherTerms, otherTermsArray) {
     this.ontologyTermId = ko.observable(ontologyTermId);
     this.description = ko.observable(description);
     this.otherTerms = ko.observable(otherTerms);
+    this.otherTermsArray = ko.observableArray(otherTermsArray);
 }
 
-function DiseaseStatusModal(ontologyTermId, description, otherTerms) {
+function DiseaseStatusModal(ontologyTermId, description, otherTerms, otherTermsArray) {
     this.modalModeAdd = "Add";
     this.modalModeEdit = "Update";
 
     this.mode = ko.observable(this.modalModeAdd);
 
     this.diseaseStatus = ko.observable(
-        new DiseaseStatus(ontologyTermId, description, otherTerms)
+        new DiseaseStatus(ontologyTermId, description, otherTerms, otherTermsArray)
     );
 }
 
@@ -20,7 +21,7 @@ function AdacDiseaseStatusViewModel() {
     var _this = this;
 
     this.modalId = "#disease-status-modal";
-    this.modal = new DiseaseStatusModal("", "", "");
+    this.modal = new DiseaseStatusModal("", "", "",[]);
     this.dialogErrors = ko.observableArray([]);
 
     this.showModal = function () {
@@ -36,19 +37,26 @@ function AdacDiseaseStatusViewModel() {
         $("#OntologyTermId").prop("readonly", false);
 
         _this.modal.mode(_this.modal.modalModeAdd);
-        _this.modal.diseaseStatus(new DiseaseStatus("", "", ""));
+        _this.modal.diseaseStatus(new DiseaseStatus("", "", "",[]));
         _this.showModal();
     };
 
   this.openModalForEdit = function (_, event) {
     _this.modal.mode(_this.modal.modalModeEdit);
 
-    var diseaseStatus = $(event.currentTarget).data("disease-status");
+      var diseaseStatus = $(event.currentTarget).data("disease-status");
+      //let otherTermsArray = (diseaseStatus.OtherTerms ? diseaseStatus.OtherTerms.split(",").map(item => item.trim()) : diseaseStatus.OtherTerms)
+      let otherTermsArray = (diseaseStatus.OtherTerms ? diseaseStatus.OtherTerms.split(",").map(function (item, index) {
+          return { "index": index, "term": item.trim() };
+      }
+      ) : diseaseStatus.OtherTerms)
+
     _this.modal.diseaseStatus(
       new DiseaseStatus(
           diseaseStatus.OntologyTermId,
           diseaseStatus.Description,
-          diseaseStatus.OtherTerms
+          diseaseStatus.OtherTerms,
+          otherTermsArray
 
       )
     );
@@ -82,6 +90,16 @@ function AdacDiseaseStatusViewModel() {
             $("#OntologyTermId").prop('readonly', false);
             $("#Description").prop('readonly', false);
         }
+    }
+
+    this.addOtherTerms = function () {
+        _this.modal.diseaseStatus().otherTermsArray.push({});
+    }
+    this.removeOtherTerms = function () {
+        _this.modal.diseaseStatus().otherTermsArray.remove(this.valueOf())
+    }
+    this.updateOtherTerms = function () {
+        _this.modal.diseaseStatus().otherTermsArray.replace(this.valueOf())
     }
 }
 

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -1,18 +1,17 @@
-function DiseaseStatus(ontologyTermId, description, otherTerms, otherTermsArray) {
+function DiseaseStatus(ontologyTermId, description, otherTerms) {
     this.ontologyTermId = ko.observable(ontologyTermId);
     this.description = ko.observable(description);
-    this.otherTerms = ko.observable(otherTerms);
-    this.otherTermsArray = ko.observableArray(otherTermsArray);
+    this.otherTerms = ko.observableArray(otherTerms);
 }
 
-function DiseaseStatusModal(ontologyTermId, description, otherTerms, otherTermsArray) {
+function DiseaseStatusModal(ontologyTermId, description, otherTerms) {
     this.modalModeAdd = "Add";
     this.modalModeEdit = "Update";
 
     this.mode = ko.observable(this.modalModeAdd);
 
     this.diseaseStatus = ko.observable(
-        new DiseaseStatus(ontologyTermId, description, otherTerms, otherTermsArray)
+        new DiseaseStatus(ontologyTermId, description, otherTerms)
     );
 }
 
@@ -21,7 +20,7 @@ function AdacDiseaseStatusViewModel() {
     var _this = this;
 
     this.modalId = "#disease-status-modal";
-    this.modal = new DiseaseStatusModal("", "", "",[]);
+    this.modal = new DiseaseStatusModal("", "", []);
     this.dialogErrors = ko.observableArray([]);
 
     this.showModal = function () {
@@ -37,7 +36,7 @@ function AdacDiseaseStatusViewModel() {
         $("#OntologyTermId").prop("readonly", false);
 
         _this.modal.mode(_this.modal.modalModeAdd);
-        _this.modal.diseaseStatus(new DiseaseStatus("", "", "", []));
+        _this.modal.diseaseStatus(new DiseaseStatus("", "",[]));
         _this.setPartialEdit(false);
         _this.showModal();
     };
@@ -46,14 +45,15 @@ function AdacDiseaseStatusViewModel() {
     _this.modal.mode(_this.modal.modalModeEdit);
 
       var diseaseStatus = $(event.currentTarget).data("disease-status");
-      let otherTermsArray = (diseaseStatus.OtherTerms ? diseaseStatus.OtherTerms.split(",").map(item => item.trim()) : diseaseStatus.OtherTerms)
+      let otherTerms = (diseaseStatus.OtherTerms
+          ? diseaseStatus.OtherTerms.split(",").map(item => item.trim())
+          : diseaseStatus.OtherTerms)
 
     _this.modal.diseaseStatus(
       new DiseaseStatus(
           diseaseStatus.OntologyTermId,
           diseaseStatus.Description,
-          diseaseStatus.OtherTerms,
-          otherTermsArray
+          otherTerms
 
       )
     );
@@ -67,7 +67,7 @@ function AdacDiseaseStatusViewModel() {
         var form = $(e.target); // get form as a jquery object
 
         //Concatenate other terms (exclude null/empty/whitespace strings)
-        $("#OtherTerms").val(_this.modal.diseaseStatus().otherTermsArray().filter(x => x && x.trim()).join(','));
+        $("#OtherTerms").val(_this.modal.diseaseStatus().otherTerms().filter(x => x && x.trim()).join(','));
 
         // Get Action Type
         var action = _this.modal.mode();
@@ -93,10 +93,10 @@ function AdacDiseaseStatusViewModel() {
     }
 
     this.addOtherTerms = function () {
-        _this.modal.diseaseStatus().otherTermsArray.push("");
+        _this.modal.diseaseStatus().otherTerms.push("");
     }
     this.removeOtherTerms = function (idx) {
-        _this.modal.diseaseStatus().otherTermsArray.splice(idx,1)
+        _this.modal.diseaseStatus().otherTerms.splice(idx,1)
     }
 }
 

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -45,11 +45,7 @@ function AdacDiseaseStatusViewModel() {
     _this.modal.mode(_this.modal.modalModeEdit);
 
       var diseaseStatus = $(event.currentTarget).data("disease-status");
-      //let otherTermsArray = (diseaseStatus.OtherTerms ? diseaseStatus.OtherTerms.split(",").map(item => item.trim()) : diseaseStatus.OtherTerms)
-      let otherTermsArray = (diseaseStatus.OtherTerms ? diseaseStatus.OtherTerms.split(",").map(function (item, index) {
-          return { "index": index, "term": item.trim() };
-      }
-      ) : diseaseStatus.OtherTerms)
+      let otherTermsArray = (diseaseStatus.OtherTerms ? diseaseStatus.OtherTerms.split(",").map(item => item.trim()) : diseaseStatus.OtherTerms)
 
     _this.modal.diseaseStatus(
       new DiseaseStatus(
@@ -93,13 +89,13 @@ function AdacDiseaseStatusViewModel() {
     }
 
     this.addOtherTerms = function () {
-        _this.modal.diseaseStatus().otherTermsArray.push({});
+        _this.modal.diseaseStatus().otherTermsArray.push("");
     }
-    this.removeOtherTerms = function () {
-        _this.modal.diseaseStatus().otherTermsArray.remove(this.valueOf())
+    this.removeOtherTerms = function (idx) {
+        _this.modal.diseaseStatus().otherTermsArray.splice(idx,1)
     }
-    this.updateOtherTerms = function () {
-        _this.modal.diseaseStatus().otherTermsArray.replace(this.valueOf())
+    this.updateOtherTerms = function (idx) {
+        _this.modal.diseaseStatus().otherTermsArray.replace(this.valueOf());
     }
 }
 

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -37,7 +37,8 @@ function AdacDiseaseStatusViewModel() {
         $("#OntologyTermId").prop("readonly", false);
 
         _this.modal.mode(_this.modal.modalModeAdd);
-        _this.modal.diseaseStatus(new DiseaseStatus("", "", "",[]));
+        _this.modal.diseaseStatus(new DiseaseStatus("", "", "", []));
+        _this.setPartialEdit(false);
         _this.showModal();
     };
 

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -65,6 +65,9 @@ function AdacDiseaseStatusViewModel() {
         e.preventDefault();
         var form = $(e.target); // get form as a jquery object
 
+        //Concatenate other terms (exclude null/empty/whitespace strings)
+        $("#OtherTerms").val(_this.modal.diseaseStatus().otherTermsArray().filter(x => x && x.trim()).join(','));
+
         // Get Action Type
         var action = _this.modal.mode();
         if (action == 'Add') {
@@ -93,9 +96,6 @@ function AdacDiseaseStatusViewModel() {
     }
     this.removeOtherTerms = function (idx) {
         _this.modal.diseaseStatus().otherTermsArray.splice(idx,1)
-    }
-    this.updateOtherTerms = function (idx) {
-        _this.modal.diseaseStatus().otherTermsArray.replace(this.valueOf());
     }
 }
 

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -122,7 +122,7 @@
                         <div class="col-sm-12">
 
                             <input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
-
+                            <input type="hidden" id="OtherTerms" name="OtherTerms">
                             <!-- SNOMED ID -->
                             <div class="form-group">
                                 <label class="col-sm-3 control-label">Ontology Term ID</label>
@@ -145,12 +145,12 @@
                             <div data-bind="foreach: modal.diseaseStatus().otherTermsArray()">
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label" data-bind="visible: $index() < 1">Other Terms</label>
-                                    <div class="col-sm-8"  data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
-                                        <input type="text" name="OtherTerms" class="form-control"
+                                    <div class="col-sm-8" data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
+                                        <input type="text" class="form-control"
                                                data-bind="textInput: $parent.modal.diseaseStatus().otherTermsArray()[$index()]">
                                     </div>
                                     <div class="col-sm-1">
-                                        <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right" 
+                                        <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right"
                                                 data-bind="click: function() { $parent.removeOtherTerms($index())}" />
                                     </div>
                                 </div>

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -142,12 +142,12 @@
                             </div>
 
                             <!-- Other Terms -->
-                            <div data-bind="foreach: modal.diseaseStatus().otherTermsArray()">
+                            <div data-bind="foreach: modal.diseaseStatus().otherTerms()">
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label" data-bind="visible: $index() < 1">Other Terms</label>
                                     <div class="col-sm-8" data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
                                         <input type="text" class="form-control"
-                                               data-bind="textInput: $parent.modal.diseaseStatus().otherTermsArray()[$index()]">
+                                               data-bind="textInput: $parent.modal.diseaseStatus().otherTerms()[$index()]">
                                     </div>
                                     <div class="col-sm-1">
                                         <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right"

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -142,34 +142,27 @@
                             </div>
 
                             <!-- Other Terms -->
-                            <div class="form-group">
-                                <label class="col-sm-3 control-label">Other Terms</label>
-                                <div class="col-sm-8">
-                                    <input type="text" id="OtherTerms" name="OtherTerms" class="form-control"
-                                           data-bind="value: modal.diseaseStatus().otherTermsArray()[0]">
-                                </div>
-                                <div class="col-sm-1">
-                                    <button type="button" class="fa fa-plus-circle btn btn-default form-control-static pull-right" data-bind="click: addOtherTerms"/>
-                                </div>
-                            </div>
-                            <div data-bind="visible: modal.diseaseStatus().otherTermsArray().length > 1, foreach: modal.diseaseStatus().otherTermsArray().slice(1) ">
+                            <div data-bind="foreach: modal.diseaseStatus().otherTermsArray()">
                                 <div class="form-group">
-                                    <div class="col-sm-offset-3 col-sm-8">
-                                        <input type="text" id="OtherTerms" name="OtherTerms" class="form-control"
-                                               data-bind="value: $data.term">
+                                    <label class="col-sm-3 control-label" data-bind="visible: $index() < 1">Other Terms</label>
+                                    <div class="col-sm-8"  data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
+                                        <input type="text" name="OtherTerms" class="form-control"
+                                               data-bind="textInput: $parent.modal.diseaseStatus().otherTermsArray()[$index()]">
                                     </div>
                                     <div class="col-sm-1">
-                                        <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right" data-bind="click: $parent.removeOtherTerms"/>
+                                        <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right" 
+                                                data-bind="click: function() { $parent.removeOtherTerms($index())}" />
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
 				</div>
-				<div class="modal-footer">
-					<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-					<button type="submit" class="btn btn-primary" data-bind="text: modal.mode"></button>
-				</div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-success" data-bind="click: addOtherTerms">Add Other Term</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary" data-bind="text: modal.mode"></button>
+                </div>
 			</form>
 		</div>
 	</div>

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -119,39 +119,52 @@
 				<div class="modal-body">
 
 					<div class="row">
-						<div class="col-sm-12">
+                        <div class="col-sm-12">
 
-							<input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
+                            <input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
 
-							<!-- SNOMED ID -->
-							<div class="form-group">
-								<label class="col-sm-3 control-label">Ontology Term ID</label>
-								<div class="col-sm-9">
-									<input type="text" id="OntologyTermId" name="OntologyTermId" class="form-control"
-										   data-bind="value: modal.diseaseStatus().ontologyTermId()" maxlength="20">
-								</div>
-							</div>
+                            <!-- SNOMED ID -->
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">Ontology Term ID</label>
+                                <div class="col-sm-9">
+                                    <input type="text" id="OntologyTermId" name="OntologyTermId" class="form-control"
+                                           data-bind="value: modal.diseaseStatus().ontologyTermId()" maxlength="20">
+                                </div>
+                            </div>
 
-							<!-- Description -->
-							<div class="form-group">
-								<label class="col-sm-3 control-label">Name</label>
-								<div class="col-sm-9">
-									<input type="text" id="Description" name="Description" class="form-control"
-										   data-bind="value: modal.diseaseStatus().description()">
-								</div>
-							</div>
+                            <!-- Description -->
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">Name</label>
+                                <div class="col-sm-9">
+                                    <input type="text" id="Description" name="Description" class="form-control"
+                                           data-bind="value: modal.diseaseStatus().description()">
+                                </div>
+                            </div>
 
-							<!-- Other Terms -->
-							<div class="form-group">
-								<label class="col-sm-3 control-label">Other Terms</label>
-								<div class="col-sm-9">
-									<input type="text" id="OtherTerms" name="OtherTerms" class="form-control"
-										   data-bind="value: modal.diseaseStatus().otherTerms()">
-								</div>
-							</div>
-						</div>
-					</div>
-
+                            <!-- Other Terms -->
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">Other Terms</label>
+                                <div class="col-sm-8">
+                                    <input type="text" id="OtherTerms" name="OtherTerms" class="form-control"
+                                           data-bind="value: modal.diseaseStatus().otherTermsArray()[0]">
+                                </div>
+                                <div class="col-sm-1">
+                                    <button type="button" class="fa fa-plus-circle btn btn-default form-control-static pull-right" data-bind="click: addOtherTerms"/>
+                                </div>
+                            </div>
+                            <div data-bind="visible: modal.diseaseStatus().otherTermsArray().length > 1, foreach: modal.diseaseStatus().otherTermsArray().slice(1) ">
+                                <div class="form-group">
+                                    <div class="col-sm-offset-3 col-sm-8">
+                                        <input type="text" id="OtherTerms" name="OtherTerms" class="form-control"
+                                               data-bind="value: $data.term">
+                                    </div>
+                                    <div class="col-sm-1">
+                                        <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right" data-bind="click: $parent.removeOtherTerms"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 				</div>
 				<div class="modal-footer">
 					<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>


### PR DESCRIPTION
## Overview
In Disease Statuses, when adding other terms, it would be better if if the UI had a new entry for each Other Term for a given disease. 
In the DB back end the Other Terms can remain unchanged but delimiter can split up each entry in the UI. Adding new other terms in the UI will then populate the entry with delimiters.