### PR TITLE
AB#33311: Fixing Publications/Analytics for Linux

### DIFF
--- a/src/Analytics/AzureFunctions/Startup.cs
+++ b/src/Analytics/AzureFunctions/Startup.cs
@@ -20,7 +20,7 @@ namespace Analytics.AnalyticsAzureFunctions
             _configuration = builder.Services.BuildServiceProvider()
                 .GetService<IConfiguration>();
 
-            var sqlConnection = _configuration.GetConnectionString("sqldb-connection");
+            var sqlConnection = _configuration.GetConnectionString("Default");
             builder.Services.AddDbContext<AnalyticsDbContext>(options =>
                options.UseSqlServer(sqlConnection, options => options.EnableRetryOnFailure()));
 

--- a/src/Analytics/Services/AnalyticsReportGenerator.cs
+++ b/src/Analytics/Services/AnalyticsReportGenerator.cs
@@ -22,10 +22,10 @@ namespace Analytics.Services
         {
             _config = configuration;
             _googleAnalyticsReadService = googleAnalyticsReadService;
-            _numOfTopBiobanks = _config.GetValue<int>("metric-threshold", 10);
-            _eventThreshold = _config.GetValue<int>("event-threshold", 30); 
-            _filterByHost = _config.GetValue<bool>("filterby-host", true); 
-            _hostname = _config.GetValue<string>("directory-hostname",""); 
+            _numOfTopBiobanks = _config.GetValue<int>("MetricThreshold", 10);
+            _eventThreshold = _config.GetValue<int>("EventThreshold", 30); 
+            _filterByHost = _config.GetValue<bool>("FilterbyHost", true); 
+            _hostname = _config.GetValue<string>("DirectoryHostname",""); 
         }
 
         public ProfilePageViewsDto GetProfilePageViews(string biobankId, IEnumerable<Data.Entities.OrganisationAnalytic> biobankData)

--- a/src/Analytics/Services/GoogleAnalyticsReadService.cs
+++ b/src/Analytics/Services/GoogleAnalyticsReadService.cs
@@ -45,10 +45,10 @@ namespace Analytics.Services
         {
             _ctx = ctx;
             _config = configuration;
-            _viewId = _config.GetValue<string>("analytics-viewid", "");
-            _startDate = _config.GetValue<string>("start-date", "2016-01-01");
+            _viewId = _config.GetValue<string>("AnalyticsViewid", "");
+            _startDate = _config.GetValue<string>("StartDate", "2016-01-01");
 
-            _credentials = GoogleCredential.FromJson(_config.GetValue<string>("analytics-apikey", "{}"))
+            _credentials = GoogleCredential.FromJson(_config.GetValue<string>("AnalyticsApikey", "{}"))
                 .CreateScoped(new[] { AnalyticsReportingService.Scope.AnalyticsReadonly });
 
             _analytics = new AnalyticsReportingService(

--- a/src/Analytics/readme.md
+++ b/src/Analytics/readme.md
@@ -1,10 +1,10 @@
-# UKCRC Tissue Directory Reporting pipeline
+# UKCRC Tissue Directory Reporting Service
 
 The code in this repository can generate reports on the Google Analytics data associated with the UKCRC TDCC Directory.
 
 Reports can either be run for the entirety of the directory, or for each registered biobank / sample resource individually.
 
-# Pipeline overview
+# Overview
 
 ## Google Analytics key file
 For authentication with Google Analytics, a key file (JSON) is necessary in order to work with OAuth2. More details on that here: https://developers.google.com/analytics/devguides/reporting/core/v4/authorization
@@ -18,7 +18,7 @@ AnalyticsFunction.cs # Generates biobank report from HTTP request
 - BatchFunction.cs # Downloads analytics data for biobanks and TDCC directory from Google Analytics
 ```
 
-to run the pipeline (generate a report), 
+to use the service (generate a report), 
 simply send a GET request using the function route e.g. for a biobank report :
 ```
 http://{hostname}/api/GetAnalyticsReport/{biobankId}/{year}/{quarter}/{period}?code={apikey}";
@@ -40,21 +40,16 @@ apikey :  string # can be found for example from the azure function's portal,
 ## Configuration
 Definition of App configs:
 ```
-"analytics-apikey": JSON, # json object in Google Analytics key file, see section above 
-"analytics-viewid": int, # ID of the Google Analytics view
-"DirectoryUrl": string # URL of TDCC site to retrieve biobank information via api call e.g ("http://directory.biobankinguk.org/")
-"filterby-host": boolean # if set to true, analytics data would be filtered to include only those from the specified hostname
-"directory-hostname": string # specifies hostname when filterby-host is enabled e.g. ("directory.biobankinguk.org")
-"start-date": string, # start date of the timeframe to download Google Analytics data for (format: yyyy-mm-dd)
-"metric-threshold": int, # number of biobanks to include in the ranking for biobank reports (default: 10)
-"event-threshold": int, #  number of event groups that originated from the same location on a particular day above which will be excluded from plots default: 30)
-"sqldb-username": string # username for the (azure) database used to store the analytics data
-"sqldb-password": string # password for the (azure) database used to store the analytics data
-"analyticsdb_connection": string # connection string for the (azure) database used to store the analytics data with the username and password excluded (to be parsed in) in the format e.g "Server=servername;Initial Catalog=dbname;Persist Security Info=False;User ID={0};Password={1};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+"AnalyticsApikey": JSON, # json object in Google Analytics key file, see section above 
+"AnalyticsViewid": int, # ID of the Google Analytics view
+"FilterbyHost": boolean # if set to true, analytics data would be filtered to include only those from the specified hostname
+"DirectoryHostname": string # specifies hostname when FilterbyHost is enabled e.g. ("directory.biobankinguk.org")
+"StartDate": string, # start date of the timeframe to download Google Analytics data for (format: yyyy-mm-dd)
+"MetricThreshold": int, # number of biobanks to include in the ranking for biobank reports (default: 10)
+"EventThreshold": int, #  number of event groups that originated from the same location on a particular day above which will be excluded from plots default: 30)
+"ConnectionStrings:Default": string # connection string for the (azure) database used to store the analytics data
 ```
 
 
-# Further misc comments on the pipeline
+# Notes
 - Code adapted from 'biobanks.analytics' Azure DevOps repo (written in python). See for more information (relevant UoN people should have access)
-
-- when running EF migrations, the username and password should be filled/passed into "analyticsdb_connection" (as you'd have for a normal connection string) and passed as an env variable. This is expected by AnalyticsDbContext.cs during creation.

--- a/src/Publications/PublicationsAzureFunctions/Startup.cs
+++ b/src/Publications/PublicationsAzureFunctions/Startup.cs
@@ -29,7 +29,7 @@ namespace PublicationsAzureFunctions
                 .GetService<IConfiguration>();
 
             // Populate connection string with credentials
-            var sqlConnection = _configuration.GetConnectionString("sqldb-connection");
+            var sqlConnection = _configuration.GetConnectionString("Default");
 
             // Register DbContext
             builder.Services.AddDbContext<PublicationDbContext>(options =>

--- a/src/Publications/README.md
+++ b/src/Publications/README.md
@@ -83,9 +83,8 @@ The function app uses App Settings to configure the URLs of the apis it relies u
   <img src="./readme/azure-function-settings.png" width="60%" />
 </p>
 
-The Function App requires two URLs
+The Function App requires the EPMC API URL
 ```yml
-DirectoryUrl: "<directory-url>",
 EpmcApiUrl: "https://www.ebi.ac.uk/europepmc/"
 ```
 


### PR DESCRIPTION
## Overview

While sorting some of our Azure infrastructure, it's desirable to deploy our functions apps to Linux environments. This PR aims to resolve some incompatibility:

- Linux doesn't support `-` in Environment Variables
- These apps use `-` in some configuration keys
- Azure Portal sets configuration as environment variables

## Azure Boards

- [AB#33311](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/33311)