### PR TITLE
AB#32943: Publicly display the version

### DIFF
--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -457,6 +457,7 @@
     <Compile Include="App_Start\ProfilerConfig.cs" />
     <Compile Include="Controllers\FooterController.cs" />
     <Compile Include="Controllers\HeaderController.cs" />
+    <Compile Include="Controllers\VersionController.cs" />
     <Compile Include="Extensions\DictionaryExtension.cs" />
     <Compile Include="Filters\UserApiAuthorizeAttribute.cs" />
     <Compile Include="Models\ADAC\PreservationTypeModel.cs" />
@@ -1044,6 +1045,7 @@
     <Compile Include="Utilities\FeedbackMessage.cs" />
     <Compile Include="Utilities\SessionHelper.cs" />
     <Compile Include="Utilities\SessionKeys.cs" />
+    <Compile Include="Utilities\VersionHelper.cs" />
     <Compile Include="Views\ApplicationBaseViewPage.cs" />
     <Compile Include="Windsor\WindsorActionFilterHelper.cs" />
     <Compile Include="Windsor\WindsorActionInvoker.cs" />
@@ -1101,6 +1103,7 @@
     <Folder Include="Views\ServiceOfferings\" />
     <Folder Include="Views\Sexes\" />
     <Folder Include="Views\SopStatus\" />
+    <Folder Include="Views\Version\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Data\Data.csproj">

--- a/src/Directory/Biobanks.Web/Controllers/VersionController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/VersionController.cs
@@ -1,0 +1,18 @@
+﻿using Biobanks.Web.HtmlHelpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Biobanks.Web.Controllers
+{
+    public class VersionController : Controller
+    {
+        // GET: Version
+        public string Index()
+        {            
+            return Utilities.VersionHelper.GetVersionNumber();
+        }
+    }
+}

--- a/src/Directory/Biobanks.Web/Controllers/VersionController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/VersionController.cs
@@ -12,7 +12,7 @@ namespace Biobanks.Web.Controllers
         // GET: Version
         public string Index()
         {            
-            return Utilities.VersionHelper.GetVersionNumber();
+            return Utilities.VersionHelper.GetInformationalVersion();
         }
     }
 }

--- a/src/Directory/Biobanks.Web/HtmlHelpers/VersionHelper.cs
+++ b/src/Directory/Biobanks.Web/HtmlHelpers/VersionHelper.cs
@@ -14,13 +14,8 @@ namespace Biobanks.Web.HtmlHelpers
 
         public static string InformationalVersion(this HtmlHelper helper)
         {
-            //InformationalVersion can contain strings, not just numbers
-            //so is useful for Semantic Versioning http://semver.org            
-
-            var attr = Utilities.VersionHelper.GetVersionNumber();            
-
             //return the assembly version if no informational version
-            return attr ?? AssemblyVersion(helper);
+            return Utilities.VersionHelper.GetInformationalVersion() ?? AssemblyVersion(helper);
         }        
     }
 }

--- a/src/Directory/Biobanks.Web/HtmlHelpers/VersionHelper.cs
+++ b/src/Directory/Biobanks.Web/HtmlHelpers/VersionHelper.cs
@@ -9,28 +9,18 @@ namespace Biobanks.Web.HtmlHelpers
     {
         public static string AssemblyVersion(this HtmlHelper helper)
         {
-            return GetAspNetAssembly().GetName().Version.ToString();
+            return Utilities.VersionHelper.GetAspNetAssembly().GetName().Version.ToString();
         }
 
         public static string InformationalVersion(this HtmlHelper helper)
         {
             //InformationalVersion can contain strings, not just numbers
-            //so is useful for Semantic Versioning http://semver.org
+            //so is useful for Semantic Versioning http://semver.org            
 
-            //http://stackoverflow.com/questions/7770068/get-the-net-assemblys-assemblyinformationalversion-value
-            var attr = Attribute.GetCustomAttribute(
-                    GetAspNetAssembly(),
-                    typeof(AssemblyInformationalVersionAttribute))
-                as AssemblyInformationalVersionAttribute;
+            var attr = Utilities.VersionHelper.GetVersionNumber();            
 
             //return the assembly version if no informational version
-            return attr?.InformationalVersion ?? AssemblyVersion(helper);
-        }
-
-        private static Assembly GetAspNetAssembly()
-        {
-            //http://stackoverflow.com/questions/4277692/getentryassembly-for-web-applications
-            return HttpContext.Current.ApplicationInstance.GetType().BaseType?.Assembly;
-        }
+            return attr ?? AssemblyVersion(helper);
+        }        
     }
 }

--- a/src/Directory/Biobanks.Web/Utilities/VersionHelper.cs
+++ b/src/Directory/Biobanks.Web/Utilities/VersionHelper.cs
@@ -8,8 +8,10 @@ namespace Biobanks.Web.Utilities
 {
     public class VersionHelper
     {
-        public static string GetVersionNumber()
+        public static string GetInformationalVersion()
         {
+            //InformationalVersion can contain strings, not just numbers
+            //so is useful for Semantic Versioning http://semver.org 
             //http://stackoverflow.com/questions/7770068/get-the-net-assemblys-assemblyinformationalversion-value
             var attr = Attribute.GetCustomAttribute(
                     GetAspNetAssembly(),

--- a/src/Directory/Biobanks.Web/Utilities/VersionHelper.cs
+++ b/src/Directory/Biobanks.Web/Utilities/VersionHelper.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Web;
+
+namespace Biobanks.Web.Utilities
+{
+    public class VersionHelper
+    {
+        public static string GetVersionNumber()
+        {
+            //http://stackoverflow.com/questions/7770068/get-the-net-assemblys-assemblyinformationalversion-value
+            var attr = Attribute.GetCustomAttribute(
+                    GetAspNetAssembly(),
+                    typeof(AssemblyInformationalVersionAttribute))
+                as AssemblyInformationalVersionAttribute;
+
+            return attr?.InformationalVersion;
+        }
+
+        public static Assembly GetAspNetAssembly()
+        {
+            //http://stackoverflow.com/questions/4277692/getentryassembly-for-web-applications
+            return HttpContext.Current.ApplicationInstance.GetType().BaseType?.Assembly;
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Displays the version at /version in plain text

## Notes

Refactored some of the code to eliminate any duplicate code. New VersionHelper in Utilities contains code that was previously in HtmlHelpers\VersionHelper. This HtmlHelper now references the new VersionHelper.