### PR TITLE
AB#31168: Release workflow changes for deployment pipelines

### DIFF
--- a/.github/actions/version-manifest/action.yml
+++ b/.github/actions/version-manifest/action.yml
@@ -14,6 +14,8 @@ inputs:
 outputs:
   version:
     description: Updated version according to the manifest's release type.
+  isPrerelease:
+    description: Is the updated version a prerelease version?
   doRelease:
     description: Whether a release should be triggered based on the manifest release type.
 runs:

--- a/.github/actions/version-manifest/dist/index.js
+++ b/.github/actions/version-manifest/dist/index.js
@@ -74,6 +74,11 @@ try {
   // record the updated version
   core.setOutput("version", manifest.version);
   console.log("version:", manifest.version);
+
+  // and if it's a prerelease
+  const isPrerelease = !!semver.prerelease(manifest.version);
+  core.setOutput("isPrerelease", isPrerelease);
+  console.log("isPrerelease:", isPrerelease);
 } catch (e) {
   core.setFailed(e.message);
 }

--- a/.github/actions/version-manifest/index.js
+++ b/.github/actions/version-manifest/index.js
@@ -67,6 +67,11 @@ try {
   // record the updated version
   core.setOutput("version", manifest.version);
   console.log("version:", manifest.version);
+
+  // and if it's a prerelease
+  const isPrerelease = !!semver.prerelease(manifest.version);
+  core.setOutput("isPrerelease", isPrerelease);
+  console.log("isPrerelease:", isPrerelease);
 } catch (e) {
   core.setFailed(e.message);
 }

--- a/.github/workflows/main.release.yml
+++ b/.github/workflows/main.release.yml
@@ -8,12 +8,20 @@
 # 3. Include the artifact in the `releaseArtifacts` variable
 
 name: GitHub Release
+
 on:
+  workflow_dispatch: # manual trigger
+    inputs:
+      buildConfig:
+        description: Build Configuration
+        required: true
+        default: ${CI_build-config} # lets us set the default once in environment
   push:
     branches: [main, support/*]
 
 env:
-  CI_build-config: release
+  # lets workflow_dispatch override, but allows all steps to reference the env variable
+  CI_build-config: ${{ github.events.inputs.buildConfig || 'release' }}
   CI_dotnet-version: 5.0.x
   CI_publish-dir: publish
 
@@ -45,18 +53,17 @@ jobs:
       # add new jobs here;
       # this should essentially depend on everything
       # that isn't a dependency of something else!
-      # - publish-dataseed
+      - publish-dataseed
       - publish-identitytool
-      # - publish-submissions-api
-      # - publish-submissions-azfunctions
-      # - publish-analytics-azfunctions
-      # - publish-publications-azfunctions
-      # - publish-directory
-      # - publish-data-migrations
+      - publish-submissions-api
+      - publish-submissions-azfunctions
+      - publish-analytics-azfunctions
+      - publish-publications-azfunctions
+      - publish-directory
+      - publish-data-migrations
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publish jobs complete"
-
 
   # Stage 1.
   # - Get version status from manifest, to inform the rest of the workflow
@@ -72,46 +79,47 @@ jobs:
       - uses: actions/checkout@v2
       - id: manifest
         uses: ./.github/actions/version-manifest
-      - uses: chrnorm/deployment-action@v1.2.0
-        id: deployment
+      - id: friendly-ref
+        run: echo "##[set-output name=ref_name;]$(echo ${GITHUB_REF##*/})"
+      - id: deployment
+        uses: chrnorm/deployment-action@v1.2.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          environment: ${{ github.ref }}
-
+          environment: ${{ steps.friendly-ref.outputs.ref_name }}
 
   # Stage 2. Build and Publish artifacts
-  # publish-dataseed:
-  #   runs-on: ubuntu-latest
-  #   needs: [init]
-  #   env:
-  #     CI_project: ./src/DataSeed/DataSeed.csproj
-  #     CI_artifact-name: dataseed
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: ${{ env.CI_dotnet-version }}
-  #     - name: dotnet publish
-  #       # many of the arguments below are due to poor dependencies on net48 libraries
-  #       # such as Biobanks.Directory.Services
-  #       # When those are tidied, this can be too
-  #       run: >-
-  #         dotnet publish
-  #         ${{ env.CI_project }}
-  #         -c ${{ env.CI_build-config }}
-  #         -o ${{ env.CI_publish-dir }}
-  #         /P:Version=${{ needs.init.outputs.version }}
-  #         /P:DebugType=embedded
-  #         /P:SatelliteResourceLanguages=en-GB
-  #         -r win-x64
-  #         --self-contained false
-  #     - uses: edgarrc/action-7z@v1.0.4
-  #       with:
-  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+  publish-dataseed:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_project: ./src/DataSeed/DataSeed.csproj
+      CI_artifact-name: dataseed
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.CI_dotnet-version }}
+      - name: dotnet publish
+        # many of the arguments below are due to poor dependencies on net48 libraries
+        # such as Biobanks.Directory.Services
+        # When those are tidied, this can be too
+        run: >-
+          dotnet publish
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          -o ${{ env.CI_publish-dir }}
+          /P:Version=${{ needs.init.outputs.version }}
+          /P:DebugType=embedded
+          /P:SatelliteResourceLanguages=en-GB
+          -r win-x64
+          --self-contained false
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
   publish-identitytool:
     runs-on: ubuntu-latest
@@ -140,204 +148,204 @@ jobs:
           name: ${{ env.CI_artifact-name }}
           path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
-  # publish-submissions-api:
-  #   runs-on: ubuntu-latest
-  #   needs: [init]
-  #   env:
-  #     CI_project: ./src/Submissions/Api/Api.csproj
-  #     CI_artifact-name: submissions-api
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: ${{ env.CI_dotnet-version }}
-  #     - name: dotnet publish
-  #       run: >-
-  #         dotnet publish
-  #         ${{ env.CI_project }}
-  #         -c ${{ env.CI_build-config }}
-  #         -o ${{ env.CI_publish-dir }}
-  #         /P:Version=${{ needs.init.outputs.version }}
-  #     - uses: edgarrc/action-7z@v1.0.4
-  #       with:
-  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+  publish-submissions-api:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_project: ./src/Submissions/Api/Api.csproj
+      CI_artifact-name: submissions-api
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.CI_dotnet-version }}
+      - name: dotnet publish
+        run: >-
+          dotnet publish
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          -o ${{ env.CI_publish-dir }}
+          /P:Version=${{ needs.init.outputs.version }}
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
-  # publish-submissions-azfunctions:
-  #   runs-on: ubuntu-latest
-  #   needs: [init]
-  #   env:
-  #     CI_project: ./src/Submissions/AzFunctions/AzFunctions.csproj
-  #     CI_artifact-name: submissions-workers-azfunctions
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: ${{ env.CI_dotnet-version }}
-  #     # .NET Isolated Functions Worker still has a 3.1 SDK dependency for now
-  #     # https://github.com/Azure/azure-functions-dotnet-worker/issues/301
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: 3.1.x
-  #     - name: dotnet publish
-  #       run: >-
-  #         dotnet publish
-  #         ${{ env.CI_project }}
-  #         -c ${{ env.CI_build-config }}
-  #         -o ${{ env.CI_publish-dir }}
-  #         /P:Version=${{ needs.init.outputs.version }}
-  #     - uses: edgarrc/action-7z@v1.0.4
-  #       with:
-  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+  publish-submissions-azfunctions:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_project: ./src/Submissions/AzFunctions/AzFunctions.csproj
+      CI_artifact-name: submissions-workers-azfunctions
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.CI_dotnet-version }}
+      # .NET Isolated Functions Worker still has a 3.1 SDK dependency for now
+      # https://github.com/Azure/azure-functions-dotnet-worker/issues/301
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+      - name: dotnet publish
+        run: >-
+          dotnet publish
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          -o ${{ env.CI_publish-dir }}
+          /P:Version=${{ needs.init.outputs.version }}
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
-  # publish-analytics-azfunctions:
-  #   runs-on: ubuntu-latest
-  #   needs: [init]
-  #   env:
-  #     CI_project: ./src/Analytics/AzureFunctions/AzureFunctions.csproj
-  #     CI_artifact-name: analytics-azfunctions
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: 3.1.x # TODO revert to stack version after upgrade
-  #     - name: dotnet publish
-  #       run: >-
-  #         dotnet publish
-  #         ${{ env.CI_project }}
-  #         -c ${{ env.CI_build-config }}
-  #         -o ${{ env.CI_publish-dir }}
-  #         /P:Version=${{ needs.init.outputs.version }}
-  #     - uses: edgarrc/action-7z@v1.0.4
-  #       with:
-  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+  publish-analytics-azfunctions:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_project: ./src/Analytics/AzureFunctions/AzureFunctions.csproj
+      CI_artifact-name: analytics-azfunctions
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x # TODO revert to stack version after upgrade
+      - name: dotnet publish
+        run: >-
+          dotnet publish
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          -o ${{ env.CI_publish-dir }}
+          /P:Version=${{ needs.init.outputs.version }}
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
-  # publish-publications-azfunctions:
-  #   runs-on: ubuntu-latest
-  #   needs: [init]
-  #   env:
-  #     CI_project: ./src/Publications/PublicationsAzureFunctions/PublicationsAzureFunctions.csproj
-  #     CI_artifact-name: publications-azfunctions
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: 3.1.x # TODO revert to stack version after upgrade
-  #     - name: dotnet publish
-  #       run: >-
-  #         dotnet publish
-  #         ${{ env.CI_project }}
-  #         -c ${{ env.CI_build-config }}
-  #         -o ${{ env.CI_publish-dir }}
-  #         /P:Version=${{ needs.init.outputs.version }}
-  #     - uses: edgarrc/action-7z@v1.0.4
-  #       with:
-  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+  publish-publications-azfunctions:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_project: ./src/Publications/PublicationsAzureFunctions/PublicationsAzureFunctions.csproj
+      CI_artifact-name: publications-azfunctions
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x # TODO revert to stack version after upgrade
+      - name: dotnet publish
+        run: >-
+          dotnet publish
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          -o ${{ env.CI_publish-dir }}
+          /P:Version=${{ needs.init.outputs.version }}
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
-  # publish-directory:
-  #   runs-on: windows-latest
-  #   needs: [init]
-  #   env:
-  #     CI_src: ./src/Directory
-  #     CI_project: ./src/Directory/Directory.sln
-  #     CI_artifact-name: directory
-  #   steps:
-  #     - uses: actions/checkout@v2
+  publish-directory:
+    runs-on: windows-latest
+    needs: [init]
+    env:
+      CI_src: ./src/Directory
+      CI_project: ./src/Directory/Directory.sln
+      CI_artifact-name: directory
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - uses: microsoft/setup-msbuild@v1
-  #     - uses: NuGet/setup-nuget@v1.0.5
-  #       with:
-  #         nuget-version: 5.x
+      - uses: microsoft/setup-msbuild@v1
+      - uses: NuGet/setup-nuget@v1.0.5
+        with:
+          nuget-version: 5.x
 
-  #     - name: nuget restore
-  #       run: nuget restore ${{ env.CI_project }}
+      - name: nuget restore
+        run: nuget restore ${{ env.CI_project }}
 
-  #     - name: Build Solution
-  #       run: >-
-  #         msbuild.exe
-  #         ${{ env.CI_project }}
-  #         /p:Configuration="${{ env.CI_build-config }}"
-  #         /nologo
-  #         /nr:false
-  #         /p:DeployOnBuild=true
-  #         /p:WebPublishMethod=Package
-  #         /p:_PackageTempDir=C:/Package
-  #         /p:PackageAsSingleFile=true
-  #         /p:PrecompileBeforePublish=true
-  #         /p:SkipInvalidConfigurations=true
-  #         /p:PackageLocation=${{ github.workspace}}\${{ env.CI_publish-dir }}
-  #         /p:Platform="Any CPU"
-  #     - run: >-
-  #         Compress-Archive
-  #         -Path .\${{ env.CI_publish-dir }}\*
-  #         -DestinationPath .\${{ env.CI_publish-dir }}\${{ env.CI_artifact-name }}
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+      - name: Build Solution
+        run: >-
+          msbuild.exe
+          ${{ env.CI_project }}
+          /p:Configuration="${{ env.CI_build-config }}"
+          /nologo
+          /nr:false
+          /p:DeployOnBuild=true
+          /p:WebPublishMethod=Package
+          /p:_PackageTempDir=C:/Package
+          /p:PackageAsSingleFile=true
+          /p:PrecompileBeforePublish=true
+          /p:SkipInvalidConfigurations=true
+          /p:PackageLocation=${{ github.workspace}}\${{ env.CI_publish-dir }}
+          /p:Platform="Any CPU"
+      - run: >-
+          Compress-Archive
+          -Path .\${{ env.CI_publish-dir }}\*
+          -DestinationPath .\${{ env.CI_publish-dir }}\${{ env.CI_artifact-name }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
-  #     # publish identity migrations from this build as well
-  #     - name: Copy migrations files
-  #       run: |
-  #         mkdir -p ${{ env.CI_publish-dir }}/migrations
-  #         cp ${{ env.CI_src }}/packages/EntityFramework*/tools/net45/win-x86/ef6.exe ${{ env.CI_publish-dir }}/migrations
-  #         ls -r -include *.dll ${{ env.CI_src }}/Identity/bin | % { cp $_ ${{ env.CI_publish-dir }}/migrations }
-  #     - run: >-
-  #         Compress-Archive
-  #         -Path .\${{ env.CI_publish-dir }}\migrations\*
-  #         -DestinationPath .\${{ env.CI_publish-dir }}\identity-migrations
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: identity-migrations
-  #         path: ${{ env.CI_publish-dir }}/identity-migrations.zip
+      # publish identity migrations from this build as well
+      - name: Copy migrations files
+        run: |
+          mkdir -p ${{ env.CI_publish-dir }}/migrations
+          cp ${{ env.CI_src }}/packages/EntityFramework*/tools/net45/win-x86/ef6.exe ${{ env.CI_publish-dir }}/migrations
+          ls -r -include *.dll ${{ env.CI_src }}/Identity/bin | % { cp $_ ${{ env.CI_publish-dir }}/migrations }
+      - run: >-
+          Compress-Archive
+          -Path .\${{ env.CI_publish-dir }}\migrations\*
+          -DestinationPath .\${{ env.CI_publish-dir }}\identity-migrations
+      - uses: actions/upload-artifact@v2
+        with:
+          name: identity-migrations
+          path: ${{ env.CI_publish-dir }}/identity-migrations.zip
 
-  # publish-data-migrations:
-  #   runs-on: ubuntu-latest
-  #   needs: [init]
-  #   env:
-  #     CI_src: ./src/Data
-  #     CI_project: ./src/Data/Data.csproj
-  #     CI_artifact-name: data-migrations
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: ${{ env.CI_dotnet-version }}
-  #     - name: dotnet build
-  #       run: >-
-  #         dotnet build
-  #         ${{ env.CI_project }}
-  #         -c ${{ env.CI_build-config }}
-  #         /P:Version=${{ needs.init.outputs.version }}
-  #     - name: Copy migrations files
-  #       run: |
-  #         mkdir -p ${{ env.CI_publish-dir }}/bin
-  #         mkdir -p ${{ env.CI_publish-dir }}/obj
-  #         cp -r ${{ env.CI_src }}/bin/* ${{ env.CI_publish-dir }}/bin
-  #         cp -r ${{ env.CI_src }}/obj/* ${{ env.CI_publish-dir }}/obj
-  #         cp ${{ env.CI_src }}/Data.csproj ${{ env.CI_publish-dir }}
-  #     - uses: edgarrc/action-7z@v1.0.4
-  #       with:
-  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ${{ env.CI_artifact-name }}
-  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+  publish-data-migrations:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_src: ./src/Data
+      CI_project: ./src/Data/Data.csproj
+      CI_artifact-name: data-migrations
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.CI_dotnet-version }}
+      - name: dotnet build
+        run: >-
+          dotnet build
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          /P:Version=${{ needs.init.outputs.version }}
+      - name: Copy migrations files
+        run: |
+          mkdir -p ${{ env.CI_publish-dir }}/bin
+          mkdir -p ${{ env.CI_publish-dir }}/obj
+          cp -r ${{ env.CI_src }}/bin/* ${{ env.CI_publish-dir }}/bin
+          cp -r ${{ env.CI_src }}/obj/* ${{ env.CI_publish-dir }}/obj
+          cp ${{ env.CI_src }}/Data.csproj ${{ env.CI_publish-dir }}
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
 
   # Stage 4. Deployment Status updates
   deployment-success:
@@ -364,7 +372,6 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
           state: "failure"
           deployment_id: ${{ needs.init.outputs.deploymentId }}
-
 
   # Stage 5. Create a GitHub Release if appropriate
   release:

--- a/.github/workflows/main.release.yml
+++ b/.github/workflows/main.release.yml
@@ -23,11 +23,13 @@ env:
 
 jobs:
 
-  # Stage 4. Create a release if all publish jobs completed successfully
+  # Stage 3. Create a release if all publish jobs completed successfully
   # This is the last job which runs, after everything else,
   # but it's also the one that needs modifying, so we keep it at the top
   release:
+    if: needs.version-check.outputs.doRelease
     needs:
+      - version-check
       - publish-dataseed
       - publish-identitytool
       - publish-submissions-api
@@ -91,16 +93,8 @@ jobs:
       - uses: actions/checkout@v2
       - id: manifest
         uses: ./.github/actions/version-manifest
-  
-  # Stage 2. the entire rest of the workflow only runs if doRelease is true
-  release-gate:
-    runs-on: ubuntu-latest
-    needs: version-check
-    if: needs.version-check.outputs.doRelease
-    steps:
-      - run: 'echo "Release Triggered: ${{ needs.version-check.outputs.version }}"'
 
-  # Stage 3. Publish artifacts
+  # Stage 2. Build and Publish artifacts
   publish-dataseed:
     runs-on: ubuntu-latest
     needs: [version-check]

--- a/.github/workflows/main.release.yml
+++ b/.github/workflows/main.release.yml
@@ -70,6 +70,7 @@ jobs:
           tag: ${{ steps.manifest.outputs.version }}
           name: ${{ steps.manifest.outputs.version }}
           body: ${{ steps.manifest.outputs.version }}
+          prerelease: ${{ steps.manifest.outputs.isPrerelease }}
           artifacts: >-
             artifacts/identitytool/*,
             artifacts/dataseed/*,

--- a/.github/workflows/main.release.yml
+++ b/.github/workflows/main.release.yml
@@ -103,7 +103,7 @@ jobs:
   # Stage 3. Publish artifacts
   publish-dataseed:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_project: ./src/DataSeed/DataSeed.csproj
       CI_artifact-name: dataseed
@@ -136,7 +136,7 @@ jobs:
   
   publish-identitytool:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_project: ./src/IdentityModel/IdentityTool/IdentityTool.csproj
       CI_artifact-name: identitytool
@@ -163,7 +163,7 @@ jobs:
   
   publish-submissions-api:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_project: ./src/Submissions/Api/Api.csproj
       CI_artifact-name: submissions-api
@@ -189,7 +189,7 @@ jobs:
   
   publish-submissions-azfunctions:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_project: ./src/Submissions/AzFunctions/AzFunctions.csproj
       CI_artifact-name: submissions-workers-azfunctions
@@ -220,7 +220,7 @@ jobs:
   
   publish-analytics-azfunctions:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_project: ./src/Analytics/AzureFunctions/AzureFunctions.csproj
       CI_artifact-name: analytics-azfunctions
@@ -246,7 +246,7 @@ jobs:
   
   publish-publications-azfunctions:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_project: ./src/Publications/PublicationsAzureFunctions/PublicationsAzureFunctions.csproj
       CI_artifact-name: publications-azfunctions
@@ -272,7 +272,7 @@ jobs:
   
   publish-directory:
     runs-on: windows-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_src: ./src/Directory
       CI_project: ./src/Directory/Directory.sln
@@ -329,7 +329,7 @@ jobs:
   
   publish-data-migrations:
     runs-on: ubuntu-latest
-    needs: [release-gate, version-check]
+    needs: [version-check]
     env:
       CI_src: ./src/Data
       CI_project: ./src/Data/Data.csproj

--- a/.github/workflows/main.release.yml
+++ b/.github/workflows/main.release.yml
@@ -1,17 +1,16 @@
 # How to add new stack items:
-# 
+#
 # 1. Create the new publish job
 #   - it should zip the publish result
 #   - upload the zip as an artifact
-# 2. Make the `release` job depend on it
-#   - add the new publish job id to `release.needs`
-# 3. Include the artifact in the GitHub release
-#   - add the artifact to the `artifacts` list in the `release` job
+# 2. Make the `dependency-gate` job depend on it
+#   - add the new publish job id to `dependency-gate.needs`
+# 3. Include the artifact in the `releaseArtifacts` variable
 
 name: GitHub Release
 on:
   push:
-    branches: [main]
+    branches: [main, support/*]
 
 env:
   CI_build-config: release
@@ -21,23 +20,356 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
 
-jobs:
+  # add artifacts here if you publish new ones
+  # and want them to go in the GitHub Release
+  # in the form `artifacts/<artifact-name>/*`
+  releaseArtifacts: >-
+    artifacts/identitytool/*,
+    artifacts/dataseed/*,
+    artifacts/submissions-api/*,
+    artifacts/submissions-workers-azfunctions/*,
+    artifacts/publications-azfunctions/*,
+    artifacts/analytics-azfunctions/*,
+    artifacts/directory/*,
+    artifacts/identity-migrations/*,
+    artifacts/data-migrations/*
 
-  # Stage 3. Create a release if all publish jobs completed successfully
-  # This is the last job which runs, after everything else,
-  # but it's also the one that needs modifying, so we keep it at the top
-  release:
-    if: needs.version-check.outputs.doRelease
+jobs:
+  # Stage 3. Wait for all the parallel bits to finish
+  # to simplify the future dependency graph.
+  #
+  # We keep this at the top since it needs modifying
+  dependency-gate:
+    if: always() # failures don't matter
     needs:
-      - version-check
-      - publish-dataseed
+      # add new jobs here;
+      # this should essentially depend on everything
+      # that isn't a dependency of something else!
+      # - publish-dataseed
       - publish-identitytool
-      - publish-submissions-api
-      - publish-submissions-azfunctions
-      - publish-analytics-azfunctions
-      - publish-publications-azfunctions
-      - publish-directory
-      - publish-data-migrations
+      # - publish-submissions-api
+      # - publish-submissions-azfunctions
+      # - publish-analytics-azfunctions
+      # - publish-publications-azfunctions
+      # - publish-directory
+      # - publish-data-migrations
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Publish jobs complete"
+
+
+  # Stage 1.
+  # - Get version status from manifest, to inform the rest of the workflow
+  # - Create a GitHub Deployment for the branch we're on
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.manifest.outputs.version }}
+      doRelease: ${{ steps.manifest.outputs.doRelease }}
+      isPrerelease: ${{ steps.manifest.outputs.isPrerelease }}
+      deploymentId: ${{ steps.deployment.outputs.deployment_id }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: manifest
+        uses: ./.github/actions/version-manifest
+      - uses: chrnorm/deployment-action@v1.2.0
+        id: deployment
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          environment: ${{ github.ref }}
+
+
+  # Stage 2. Build and Publish artifacts
+  # publish-dataseed:
+  #   runs-on: ubuntu-latest
+  #   needs: [init]
+  #   env:
+  #     CI_project: ./src/DataSeed/DataSeed.csproj
+  #     CI_artifact-name: dataseed
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: ${{ env.CI_dotnet-version }}
+  #     - name: dotnet publish
+  #       # many of the arguments below are due to poor dependencies on net48 libraries
+  #       # such as Biobanks.Directory.Services
+  #       # When those are tidied, this can be too
+  #       run: >-
+  #         dotnet publish
+  #         ${{ env.CI_project }}
+  #         -c ${{ env.CI_build-config }}
+  #         -o ${{ env.CI_publish-dir }}
+  #         /P:Version=${{ needs.init.outputs.version }}
+  #         /P:DebugType=embedded
+  #         /P:SatelliteResourceLanguages=en-GB
+  #         -r win-x64
+  #         --self-contained false
+  #     - uses: edgarrc/action-7z@v1.0.4
+  #       with:
+  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  publish-identitytool:
+    runs-on: ubuntu-latest
+    needs: [init]
+    env:
+      CI_project: ./src/IdentityModel/IdentityTool/IdentityTool.csproj
+      CI_artifact-name: identitytool
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.CI_dotnet-version }}
+      - name: dotnet publish
+        run: >-
+          dotnet publish
+          ${{ env.CI_project }}
+          -c ${{ env.CI_build-config }}
+          -o ${{ env.CI_publish-dir }}
+          /P:Version=${{ needs.init.outputs.version }}
+          /P:DebugType=embedded
+      - uses: edgarrc/action-7z@v1.0.4
+        with:
+          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_artifact-name }}
+          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  # publish-submissions-api:
+  #   runs-on: ubuntu-latest
+  #   needs: [init]
+  #   env:
+  #     CI_project: ./src/Submissions/Api/Api.csproj
+  #     CI_artifact-name: submissions-api
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: ${{ env.CI_dotnet-version }}
+  #     - name: dotnet publish
+  #       run: >-
+  #         dotnet publish
+  #         ${{ env.CI_project }}
+  #         -c ${{ env.CI_build-config }}
+  #         -o ${{ env.CI_publish-dir }}
+  #         /P:Version=${{ needs.init.outputs.version }}
+  #     - uses: edgarrc/action-7z@v1.0.4
+  #       with:
+  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  # publish-submissions-azfunctions:
+  #   runs-on: ubuntu-latest
+  #   needs: [init]
+  #   env:
+  #     CI_project: ./src/Submissions/AzFunctions/AzFunctions.csproj
+  #     CI_artifact-name: submissions-workers-azfunctions
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: ${{ env.CI_dotnet-version }}
+  #     # .NET Isolated Functions Worker still has a 3.1 SDK dependency for now
+  #     # https://github.com/Azure/azure-functions-dotnet-worker/issues/301
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: 3.1.x
+  #     - name: dotnet publish
+  #       run: >-
+  #         dotnet publish
+  #         ${{ env.CI_project }}
+  #         -c ${{ env.CI_build-config }}
+  #         -o ${{ env.CI_publish-dir }}
+  #         /P:Version=${{ needs.init.outputs.version }}
+  #     - uses: edgarrc/action-7z@v1.0.4
+  #       with:
+  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  # publish-analytics-azfunctions:
+  #   runs-on: ubuntu-latest
+  #   needs: [init]
+  #   env:
+  #     CI_project: ./src/Analytics/AzureFunctions/AzureFunctions.csproj
+  #     CI_artifact-name: analytics-azfunctions
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: 3.1.x # TODO revert to stack version after upgrade
+  #     - name: dotnet publish
+  #       run: >-
+  #         dotnet publish
+  #         ${{ env.CI_project }}
+  #         -c ${{ env.CI_build-config }}
+  #         -o ${{ env.CI_publish-dir }}
+  #         /P:Version=${{ needs.init.outputs.version }}
+  #     - uses: edgarrc/action-7z@v1.0.4
+  #       with:
+  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  # publish-publications-azfunctions:
+  #   runs-on: ubuntu-latest
+  #   needs: [init]
+  #   env:
+  #     CI_project: ./src/Publications/PublicationsAzureFunctions/PublicationsAzureFunctions.csproj
+  #     CI_artifact-name: publications-azfunctions
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: 3.1.x # TODO revert to stack version after upgrade
+  #     - name: dotnet publish
+  #       run: >-
+  #         dotnet publish
+  #         ${{ env.CI_project }}
+  #         -c ${{ env.CI_build-config }}
+  #         -o ${{ env.CI_publish-dir }}
+  #         /P:Version=${{ needs.init.outputs.version }}
+  #     - uses: edgarrc/action-7z@v1.0.4
+  #       with:
+  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  # publish-directory:
+  #   runs-on: windows-latest
+  #   needs: [init]
+  #   env:
+  #     CI_src: ./src/Directory
+  #     CI_project: ./src/Directory/Directory.sln
+  #     CI_artifact-name: directory
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - uses: microsoft/setup-msbuild@v1
+  #     - uses: NuGet/setup-nuget@v1.0.5
+  #       with:
+  #         nuget-version: 5.x
+
+  #     - name: nuget restore
+  #       run: nuget restore ${{ env.CI_project }}
+
+  #     - name: Build Solution
+  #       run: >-
+  #         msbuild.exe
+  #         ${{ env.CI_project }}
+  #         /p:Configuration="${{ env.CI_build-config }}"
+  #         /nologo
+  #         /nr:false
+  #         /p:DeployOnBuild=true
+  #         /p:WebPublishMethod=Package
+  #         /p:_PackageTempDir=C:/Package
+  #         /p:PackageAsSingleFile=true
+  #         /p:PrecompileBeforePublish=true
+  #         /p:SkipInvalidConfigurations=true
+  #         /p:PackageLocation=${{ github.workspace}}\${{ env.CI_publish-dir }}
+  #         /p:Platform="Any CPU"
+  #     - run: >-
+  #         Compress-Archive
+  #         -Path .\${{ env.CI_publish-dir }}\*
+  #         -DestinationPath .\${{ env.CI_publish-dir }}\${{ env.CI_artifact-name }}
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  #     # publish identity migrations from this build as well
+  #     - name: Copy migrations files
+  #       run: |
+  #         mkdir -p ${{ env.CI_publish-dir }}/migrations
+  #         cp ${{ env.CI_src }}/packages/EntityFramework*/tools/net45/win-x86/ef6.exe ${{ env.CI_publish-dir }}/migrations
+  #         ls -r -include *.dll ${{ env.CI_src }}/Identity/bin | % { cp $_ ${{ env.CI_publish-dir }}/migrations }
+  #     - run: >-
+  #         Compress-Archive
+  #         -Path .\${{ env.CI_publish-dir }}\migrations\*
+  #         -DestinationPath .\${{ env.CI_publish-dir }}\identity-migrations
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: identity-migrations
+  #         path: ${{ env.CI_publish-dir }}/identity-migrations.zip
+
+  # publish-data-migrations:
+  #   runs-on: ubuntu-latest
+  #   needs: [init]
+  #   env:
+  #     CI_src: ./src/Data
+  #     CI_project: ./src/Data/Data.csproj
+  #     CI_artifact-name: data-migrations
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: ${{ env.CI_dotnet-version }}
+  #     - name: dotnet build
+  #       run: >-
+  #         dotnet build
+  #         ${{ env.CI_project }}
+  #         -c ${{ env.CI_build-config }}
+  #         /P:Version=${{ needs.init.outputs.version }}
+  #     - name: Copy migrations files
+  #       run: |
+  #         mkdir -p ${{ env.CI_publish-dir }}/bin
+  #         mkdir -p ${{ env.CI_publish-dir }}/obj
+  #         cp -r ${{ env.CI_src }}/bin/* ${{ env.CI_publish-dir }}/bin
+  #         cp -r ${{ env.CI_src }}/obj/* ${{ env.CI_publish-dir }}/obj
+  #         cp ${{ env.CI_src }}/Data.csproj ${{ env.CI_publish-dir }}
+  #     - uses: edgarrc/action-7z@v1.0.4
+  #       with:
+  #         args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.CI_artifact-name }}
+  #         path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
+
+  # Stage 4. Deployment Status updates
+  deployment-success:
+    if: success()
+    needs: [init, dependency-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deployment Success"
+      - uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          state: "success"
+          deployment_id: ${{ needs.init.outputs.deploymentId }}
+          # put a link to the this run. from here anyone (e.g. Azure Pipelines) can get artifacts programmatically
+          environment_url: https://api.github.com/repos/biobankinguk/biobankinguk/actions/runs/${{ github.run_id }}
+  deployment-failure:
+    if: failure()
+    needs: [init, dependency-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deployment Failure"
+      - uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          state: "failure"
+          deployment_id: ${{ needs.init.outputs.deploymentId }}
+
+
+  # Stage 5. Create a GitHub Release if appropriate
+  release:
+    if: needs.init.outputs.doRelease && github.event == 'push'
+    needs: [init, dependency-gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -56,12 +388,12 @@ jobs:
           git commit -am "🚀 ${{ steps.manifest.outputs.version }}" -m "[skip ci]"
           git tag ${{ steps.manifest.outputs.version }}
           git push --atomic origin ${{ github.ref }} ${{ steps.manifest.outputs.version }}
-      
+
       # get ALL our release artifacts
       - uses: actions/download-artifact@v2
         with:
           path: artifacts
-      
+
       # TODO: Release notes generation?
       # TODO: Link to usage docs? (i.e. what assets to use, how to use them, etc...)
       - uses: ncipollo/release-action@v1
@@ -71,286 +403,5 @@ jobs:
           name: ${{ steps.manifest.outputs.version }}
           body: ${{ steps.manifest.outputs.version }}
           prerelease: ${{ steps.manifest.outputs.isPrerelease }}
-          artifacts: >-
-            artifacts/identitytool/*,
-            artifacts/dataseed/*,
-            artifacts/submissions-api/*,
-            artifacts/submissions-workers-azfunctions/*,
-            artifacts/publications-azfunctions/*,
-            artifacts/analytics-azfunctions/*,
-            artifacts/directory/*,
-            artifacts/identity-migrations/*,
-            artifacts/data-migrations/*
-          # don't leave a final trailing comma, above!
+          artifacts: releaseArtifacts
           artifactContentType: application/zip
-
-  # Stage 1. Check if version manifest should cause the rest of the workflow to run
-  version-check:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.manifest.outputs.version }}
-      doRelease: ${{ steps.manifest.outputs.doRelease }}
-    steps:
-      - uses: actions/checkout@v2
-      - id: manifest
-        uses: ./.github/actions/version-manifest
-
-  # Stage 2. Build and Publish artifacts
-  publish-dataseed:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_project: ./src/DataSeed/DataSeed.csproj
-      CI_artifact-name: dataseed
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.CI_dotnet-version }}
-      - name: dotnet publish
-        # many of the arguments below are due to poor dependencies on net48 libraries
-        # such as Biobanks.Directory.Services
-        # When those are tidied, this can be too
-        run: >-
-          dotnet publish
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          -o ${{ env.CI_publish-dir }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-          /P:DebugType=embedded
-          /P:SatelliteResourceLanguages=en-GB
-          -r win-x64
-          --self-contained false
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-  
-  publish-identitytool:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_project: ./src/IdentityModel/IdentityTool/IdentityTool.csproj
-      CI_artifact-name: identitytool
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.CI_dotnet-version }}
-      - name: dotnet publish
-        run: >-
-          dotnet publish
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          -o ${{ env.CI_publish-dir }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-          /P:DebugType=embedded
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-  
-  publish-submissions-api:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_project: ./src/Submissions/Api/Api.csproj
-      CI_artifact-name: submissions-api
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.CI_dotnet-version }}
-      - name: dotnet publish
-        run: >-
-          dotnet publish
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          -o ${{ env.CI_publish-dir }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-  
-  publish-submissions-azfunctions:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_project: ./src/Submissions/AzFunctions/AzFunctions.csproj
-      CI_artifact-name: submissions-workers-azfunctions
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.CI_dotnet-version }}
-      # .NET Isolated Functions Worker still has a 3.1 SDK dependency for now
-      # https://github.com/Azure/azure-functions-dotnet-worker/issues/301
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
-      - name: dotnet publish
-        run: >-
-          dotnet publish
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          -o ${{ env.CI_publish-dir }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-  
-  publish-analytics-azfunctions:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_project: ./src/Analytics/AzureFunctions/AzureFunctions.csproj
-      CI_artifact-name: analytics-azfunctions
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x # TODO revert to stack version after upgrade
-      - name: dotnet publish
-        run: >-
-          dotnet publish
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          -o ${{ env.CI_publish-dir }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-  
-  publish-publications-azfunctions:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_project: ./src/Publications/PublicationsAzureFunctions/PublicationsAzureFunctions.csproj
-      CI_artifact-name: publications-azfunctions
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x # TODO revert to stack version after upgrade
-      - name: dotnet publish
-        run: >-
-          dotnet publish
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          -o ${{ env.CI_publish-dir }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-  
-  publish-directory:
-    runs-on: windows-latest
-    needs: [version-check]
-    env:
-      CI_src: ./src/Directory
-      CI_project: ./src/Directory/Directory.sln
-      CI_artifact-name: directory
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: microsoft/setup-msbuild@v1
-      - uses: NuGet/setup-nuget@v1.0.5
-        with:
-          nuget-version: 5.x
-
-      - name: nuget restore
-        run: nuget restore ${{ env.CI_project }}
-
-      - name: Build Solution
-        run: >-
-          msbuild.exe
-          ${{ env.CI_project }}
-          /p:Configuration="${{ env.CI_build-config }}"
-          /nologo
-          /nr:false
-          /p:DeployOnBuild=true
-          /p:WebPublishMethod=Package
-          /p:_PackageTempDir=C:/Package
-          /p:PackageAsSingleFile=true
-          /p:PrecompileBeforePublish=true
-          /p:SkipInvalidConfigurations=true
-          /p:PackageLocation=${{ github.workspace}}\${{ env.CI_publish-dir }}
-          /p:Platform="Any CPU"
-      - run: >-
-          Compress-Archive
-          -Path .\${{ env.CI_publish-dir }}\*
-          -DestinationPath .\${{ env.CI_publish-dir }}\${{ env.CI_artifact-name }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip
-      
-      # publish identity migrations from this build as well
-      - name: Copy migrations files
-        run: |
-          mkdir -p ${{ env.CI_publish-dir }}/migrations
-          cp ${{ env.CI_src }}/packages/EntityFramework*/tools/net45/win-x86/ef6.exe ${{ env.CI_publish-dir }}/migrations
-          ls -r -include *.dll ${{ env.CI_src }}/Identity/bin | % { cp $_ ${{ env.CI_publish-dir }}/migrations }
-      - run: >-
-          Compress-Archive
-          -Path .\${{ env.CI_publish-dir }}\migrations\*
-          -DestinationPath .\${{ env.CI_publish-dir }}\identity-migrations
-      - uses: actions/upload-artifact@v2
-        with:
-          name: identity-migrations
-          path: ${{ env.CI_publish-dir }}/identity-migrations.zip
-  
-  publish-data-migrations:
-    runs-on: ubuntu-latest
-    needs: [version-check]
-    env:
-      CI_src: ./src/Data
-      CI_project: ./src/Data/Data.csproj
-      CI_artifact-name: data-migrations
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.CI_dotnet-version }}
-      - name: dotnet build
-        run: >-
-          dotnet build
-          ${{ env.CI_project }}
-          -c ${{ env.CI_build-config }}
-          /P:Version=${{ needs.version-check.outputs.version }}
-      - name: Copy migrations files
-        run: |
-          mkdir -p ${{ env.CI_publish-dir }}/bin
-          mkdir -p ${{ env.CI_publish-dir }}/obj
-          cp -r ${{ env.CI_src }}/bin/* ${{ env.CI_publish-dir }}/bin
-          cp -r ${{ env.CI_src }}/obj/* ${{ env.CI_publish-dir }}/obj
-          cp ${{ env.CI_src }}/Data.csproj ${{ env.CI_publish-dir }}
-      - uses: edgarrc/action-7z@v1.0.4
-        with:
-          args: 7z a ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip ./${{ env.CI_publish-dir }}/*
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_artifact-name }}
-          path: ${{ env.CI_publish-dir }}/${{ env.CI_artifact-name }}.zip


### PR DESCRIPTION
## Overview

This PR includes improvements and changes to the release workflow to support our deployment pipelines workflow

## Azure Boards

- [AB#31168](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/31168) - Main deployment pipelines item to which this work relates
- [AB#33527](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/33527) - the `doRelease` condition wasn't working. It does now.
- [AB#33528](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/33528) - builds always run; `doRelease` only now affects GitHub Release creation
- [AB#33529](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/33529) - The Release workflow can be manually triggered for any branch, optionally with `Debug` builds
- [AB#33530](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/33530) - Prerelease versions will give prerelease GitHub Releases
- [AB#33576](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/33576) - The release workflow generates GitHub Deployments, to track build artifacts for given branches which can be used more granularly (e.g. nightly, merges to main etc) than formal versioned Releases