### PR TITLE
AB#33995: Added deletion for material details within delete sample set method

### DIFF
--- a/src/Directory/Services/BiobankWriteService.cs
+++ b/src/Directory/Services/BiobankWriteService.cs
@@ -390,6 +390,10 @@ namespace Biobanks.Services
             //we need to check if the sampleset belongs to a suspended bb, BEFORE we delete the sampleset
             var suspended = await _biobankReadService.IsSampleSetBiobankSuspendedAsync(id);
 
+            //delete materialdetails to avoid orphaned data or integrity errors
+            await _materialDetailRepository.DeleteWhereAsync(x => x.SampleSetId == id);
+            await _materialDetailRepository.SaveChangesAsync();
+
             await _sampleSetRepository.DeleteWhereAsync(x => x.Id == id);
 
             await _sampleSetRepository.SaveChangesAsync();


### PR DESCRIPTION
Fix for deletion of SampleSets. 
Now deletes all of the MaterialDetails which belong to that SampleSet. 

Issue has been around for a while but previously no referential integrity was enforced, resulting in orphaned data. With the last release, this is now enforced, which prevents the SampleSet from being deleted at all.