### PR TITLE
AB#34045: Submission sample not adding to queue fix

### DIFF
--- a/src/Submissions/Api/Controllers/SubmitController.cs
+++ b/src/Submissions/Api/Controllers/SubmitController.cs
@@ -195,7 +195,6 @@ namespace Biobanks.Submissions.Api.Controllers
                             }
 
                         }
-                        else
                             samplesUpdates.Add(sampleModel);
                         break;
 

--- a/src/Submissions/Api/Controllers/SubmitController.cs
+++ b/src/Submissions/Api/Controllers/SubmitController.cs
@@ -167,6 +167,10 @@ namespace Biobanks.Submissions.Api.Controllers
                             int ageAtDonationInt; 
                             if (int.TryParse(sampleModel.AgeAtDonation, out ageAtDonationInt))
                             {
+                                if (ageAtDonationInt > 150)
+                                {
+                                    return await CancelSubmissionAndReturnBadRequest(sampleModel, submission.Id, "Invalid AgeAtDonation value, must not be greater than 150.");
+                                }
                                 // Check if negative
                                 bool isNegative = false;
                                 if (ageAtDonationInt < 0)

--- a/src/Submissions/Api/Models/SampleSubmissionModel.cs
+++ b/src/Submissions/Api/Models/SampleSubmissionModel.cs
@@ -18,7 +18,6 @@ namespace Biobanks.Submissions.Api.Models
         /// <summary>
         /// The age of the donor at time of making donation.
         /// </summary>
-        [Range(0, 150)]
         public string AgeAtDonation { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Previous ISO Duration PR #187 caused bug where sample was never added to the queue. 
This fixes that issue and removes range check on AgeAtDonation. 