### PR TITLE
AB#34185: Fixing Biobank Models/Objects to deal with CollectionTypeId & AccessConditionId

### DIFF
--- a/src/Directory/Biobanks.Web/App_Start/AutoMapperConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/AutoMapperConfig.cs
@@ -72,7 +72,9 @@ namespace Biobanks.Web
                     .ForMember(dest => dest.Logo, opts => opts.Ignore()); //Never map Logo from BiobankDetailsModel - we will alaways handle this manually
 
 
-                cfg.CreateMap<OrganisationDTO, Organisation>();
+                cfg.CreateMap<OrganisationDTO, Organisation>()
+                .AfterMap((src, dest) => dest.AccessConditionId = null)
+                .AfterMap((src, dest) => dest.CollectionTypeId = null);
                 cfg.CreateMap<Organisation, OrganisationDTO>();
 
                 cfg.CreateMap<NetworkDTO, Network>();

--- a/src/Directory/Biobanks.Web/App_Start/AutoMapperConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/AutoMapperConfig.cs
@@ -72,9 +72,7 @@ namespace Biobanks.Web
                     .ForMember(dest => dest.Logo, opts => opts.Ignore()); //Never map Logo from BiobankDetailsModel - we will alaways handle this manually
 
 
-                cfg.CreateMap<OrganisationDTO, Organisation>()
-                .AfterMap((src, dest) => dest.AccessConditionId = null)
-                .AfterMap((src, dest) => dest.CollectionTypeId = null);
+                cfg.CreateMap<OrganisationDTO, Organisation>();
                 cfg.CreateMap<Organisation, OrganisationDTO>();
 
                 cfg.CreateMap<NetworkDTO, Network>();

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -400,6 +400,8 @@ namespace Biobanks.Web.Controllers
                 BiobankId = bb.OrganisationId,
                 BiobankExternalId = bb.OrganisationExternalId,
                 OrganisationTypeId = bb.OrganisationTypeId,
+                AccessConditionId = bb.AccessConditionId,
+                CollectionTypeId = bb.CollectionTypeId,
                 OrganisationName = bb.Name,
                 Description = bb.Description,
                 Url = bb.Url,

--- a/src/Directory/Biobanks.Web/Models/Biobank/BiobankDetailsModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Biobank/BiobankDetailsModel.cs
@@ -13,7 +13,11 @@ namespace Biobanks.Web.Models.Biobank
         public int? BiobankId { get; set; } //nullable to allow for creation of new?
         public string BiobankExternalId { get; set; }
         public int? OrganisationTypeId { get; set; }
-        
+
+        public int? AccessConditionId { get; set; }
+
+        public int? CollectionTypeId { get; set; }
+
         [Required(ErrorMessage = "Please enter the name of the resource.")]
         [MaxLength(100, ErrorMessage = ModelErrors.MaxLength)]
         [Display(Name = "Name")]

--- a/src/Directory/Biobanks.Web/Views/Biobank/Edit.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Biobank/Edit.cshtml
@@ -144,7 +144,7 @@
         <div class="form-group">
             @Html.LabelFor(x => x.CountyId, new { @class = "col-sm-3 control-label required" })
             <div class="col-sm-6">
-                @Html.DropDownListFor(x => x.CountyId, new SelectList(items: Model.Counties.OrderBy(x => x.Country.Value).ThenBy(x => x.Value), dataValueField: "Id", dataTextField: "Value", dataGroupField: "Country.Value", selectedValue:null), "Select County", new { @class = "form-control" })
+                @Html.DropDownListFor(x => x.CountyId, new SelectList(items: Model.Counties.OrderBy(x => x.Country.Value).ThenBy(x => x.Value), dataValueField: "Id", dataTextField: "Value", dataGroupField: "Country.Value", selectedValue: null), "Select County", new { @class = "form-control" })
                 @Html.ValidationMessageFor(x => x.CountyId)
             </div>
         </div>
@@ -152,7 +152,7 @@
         <div class="form-group">
             @Html.LabelFor(x => x.CountryId, new { @class = "col-sm-3 control-label required" })
             <div class="col-sm-6">
-                @Html.DropDownListFor(x => x.CountryId, new SelectList(Model.Countries, "Id", "Value"), "Select Country", new { @class = "form-control"})
+                @Html.DropDownListFor(x => x.CountryId, new SelectList(Model.Countries, "Id", "Value"), "Select Country", new { @class = "form-control" })
                 @Html.ValidationMessageFor(x => x.CountryId)
             </div>
         </div>
@@ -276,6 +276,9 @@
             @Html.ValidationMessageFor(x => x.OtherRegistrationReason)
         </div>
     </div>
+
+    @Html.HiddenFor(x => x.AccessConditionId)
+    @Html.HiddenFor(x => x.CollectionTypeId)
 
     @* TODO: 'other' registration reason *@
 

--- a/src/Directory/Services/Dto/OrganisationDTO.cs
+++ b/src/Directory/Services/Dto/OrganisationDTO.cs
@@ -44,8 +44,8 @@ namespace Biobanks.Services.Dto
         public string OtherRegistrationReason { get; set; }
         public bool ExcludePublications { get; set; }
 
-        public int AccessConditionId { get; set; }
+        public int? AccessConditionId { get; set; }
 
-        public int CollectionTypeId { get; set; }
+        public int? CollectionTypeId { get; set; }
     }
 }


### PR DESCRIPTION
## Overview

Due to the recent addition of CollectionTypeId & AccessConditionId, the creating and editing funcationality for biobanks was no longer compatible and this PR edits the existing BiobankDetailsModel as well as the OrganisationDTO & Organisation entities to allow for these new additions and let them be nullable.
