### PR TITLE
AB#34188: Fix issue with valid MaterialTypes being rejected

### DIFF
--- a/src/Submissions/Core/Services/ReferenceDataReadService.cs
+++ b/src/Submissions/Core/Services/ReferenceDataReadService.cs
@@ -110,6 +110,7 @@ namespace Biobanks.Submissions.Core.Services
                 CacheKeys.MaterialTypes,
                 async () => await _db.MaterialTypes.AsNoTracking()
                     .Include(x => x.ExtractionProcedures)
+                    .Include(x => x.MaterialTypeGroups)
                     .ToListAsync());
 
         public async Task<MaterialType> GetMaterialTypeWithGroups(string value)


### PR DESCRIPTION
On listing MaterialTypes, the MaterialTypeGroups were not being included. Leading to valid MaterialTypes being rejected due to not having any MaterialTypeGroups