### PR TITLE
AB#34387: Fix to CreateContentPage Migration

### DIFF
--- a/src/Data/Migrations/20210427161809_CreateContentPage.Designer.cs
+++ b/src/Data/Migrations/20210427161809_CreateContentPage.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Biobanks.Data.Migrations
 {
     [DbContext(typeof(BiobanksDbContext))]
-    [Migration("20210427112114_CreateContentPage")]
+    [Migration("20210427161809_CreateContentPage")]
     partial class CreateContentPage
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -748,10 +748,12 @@ namespace Biobanks.Data.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<string>("RouteSlug")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(250)
+                        .HasColumnType("nvarchar(250)");
 
                     b.HasKey("Id");
 

--- a/src/Data/Migrations/20210427161809_CreateContentPage.cs
+++ b/src/Data/Migrations/20210427161809_CreateContentPage.cs
@@ -13,8 +13,8 @@ namespace Biobanks.Data.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    RouteSlug = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RouteSlug = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
+                    Title = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
                     Body = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     LastUpdated = table.Column<DateTime>(type: "datetime2", nullable: false),
                     IsEnabled = table.Column<bool>(type: "bit", nullable: false)

--- a/src/Data/Migrations/BiobanksDbContextModelSnapshot.cs
+++ b/src/Data/Migrations/BiobanksDbContextModelSnapshot.cs
@@ -746,10 +746,12 @@ namespace Biobanks.Data.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<string>("RouteSlug")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(250)
+                        .HasColumnType("nvarchar(250)");
 
                     b.HasKey("Id");
 


### PR DESCRIPTION
The latest migration does not currently reflect the navigation properties constraints for max length.

This migration has not yet been rolled out to any environments, so this fix will apply beforehand