### PR TITLE
AB#34310: Sample sets not being deleted on cold start 

### DIFF
--- a/src/Aggregator/Core/AggregationTask.cs
+++ b/src/Aggregator/Core/AggregationTask.cs
@@ -25,7 +25,6 @@ namespace Biobanks.Aggregator.Core
 
         public async Task Run()
         {
-            var count = 0;
             // All Samples Flagged For Update/Deletion
             var dirtySamples = await _sampleService.ListDirtySamplesAsync();
 
@@ -77,7 +76,6 @@ namespace Biobanks.Aggregator.Core
                 {
                     await _collectionService.DeleteCollectionAsync(collection);
                 }
-                count++;
             }
         }
     }

--- a/src/Aggregator/Core/Services/Contracts/ISampleService.cs
+++ b/src/Aggregator/Core/Services/Contracts/ISampleService.cs
@@ -12,5 +12,7 @@ namespace Biobanks.Aggregator.Core.Services.Contracts
         Task<IEnumerable<LiveSample>> ListDirtySamplesAsync();
 
         Task DeleteFlaggedSamplesAsync();
+
+        Task DeleteSampleSetById(int id);
     }
 }

--- a/src/Aggregator/Core/Services/SampleService.cs
+++ b/src/Aggregator/Core/Services/SampleService.cs
@@ -35,5 +35,9 @@ namespace Biobanks.Aggregator.Core.Services
         public async Task DeleteFlaggedSamplesAsync()
             => await _db.Samples.Where(x => x.IsDeleted).DeleteAsync();
 
+        // Moved to its own specific service class in future?
+        public async Task DeleteSampleSetById(int id)
+            => await _db.SampleSets.Where(x => x.Id == id).DeleteAsync();
+
     }
 }


### PR DESCRIPTION
- When the aggregator had run for the first time, the Collection's SampleSets weren't being deleted. Instead they were kept in the db, and the new SampleSets were being added too - resulting in duplicate records. 
- The runs following this would act properly (delete old SampleSets and add new ones). 

- This fix simply deletes the old SampleSets from the db following the update of the Collection. 