### PR TITLE
AB#34564: MaterialDetails FK Constraint Bug

### DIFF
--- a/src/Aggregator/Core/AggregationTask.cs
+++ b/src/Aggregator/Core/AggregationTask.cs
@@ -87,6 +87,10 @@ namespace Biobanks.Aggregator.Core
                     }
                     else
                     {
+                        foreach (var ss in oldSampleSets.Distinct())
+                        {
+                            await _aggregationService.DeleteMaterialDetailsBySampleSetId(ss);
+                        }
                         await _collectionService.UpdateCollectionAsync(collection);
 
                         // Remove old sampleSets from db if present

--- a/src/Aggregator/Core/Services/AggregationService.cs
+++ b/src/Aggregator/Core/Services/AggregationService.cs
@@ -6,6 +6,7 @@ using Biobanks.Entities.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml;
 using Z.EntityFramework.Plus;
 
@@ -132,5 +133,8 @@ namespace Biobanks.Aggregator.Core.Services
                 PreservationTypeId = sample.PreservationTypeId,
             };
         }
+
+        public async Task DeleteMaterialDetailsBySampleSetId(int id)
+            => await _db.MaterialDetails.Where(x => x.SampleSetId == id).DeleteAsync(); 
     }
 }

--- a/src/Aggregator/Core/Services/Contracts/IAggregationService.cs
+++ b/src/Aggregator/Core/Services/Contracts/IAggregationService.cs
@@ -1,6 +1,7 @@
 ﻿using Biobanks.Entities.Api;
 using Biobanks.Entities.Data;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Biobanks.Aggregator.Core.Services.Contracts
 {
@@ -13,5 +14,7 @@ namespace Biobanks.Aggregator.Core.Services.Contracts
         Collection GenerateCollection(IEnumerable<LiveSample> samples);
         SampleSet GenerateSampleSet(IEnumerable<LiveSample> samples);
         MaterialDetail GenerateMaterialDetail(IEnumerable<LiveSample> samples);
+
+        Task DeleteMaterialDetailsBySampleSetId(int id);
     }
 }


### PR DESCRIPTION
- When a collection was updated and a SampleSet was deleted - a FK Constraint error was thrown - MaterialDetails had a SampleSet FK.
- This manually deletes the associated MaterialDetail prior to deleting SampleSet.