### PR TITLE
AB#35393: Workers configuration for Submissions API

### DIFF
--- a/src/Core/Analytics/Services/Contracts/IGoogleAnalyticsReportingService.cs
+++ b/src/Core/Analytics/Services/Contracts/IGoogleAnalyticsReportingService.cs
@@ -1,7 +1,4 @@
-﻿using Google.Apis.AnalyticsReporting.v4.Data;
-
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Biobanks.Analytics.Services
@@ -23,7 +20,8 @@ namespace Biobanks.Analytics.Services
         /// <para>Fetch Directory level analytics data from the configured Google Analytics Reporting view, within the specified date range.</para>
         /// <para>The data is subsequently written to the local database.</para>
         /// </summary>
-        /// <param name="dateRanges"></param>
+        /// <param name="startDate"></param>
+        /// <param name="endDate"></param>
         Task DownloadDirectoryData(DateTimeOffset startDate, DateTimeOffset endDate);
     }
 }

--- a/src/Submissions/Api/Api.csproj
+++ b/src/Submissions/Api/Api.csproj
@@ -34,7 +34,6 @@
     <ProjectReference Include="..\..\Core\Core.csproj" />
     <ProjectReference Include="..\..\Data\Data.csproj" />
     <ProjectReference Include="..\..\IdentityModel\IdentityModel\IdentityModel.csproj" />
-    <ProjectReference Include="..\Core.AzureStorage\Core.AzureStorage.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Submissions/Api/Config/WorkersOptions.cs
+++ b/src/Submissions/Api/Config/WorkersOptions.cs
@@ -8,9 +8,24 @@ namespace Biobanks.Submissions.Api.Config
     /// </summary>
     public static class WorkersRecurringJobs
     {
+        /// <summary>
+        /// The Google Analytics data fetcher
+        /// </summary>
         public const string Analytics = "analytics";
+
+        /// <summary>
+        /// The EPMC Publications data fetcher
+        /// </summary>
         public const string Publications = "publications";
+
+        /// <summary>
+        /// The Submissions -> Directory Aggregator
+        /// </summary>
         public const string Aggregator = "aggregator";
+
+        /// <summary>
+        /// The expired Submissions clean up
+        /// </summary>
         public const string SubmissionsExpiry = "submissions-expiry";
     }
 
@@ -19,7 +34,15 @@ namespace Biobanks.Submissions.Api.Config
     /// </summary>
     public enum WorkersQueueService
     {
+        /// <summary>
+        /// Queued Worker Jobs (e.g. Submissions Staging) will be queued via Azure Queue Storage,
+        /// which should in turn trigger some external worker run (e.g. Functions, WebJobs...)
+        /// </summary>
         AzureQueueStorage,
+
+        /// <summary>
+        /// Queued Worker Jobs will be queued and triggered by Hangfire and run by this API process
+        /// </summary>
         Hangfire
     }
 
@@ -30,8 +53,14 @@ namespace Biobanks.Submissions.Api.Config
     /// </summary>
     public class WorkersOptions
     {
+        /// <summary>
+        /// Which jobs as per <see cref="WorkersRecurringJobs" /> should be scheduled by this API's Hangfire server
+        /// </summary>
         public List<string> HangfireRecurringJobs { get; set; } = new();
 
+        /// <summary>
+        /// Which service to use for Queued Worker Jobs
+        /// </summary>
         public WorkersQueueService QueueService { get; set; } = WorkersQueueService.Hangfire;
     }
 }

--- a/src/Submissions/Api/Config/WorkersOptions.cs
+++ b/src/Submissions/Api/Config/WorkersOptions.cs
@@ -30,7 +30,7 @@ namespace Biobanks.Submissions.Api.Config
     /// </summary>
     public class WorkersOptions
     {
-        public List<string> HangfireRecurringJobs { get; set; }
+        public List<string> HangfireRecurringJobs { get; set; } = new();
 
         public WorkersQueueService QueueService { get; set; } = WorkersQueueService.Hangfire;
     }

--- a/src/Submissions/Api/Config/WorkersOptions.cs
+++ b/src/Submissions/Api/Config/WorkersOptions.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace Biobanks.Submissions.Api.Config
+{
+    /// <summary>
+    /// Possible recurring jobs that the API can trigger using Hangfire.
+    /// Opted into via configuration.
+    /// </summary>
+    public static class WorkersRecurringJobs
+    {
+        public const string Analytics = "analytics";
+        public const string Publications = "publications";
+        public const string Aggregator = "aggregator";
+        public const string SubmissionsExpiry = "submissions-expiry";
+    }
+
+    /// <summary>
+    /// Implementations the API can use for queueing background worker jobs
+    /// </summary>
+    public enum WorkersQueueService
+    {
+        AzureQueueStorage,
+        Hangfire
+    }
+
+    /// <summary>
+    /// Options for interacting with Workers,
+    /// including which scheduled jobs the API should run using Hangfire,
+    /// and how the API should queue its jobs
+    /// </summary>
+    public class WorkersOptions
+    {
+        public List<string> HangfireRecurringJobs { get; set; }
+
+        public WorkersQueueService QueueService { get; set; } = WorkersQueueService.Hangfire;
+    }
+}

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -240,10 +240,8 @@ namespace Biobanks.Submissions.Api
         /// <param name="app"></param>
         /// <param name="env"></param>
         /// <param name="workersOptions"></param>
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IOptions<WorkersOptions> workersOptions, IServiceProvider services)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IOptions<WorkersOptions> workersOptions)
         {
-            var test = services.GetService<IBackgroundJobEnqueueingService>();
-
             // Early pipeline config
             app
                 .GnuTerryPratchett()

--- a/src/Submissions/Api/appsettings.json
+++ b/src/Submissions/Api/appsettings.json
@@ -27,5 +27,5 @@
     "EpmcApiUrl": "https://www.ebi.ac.uk/europepmc/"
   },
 
-    "AllowedHosts": "*"
-  }
+  "AllowedHosts": "*"
+}

--- a/src/Submissions/README.md
+++ b/src/Submissions/README.md
@@ -58,6 +58,23 @@ The **IdentityTool** is the only way to add credentials that aren't Biobank affi
 
 A series of background tasks are processed via the Submissions API as worker jobs. These jobs are defined in the `src/Core/Jobs` project folder. Each worker job is queued via the API's Hangfire instance, which uses the `apiHangfire` schema.
 
+You can opt in to which scheduled/recurring jobs will be run by your instance of the API usnig the following configuration:
+
+```jsonc
+"Workers": {
+    "HangfireRecurringJobs": [
+      "aggregator", // The Submissions -> Directory Aggregator, runs daily
+      "submissions-expiry", // The expired Submissions clean up, runs daily
+      "analytics", // The Google Analytics data fetcher, runs quarterly
+      "publications", // The EPMC Publications data fetcher, runs daily
+    ]
+  }
+```
+
+If you're using environment variables (or e.g. the Azure Portal), guidance on setting Config Array values is available [here](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#naming-of-environment-variables).
+
+By default, no recurring jobs are enabled - only those you include in the above config array will run.
+
 Documentation for each worker job can be found on the [Wiki - Worker Jobs](https://github.com/biobankinguk/biobankinguk/wiki/Worker-Jobs).
 
 In future other implementations of these worker jobs may be possible.


### PR DESCRIPTION
## Overview

This PR includes 2 bits of configuration relating to Worker Jobs in the API:

1. When the Submissions services run Worker Jobs on demand (by queueing a job run such as Staging, Commit or Reject), configuration allows choosing the queue service this will be done via. Currently the default, and only complete option, is Hangfire, using the API's own Hangfire instance.
2. The API is capable of running scheduled Worker Jobs via its Hangfire instance. Configuration allows specifying which, if any, scheduled jobs should be run by this instance of the API.
    - This essentially allows opting in to Directory extended services like Analytics or Publications, or only running some scheduled jobs via the API's Hangfire, and other jobs externally via cron or some other triggering system and Jobs implementation.
    - Today only Hangfire Worker Jobs implementations are complete.