### PR TITLE
AB#35280: Updated Counties Seed Data

### DIFF
--- a/sample-seed-data/Country.json
+++ b/sample-seed-data/Country.json
@@ -121,15 +121,11 @@
             },
             {
                 "id": "30",
-                "value": "London"
+                "value": "Greater London"
             },
             {
                 "id": "31",
                 "value": "Merseyside"
-            },
-            {
-                "id": "32",
-                "value": "Middlesex"
             },
             {
                 "id": "33",


### PR DESCRIPTION
- Removes Middlesex as a county
- Renames London to Greater London