### PR TITLE
AB#35741: Bug - Selecting a datatype for associated data without a corresponding provision time throws an exception

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -991,6 +991,12 @@ namespace Biobanks.Web.Controllers
 
                 return RedirectToAction("Collection", new { id = model.Id });
             }
+            else
+            {
+                //Populate Groups
+                model.Groups = null;
+                await PopulateAbstractCRUDCollectionModel(model);
+            }
 
             return View((EditCollectionModel)(await PopulateAbstractCRUDCollectionModel(model)));
         }

--- a/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCollectionModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCollectionModel.cs
@@ -64,7 +64,7 @@ namespace Biobanks.Web.Models.Biobank
                 if (!await biobankReadService.ValidOntologyTermDescriptionAsync(Diagnosis))
                 {
                     modelState.AddModelError("Diagnosis",
-                        "Please enter a valid Diagnosis or select one from the type ahead results.");
+                        "Please enter a valid Diagnosis or select one from the type ahead results lalallal.");
 
                     return false;
                 }
@@ -74,7 +74,7 @@ namespace Biobanks.Web.Models.Biobank
                     return true;
                 }
 
-                modelState.AddModelError("AssociatedData",
+                modelState.AddModelError("Groups",
                     "Please make sure you have selected a provision time for all selected data types.");
             }
 

--- a/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCollectionModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCollectionModel.cs
@@ -64,7 +64,7 @@ namespace Biobanks.Web.Models.Biobank
                 if (!await biobankReadService.ValidOntologyTermDescriptionAsync(Diagnosis))
                 {
                     modelState.AddModelError("Diagnosis",
-                        "Please enter a valid Diagnosis or select one from the type ahead results lalallal.");
+                        "Please enter a valid Diagnosis or select one from the type ahead results.");
 
                     return false;
                 }

--- a/src/Directory/Biobanks.Web/Views/Biobank/_AssociatedData.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Biobank/_AssociatedData.cshtml
@@ -7,7 +7,7 @@
 <div class="row">
     <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
-            <table class="table table-striped">
+            <table id="Groups" class="table table-striped">
                 <thead>
                     <tr>
                         <th>Data type</th>
@@ -20,13 +20,14 @@
                         <tr><td colspan="5" class="info">@Html.Raw(Model.Groups[i].Name)</td></tr>
                         for (int j = 0; j < Model.Groups[i].Types.Count(); j++)
                         {
-                          @Html.EditorFor(x => Model.Groups[i].Types[j])               
+                            @Html.EditorFor(x => Model.Groups[i].Types[j])
                         }
 
                     }
 
                 </tbody>
             </table>
+            @Html.ValidationMessageFor(x => x.Groups)
         </div>
         </div>
     </div>


### PR DESCRIPTION
## Overview

- Displays validation message for incomplete associated data fields
- prevents exception caused by null fields for associated data during editing

## Repro 
Go to a collection > Edit > scroll down to associated data > select a checkbox but don't select a radio button for time.