### PR TITLE
AB#33933: Blocklist/Allowlist UI

### DIFF
--- a/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
@@ -276,6 +276,11 @@ namespace Biobanks.Web
             bundles.Add(new ScriptBundle("~/bundles/adac/tabs").Include(
                 "~/Scripts/ADAC/adac-tabs.js"));
 
+            bundles.Add(new ScriptBundle("~/bundles/adac/block-allow-list").Include(
+                "~/Scripts/bootbox*",
+                "~/Scripts/ADAC/adac-blockallow-list.js",
+                "~/Scripts/ADAC/adac-refdata-utility.js"));
+
             // Registration Domain Rules
             bundles.Add(new ScriptBundle("~/bundles/adac/email-config").Include(
                 "~/Scripts/bootbox*",

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -854,6 +854,7 @@
     <Content Include="Views\ADAC\_ModalResetPassword.cshtml" />
     <Content Include="Views\Biobank\Submissions.cshtml" />
     <Content Include="Views\ADAC\EmailConfig.cshtml" />
+    <Content Include="Views\ADAC\BlockAllowList.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -471,6 +471,7 @@
     <Compile Include="Models\ADAC\ResetPasswordEntityModel.cs" />
     <Compile Include="Models\Biobank\AcceptanceModel.cs" />
     <Compile Include="Models\Biobank\AssociatedDataTimeFrameModel.cs" />
+    <Compile Include="Models\ADAC\BlockAllowListModel.cs" />
     <Compile Include="Models\Biobank\SubmissionsModel.cs" />
     <Compile Include="Models\Footer\FooterModel.cs" />
     <Compile Include="Models\Biobank\NetworkAcceptanceModel.cs" />
@@ -478,6 +479,7 @@
     <Compile Include="Models\Header\HeaderItemModel.cs" />
     <Compile Include="Models\Home\AboutModel.cs" />
     <Compile Include="Models\Home\HompageContentModel.cs" />
+    <Content Include="Scripts\ADAC\adac-blockallow-list.js" />
     <Content Include="Scripts\ADAC\adac-email-config.js" />
     <Content Include="Scripts\ADAC\adac-preservation-types.js" />
     <Content Include="Scripts\ADAC\adac-register-pages-config.js" />

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1972,6 +1972,29 @@ namespace Biobanks.Web.Controllers
 
         #endregion
 
+        #region Block/Allow List
+        public async Task<ActionResult> BlockAllowList()
+        {
+            var rules = (await _registrationDomainService.ListRules())
+            .Select(x => new RegistrationDomainRuleModel
+            {
+                Id = x.Id,
+                DateModified = x.DateModified,
+                RuleType = x.RuleType,
+                Source = x.Source,
+                Value = x.Value
+
+            })
+            .ToList();
+
+            return View(new BlockAllowListModel
+            {
+                RegistrationDomainRules = rules
+            });
+        }
+
+        #endregion
+
         private JsonResult JsonModelInvalidResponse(ModelStateDictionary state)
         {
             return Json(new

--- a/src/Directory/Biobanks.Web/Models/ADAC/BlockAllowListModel.cs
+++ b/src/Directory/Biobanks.Web/Models/ADAC/BlockAllowListModel.cs
@@ -1,0 +1,11 @@
+﻿using Biobanks.Web.Models.Shared;
+using System.Collections.Generic;
+
+
+namespace Biobanks.Web.Models.ADAC
+{
+    public class BlockAllowListModel
+    {
+        public ICollection<RegistrationDomainRuleModel> RegistrationDomainRules;
+    }
+}

--- a/src/Directory/Biobanks.Web/Mvc.sitemap
+++ b/src/Directory/Biobanks.Web/Mvc.sitemap
@@ -64,6 +64,7 @@
     </mvcSiteMapNode>
 
     <mvcSiteMapNode title="Requests" controller="ADAC" action="Requests"/>
+    <mvcSiteMapNode title="Block/Allow" controller="ADAC" action="BlockAllowList"/>
     <mvcSiteMapNode title="Request history" controller="ADAC" action="Historical"/>
     <mvcSiteMapNode title="Biobanks" controller="ADAC" action="Biobanks"/>
     <mvcSiteMapNode title="Biobank Activity" controller="ADAC" action="BiobankActivity"/>

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-blockallow-list.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-blockallow-list.js
@@ -38,8 +38,6 @@ function AdacRegistrationDomainRuleViewModel() {
         _this.modal.mode(_this.modal.modalModeAdd);
         _this.modal.registrationDomainRule(new RegistrationDomainRule(0, "", "Block"));
 
-        // allow selecting ruletype 
-        $('#ruleTypes').find('input:radio').attr('disabled', false);
         _this.showModal();
     };
 
@@ -56,9 +54,10 @@ function AdacRegistrationDomainRuleViewModel() {
             )
         );
 
-        // turn off editing ruletype 
-        $('#ruleTypes').find('input:radio').attr('disabled', true);
         _this.showModal();
+
+        // turn off editing ruletype 
+        $('#ruleTypes').find('input:radio:not(:checked)').attr('disabled', true);
     };
 
     this.modalSubmit = function (e) {
@@ -100,6 +99,11 @@ $(function () {
 
     adacRegistrationDomainRuleVM = new AdacRegistrationDomainRuleViewModel();
     ko.applyBindings(adacRegistrationDomainRuleVM);
+
+    // re-enable radio buttons on modal close
+    $('#domain-rule-modal').on('hidden.bs.modal', function (e) {
+        $('#ruleTypes').find('input:radio').attr('disabled', false);
+    })
 });
 
 // DataTables

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-blockallow-list.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-blockallow-list.js
@@ -1,0 +1,135 @@
+﻿// Modals
+var adacRegistrationDomainRuleVM;
+
+function RegistrationDomainRule(id, value, ruleType) {
+    this.id = id;
+    this.value = ko.observable(value);
+    this.ruleType = ko.observable(ruleType);
+}
+
+function RegistrationDomainRuleModal(id, value, ruleType) {
+    this.modalModeAdd = "Add";
+    this.modalModeEdit = "Update";
+
+    this.mode = ko.observable(this.modalModeAdd);
+
+    this.registrationDomainRule = ko.observable(
+        new RegistrationDomainRule(id, value, ruleType)
+    );
+}
+
+function AdacRegistrationDomainRuleViewModel() {
+    var _this = this;
+
+    this.modalId = "#domain-rule-modal";
+    this.modal = new RegistrationDomainRuleModal(0, "", "Block");
+    this.dialogErrors = ko.observableArray([]);
+
+    this.showModal = function () {
+        _this.dialogErrors.removeAll(); //clear errors on a new show
+        $(_this.modalId).modal("show");
+    };
+
+    this.hideModal = function () {
+        $(_this.modalId).modal("hide");
+    };
+
+    this.openModalForAdd = function () {
+        _this.modal.mode(_this.modal.modalModeAdd);
+        _this.modal.registrationDomainRule(new RegistrationDomainRule(0, "", "Block"));
+
+        // allow selecting ruletype 
+        $('#ruleTypes').find('input:radio').attr('disabled', false);
+        _this.showModal();
+    };
+
+    this.openModalForEdit = function (_, event) {
+        _this.modal.mode(_this.modal.modalModeEdit);
+
+        var registrationDomainRule = $(event.currentTarget).data("domain-rule");
+
+        _this.modal.registrationDomainRule(
+            new RegistrationDomainRule(
+                registrationDomainRule.Id,
+                registrationDomainRule.Value,
+                registrationDomainRule.RuleType
+            )
+        );
+
+        // turn off editing ruletype 
+        $('#ruleTypes').find('input:radio').attr('disabled', true);
+        _this.showModal();
+    };
+
+    this.modalSubmit = function (e) {
+        e.preventDefault();
+        var form = $(e.target); // get form as a jquery object
+
+        // Get Action Type
+        var action = _this.modal.mode();
+        if (action == 'Add') {
+            addRefData(_this, form.data("resource-url"), form.serialize(),
+                form.data("success-redirect"), form.data("refdata-type")); // cf. adac-refdata-utility.js
+        } else if (action == 'Update') {
+            editRefData(_this, form.data("resource-url") + '/' + $(e.target.Id).val(), form.serialize(),
+                form.data("success-redirect"), form.data("refdata-type"));
+        }
+    };
+}
+
+$(function () {
+    $("#modal-domain-rule-form").submit(function (e) {
+        adacRegistrationDomainRuleVM.modalSubmit(e);
+    });
+
+    $(".delete-confirm").click(function (e) {
+        e.preventDefault();
+
+        var $link = $(this);
+        var linkData = $link.data("domain-rule")
+        var url = $link.data("resource-url") + "/" + linkData.Id;
+
+        bootbox.confirm("Are you sure you want to delete " + linkData.Value + "?",
+            function (confirmation) {
+                if (confirmation) {
+                    deleteRefData(url, $link.data("success-redirect"), $link.data("refdata-type"));
+                }
+            }
+        );
+    });
+
+    adacRegistrationDomainRuleVM = new AdacRegistrationDomainRuleViewModel();
+    ko.applyBindings(adacRegistrationDomainRuleVM);
+});
+
+// DataTables
+$(function () {
+    $("#domain-rule-block")["DataTable"]({
+        paging: false,
+        info: false,
+        autoWidth: false,
+        rowReorder: false,
+        columnDefs: [
+            { orderable: false, targets: 3 },
+            { width: "250px", targets: 3 },
+        ],
+        language: {
+            search: "Filter: ",
+        },
+    });
+    $("#domain-rule-allow")["DataTable"]({
+        paging: false,
+        info: false,
+        autoWidth: false,
+        rowReorder: false,
+        columnDefs: [
+            { orderable: false, targets: 3 },
+            { width: "250px", targets: 3 },
+        ],
+        language: {
+            search: "Filter: ",
+        },
+    });
+
+    
+});

--- a/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
@@ -1,7 +1,209 @@
-﻿
+﻿@using System.Web.Optimization
+@model Biobanks.Web.Models.ADAC.BlockAllowListModel
+
 @{
     ViewBag.Title = "BlockAllowList";
 }
 
-<h2>BlockAllowList</h2>
+@Html.Partial("_ADACTabs", (string)ViewBag.Title)
 
+<h3>
+    Block List
+    <a href="#"
+       class="btn btn-success pull-right"
+       data-target="#domain-rule-modal"
+       data-bind="click: openModalForAdd">Add New Rule</a>
+</h3>
+
+<div class="row">
+    <div class="col-sm-12">
+        <br />
+        <table id="domain-rule-block" class="table table-striped table-fixed">
+
+            <thead>
+                <tr>
+                    <th>Value</th>
+                    <th>Source</th>
+                    <th>Date Modified</th>
+                    <th>@* Actions *@</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                @foreach (var type in Model.RegistrationDomainRules.Where(x => x.RuleType == "Block"))
+                {
+                    <tr data-resource-url="/api/RegistrationDomainRule"
+                        data-domain-rule-id="@type.Id"
+                        data-domain-ruletype="@type.RuleType">
+
+                        <td>@type.Value</td>
+                        <td>@type.Source</td>
+                        <td>@type.DateModified</td>
+
+                        <td class="text-right">
+                            <a title="Edit"
+                               class="action-icon"
+                               href="#"
+                               data-target="#domain-rule-modal"
+                               data-domain-rule="@Json.Encode(type)"
+                               data-bind="click: openModalForEdit">
+                                <span class="fa fa-edit labelled-icon"></span>Edit
+                            </a>
+
+                            <a title="Delete"
+                               class="action-icon delete-confirm"
+                               data-domain-rule="@Json.Encode(type)"
+                               data-resource-url="/api/RegistrationDomainRule"
+                               data-success-redirect="@Url.Action("BlockAllowList")"
+                               href="#">
+                                <span class="fa fa-trash labelled-icon"></span>Delete
+                            </a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<h3>
+    Allow List
+</h3>
+
+<div class="row">
+    <div class="col-sm-12">
+        <br />
+        <table id="domain-rule-allow" class="table table-striped table-fixed">
+
+            <thead>
+                <tr>
+                    <th>Value</th>
+                    <th>Source</th>
+                    <th>Date Modified</th>
+                    <th>@* Actions *@</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                @foreach (var type in Model.RegistrationDomainRules.Where(x => x.RuleType == "Allow"))
+                {
+                    <tr data-resource-url="/api/RegistrationDomainRule"
+                        data-domain-rule-id="@type.Id"
+                        data-domain-ruletype="@type.RuleType">
+
+                        <td>@type.Value</td>
+                        <td>@type.Source</td>
+                        <td>@type.DateModified</td>
+
+                        <td class="text-right">
+                            <a title="Edit"
+                               class="action-icon"
+                               href="#"
+                               data-target="#domain-rule-modal"
+                               data-domain-rule="@Json.Encode(type)"
+                               data-bind="click: openModalForEdit">
+                                <span class="fa fa-edit labelled-icon"></span>Edit
+                            </a>
+
+                            <a title="Delete"
+                               class="action-icon delete-confirm"
+                               data-domain-rule="@Json.Encode(type)"
+                               data-resource-url="/api/RegistrationDomainRule"
+                               data-success-redirect="@Url.Action("BlockAllowList")"
+                               data-refdata-type="Registration Domain Rule"
+                               href="#">
+                                <span class="fa fa-trash labelled-icon"></span>Delete
+                            </a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<!-- Modal -->
+<div class="modal fade" id="domain-rule-modal" tabindex="-1" role="dialog" aria-labelledby="domain-rule-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="domain-rule-modal-label"><span data-bind="text: modal.mode"></span> Block/Allow Rule</h4>
+            </div>
+
+            <!-- Error List -->
+            <div class="row">
+                <div class="col-sm-12" data-bind="visible: dialogErrors().length > 0">
+                    <div class="alert alert-danger"
+                         data-valmsg-summary="true"
+                         data-bind="foreach: dialogErrors">
+                        <p>
+                            <span class="fa fa-exclamation-triangle"></span>
+                            <span data-bind="text: $data"></span>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Modal Form -->
+            <form id="modal-domain-rule-form"
+                  data-resource-url="/api/RegistrationDomainRule"
+                  data-success-redirect="@Url.Action("BlockAllowList")"
+                  data-refdata-type="Registration Domain Rule"
+                  class="form-horizontal">
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <input type="hidden" id="Id" name="Id" data-bind="value: modal.registrationDomainRule().id">
+                            <input type="hidden" id="Source" name="Source" value="ADAC"> 
+                            <!-- Value -->
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">Value</label>
+                                <div class="col-sm-9">
+                                    <input type="text" id="Value" name="Value" class="form-control" data-bind="value: modal.registrationDomainRule().value()">
+                                </div>
+                            </div>
+
+                            <!-- Rule Type -->
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">Rule</label>
+                                <div class="col-sm-9">
+                                    <div id="ruleTypes" class="row">
+                                        <div class="col-sm-6">
+                                            <div class="radio">
+                                                <label>
+                                                    <input type="radio" id="Block" name="RuleType" value="Block" data-bind="checked: modal.registrationDomainRule().ruleType()">
+                                                    Block
+                                                </label>
+                                            </div>
+                                        </div>
+                                        <div class="col-sm-6">
+                                            <div class="radio">
+                                                <label>
+                                                    <input type="radio" id="Allow" name="RuleType" value="Allow" data-bind="checked: modal.registrationDomainRule().ruleType()">
+                                                    Allow
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary" data-bind="text: modal.mode"></button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section FooterScripts
+{
+    @Scripts.Render("~/bundles/knockout")
+    @Scripts.Render("~/bundles/datatables")
+    @Scripts.Render("~/bundles/adac/block-allow-list")
+}

--- a/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
@@ -1,0 +1,7 @@
+﻿
+@{
+    ViewBag.Title = "BlockAllowList";
+}
+
+<h2>BlockAllowList</h2>
+

--- a/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
@@ -55,6 +55,7 @@
                                data-domain-rule="@Json.Encode(type)"
                                data-resource-url="/api/RegistrationDomainRule"
                                data-success-redirect="@Url.Action("BlockAllowList")"
+                               data-refdata-type="Registration Domain Rule"
                                href="#">
                                 <span class="fa fa-trash labelled-icon"></span>Delete
                             </a>
@@ -160,7 +161,10 @@
                             <div class="form-group">
                                 <label class="col-sm-3 control-label">Value</label>
                                 <div class="col-sm-9">
-                                    <input type="text" id="Value" name="Value" class="form-control" data-bind="value: modal.registrationDomainRule().value()">
+                                    <input type="text" id="Value" name="Value" class="form-control" 
+                                           data-bind="value: modal.registrationDomainRule().value()"
+                                           pattern="^[a-zA-Z0-9_.+-]+(?:[@('@')a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]"
+                                           title="A valid email address e.g. 'john@doe.com' or domain name e.g. doe.com">
                                 </div>
                             </div>
 

--- a/src/Directory/Biobanks.Web/Views/ADAC/_ADACTabs.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/_ADACTabs.cshtml
@@ -13,6 +13,11 @@
             </li>
 
             <li role="presentation"
+                class="@(Model == "BlockAllowList" ? "active" : "true")">
+                @Html.ActionLink("Block/Allow", "BlockAllowList")
+            </li>
+
+            <li role="presentation"
                 class="@(Model == "Historical" ? "active" : "true")">
                 @Html.ActionLink("Historical", "Historical")
             </li>


### PR DESCRIPTION
## Overview
ADAC users can manage the block/allow list

Paginated datatable with filters.
Columns: Value (domain), Actions (edit, delete)

Have two main tables. Allow first, then block. Allow them to collapse for user ease.
Add new rule button - will bring up a modal form, which has value (text) input and block/allow radio button.
Stop user from adding multiple rules against the same exact domain - give a feedback message.
Edit should only edit the value, not type.