### PR TITLE
AB#35973: Added support for JSON string fields to accept numeric types

### DIFF
--- a/src/Submissions/Api/JsonConverters/JsonNumberAsStringConverter.cs
+++ b/src/Submissions/Api/JsonConverters/JsonNumberAsStringConverter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Biobanks.Submissions.Api.JsonConverters
+{
+    /// <summary>
+    /// A System.Text.Json converter that will parse integers into strings
+    /// such that JSON string fields can accept numeric types
+    /// </summary>
+    public class JsonNumberAsStringConverter : JsonConverter<string>
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert)
+            => typeToConvert == typeof(string);
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value);
+
+        /// <inheritdoc />
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt64(out long number))
+                {
+                    return number.ToString(CultureInfo.InvariantCulture);
+                }
+
+                if (reader.TryGetDouble(out double doubleNumber))
+                {
+                    return doubleNumber.ToString(CultureInfo.InvariantCulture);
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+
+            using (var document = JsonDocument.ParseValue(ref reader))
+            {
+                return document.RootElement.Clone().ToString();
+            }
+        }
+    }
+}

--- a/src/Submissions/Api/JsonConverters/JsonNumberAsStringConverter.cs
+++ b/src/Submissions/Api/JsonConverters/JsonNumberAsStringConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 namespace Biobanks.Submissions.Api.JsonConverters
 {
     /// <summary>
-    /// A System.Text.Json converter that will parse integers into strings
+    /// A System.Text.Json converter that will parse a number into a string
     /// such that JSON string fields can accept numeric types
     /// </summary>
     public class JsonNumberAsStringConverter : JsonConverter<string>

--- a/src/Submissions/Api/JsonConverters/JsonNumberAsStringConverter.cs
+++ b/src/Submissions/Api/JsonConverters/JsonNumberAsStringConverter.cs
@@ -22,6 +22,11 @@ namespace Biobanks.Submissions.Api.JsonConverters
         /// <inheritdoc />
         public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+
             if (reader.TokenType == JsonTokenType.Number)
             {
                 if (reader.TryGetInt64(out long number))
@@ -33,11 +38,6 @@ namespace Biobanks.Submissions.Api.JsonConverters
                 {
                     return doubleNumber.ToString(CultureInfo.InvariantCulture);
                 }
-            }
-
-            if (reader.TokenType == JsonTokenType.String)
-            {
-                return reader.GetString();
             }
 
             using (var document = JsonDocument.ParseValue(ref reader))

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -44,6 +44,7 @@ using Biobanks.Aggregator.Services;
 using System.Linq;
 using Microsoft.Extensions.Options;
 using Hangfire.Dashboard;
+using Biobanks.Submissions.Api.JsonConverters;
 
 namespace Biobanks.Submissions.Api
 {
@@ -80,6 +81,7 @@ namespace Biobanks.Submissions.Api
                 {
                     o.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
                     o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    o.JsonSerializerOptions.Converters.Add(new JsonNumberAsStringConverter());
                 });
 
             // Authentication


### PR DESCRIPTION
Since the API is now beyond .NET Core 3 - the old JSON library has been replaced by `System.Text.Json` which is more strict on incoming JSON types. Therefore any string field that is passed a number causes a validation error. This is bad for backwards compatibility.

## Old Behaviour
```jsonc
{
  stringField: "25", // Accepted
  stringField: 25 // Rejected - Not a string
}
```

## New Behaviour
```jsonc
{
  stringField: "25", // Accepted
  stringField: 25 // Accepted - Parsed as string
}
```
