### PR TITLE
AB#36070: Fixed Response On /Commit API Endpoint

### DIFF
--- a/src/Core/Submissions/Services/SubmissionService.cs
+++ b/src/Core/Submissions/Services/SubmissionService.cs
@@ -329,6 +329,7 @@ namespace Core.Submissions.Services
                 && s.Status.Value == Statuses.Open
                 && s.RecordsProcessed != s.TotalRecords)
                 .AsNoTracking()
+                .Include(x => x.Status)
                 .ToListAsync();
 
         /// <inheritdoc />

--- a/src/Submissions/Api/Controllers/Domain/CommitController.cs
+++ b/src/Submissions/Api/Controllers/Domain/CommitController.cs
@@ -49,7 +49,7 @@ namespace Biobanks.Submissions.Api.Controllers.Domain
         [SwaggerResponse(400, Description = "There are Open Submissions which have not been processed.")]
         public async Task<IActionResult> Post(int biobankId, string type = null)
         {
-            if (type == null) 
+            if (type == null)
                 return BadRequest("Expected Type parameter to specify 'update' or 'replace'");
 
             if (!User.HasClaim(CustomClaimTypes.BiobankId,
@@ -59,7 +59,7 @@ namespace Biobanks.Submissions.Api.Controllers.Domain
             var submissionsInProgress = await _submissionService.ListSubmissionsInProgress(biobankId);
             if (submissionsInProgress.Any())
             {
-                return BadRequest(JsonSerializer.Serialize(submissionsInProgress));
+                return BadRequest(submissionsInProgress);
             }
 
             //BackgroundJobEnqueueingService will then call either _queueWriteService or Hangfire to 
@@ -67,7 +67,7 @@ namespace Biobanks.Submissions.Api.Controllers.Domain
             //TODO: later PBI which will sort out conditional DI for which service to implement
             await _backgroundJobEnqueueingService.Commit(biobankId, type.Equals("replace", StringComparison.OrdinalIgnoreCase));
 
-            return NoContent();
+            return Accepted();
         }
     }
 }


### PR DESCRIPTION
- Fixed the status being `null` in the response payload
- Fixed the header from being `plain/text` to `application/json`
- Changed successful submission from `HTTP 204 No Content` to `HTTP 202 Accepted`