### PR TITLE
AB#36249: Fixes To API MaterialType validation and legacy mapping

### DIFF
--- a/src/Core/Submissions/Services/Contracts/IReferenceDataReadService.cs
+++ b/src/Core/Submissions/Services/Contracts/IReferenceDataReadService.cs
@@ -36,7 +36,7 @@ namespace Core.Submissions.Services.Contracts
 
         Task<OntologyTerm> GetSnomedExtractionProcedure(string value, string field);
 
-        Task<MaterialType> GetMaterialTypeWithGroups(string value);
+        Task<MaterialType> GetMaterialType(string value);
 
         Task<SampleContentMethod> GetSampleContentMethod(string value);
 

--- a/src/Core/Submissions/Services/ReferenceDataReadService.cs
+++ b/src/Core/Submissions/Services/ReferenceDataReadService.cs
@@ -111,11 +111,10 @@ namespace Core.Submissions.Services
                     .Include(x => x.MaterialTypeGroups)
                     .ToListAsync());
 
-        public async Task<MaterialType> GetMaterialTypeWithGroups(string value)
+        public async Task<MaterialType> GetMaterialType(string value)
             => (await ListMaterialTypes())
                 .FirstOrDefault(x =>
-                    x.Value.Equals(value, StringComparison.CurrentCultureIgnoreCase) &&
-                    (x.MaterialTypeGroups?.Any() ?? false));
+                    x.Value.Equals(value, StringComparison.CurrentCultureIgnoreCase));
 
         public async Task<IEnumerable<SampleContentMethod>> ListSampleContentMethods()
             => await CacheGetOrCreateWithAbsoluteExpiry(

--- a/src/Core/Submissions/Services/SampleValidationService.cs
+++ b/src/Core/Submissions/Services/SampleValidationService.cs
@@ -358,21 +358,30 @@ namespace Core.Submissions.Services
 
         private async Task<StagedSample> ValidateMaterialType(SampleDto dto, StagedSample sample)
         {
-            foreach (var obj in _materialTypesLegacy?.ListOfMappings ?? new ())
+            var legacyMapping = _materialTypesLegacy?.ListOfMappings.FirstOrDefault(x => x.Old.MaterialType == dto.MaterialType);
+
+            if (legacyMapping != null)
             {
-                if (obj.Old.MaterialType == dto.MaterialType)
-                {
-                    dto.MaterialType = obj.New.MaterialType;
-                    _logger.LogInformation($"The given material type was mapped to {obj.New.MaterialType}");
-
-                    if (!string.IsNullOrEmpty(obj.New.ExtractionProcedure))
-                    {
-                        var ep = await _refDataReadService.GetSnomedExtractionProcedure(obj.New.ExtractionProcedure, obj.New.ExtractionProcedureOntologyField);
-                        sample.ExtractionProcedureId = ep.Id;
-                    }
-
-                }
+                dto.MaterialType = legacyMapping.New.MaterialType;
+                dto.ExtractionProcedure = legacyMapping.New.ExtractionProcedure;
+                dto.ExtractionProcedureOntologyField = legacyMapping.New.ExtractionProcedureOntologyField;
             }
+
+            //foreach (var obj in _materialTypesLegacy?.ListOfMappings ?? new ())
+            //{
+            //    if (obj.Old.MaterialType == dto.MaterialType)
+            //    {
+            //        dto.MaterialType = obj.New.MaterialType;
+            //        _logger.LogInformation($"The given material type was mapped to {obj.New.MaterialType}");
+
+            //        if (!string.IsNullOrEmpty(obj.New.ExtractionProcedure))
+            //        {
+            //            var ep = await _refDataReadService.GetSnomedExtractionProcedure(obj.New.ExtractionProcedure, obj.New.ExtractionProcedureOntologyField);
+            //            sample.ExtractionProcedureId = ep.Id;
+            //        }
+
+            //    }
+            //}
 
             var result = await _refDataReadService.GetMaterialType(dto.MaterialType);
 

--- a/src/Core/Submissions/Services/SampleValidationService.cs
+++ b/src/Core/Submissions/Services/SampleValidationService.cs
@@ -367,22 +367,6 @@ namespace Core.Submissions.Services
                 dto.ExtractionProcedureOntologyField = legacyMapping.New.ExtractionProcedureOntologyField;
             }
 
-            //foreach (var obj in _materialTypesLegacy?.ListOfMappings ?? new ())
-            //{
-            //    if (obj.Old.MaterialType == dto.MaterialType)
-            //    {
-            //        dto.MaterialType = obj.New.MaterialType;
-            //        _logger.LogInformation($"The given material type was mapped to {obj.New.MaterialType}");
-
-            //        if (!string.IsNullOrEmpty(obj.New.ExtractionProcedure))
-            //        {
-            //            var ep = await _refDataReadService.GetSnomedExtractionProcedure(obj.New.ExtractionProcedure, obj.New.ExtractionProcedureOntologyField);
-            //            sample.ExtractionProcedureId = ep.Id;
-            //        }
-
-            //    }
-            //}
-
             var result = await _refDataReadService.GetMaterialType(dto.MaterialType);
 
             if (result == null)

--- a/src/Core/Submissions/Services/SampleValidationService.cs
+++ b/src/Core/Submissions/Services/SampleValidationService.cs
@@ -158,7 +158,7 @@ namespace Core.Submissions.Services
                 return sample;
 
             //check if extracted sample
-            var mt = await _refDataReadService.GetMaterialTypeWithGroups(dto.MaterialType);
+            var mt = await _refDataReadService.GetMaterialType(dto.MaterialType);
             if (!(mt?.MaterialTypeGroups.Any(x => x.Value == MaterialTypeGroups.ExtractedSample) ?? false))
                 return sample; //not invalid, but irrelevant, so no value
 
@@ -217,7 +217,7 @@ namespace Core.Submissions.Services
         private async Task<StagedSample> ValidateExtractionSite(SampleDto dto, StagedSample sample)
         {
             //check if tissue sample
-            var mt = await _refDataReadService.GetMaterialTypeWithGroups(dto.MaterialType);
+            var mt = await _refDataReadService.GetMaterialType(dto.MaterialType);
 
             if (!(mt?.MaterialTypeGroups.Any(x => x.Value == MaterialTypeGroups.TissueSample) ?? false))
                 return sample; //not invalid, but irrelevant, so no value
@@ -265,7 +265,7 @@ namespace Core.Submissions.Services
                 return sample;
 
             //check if extracted sample
-            var mt = await _refDataReadService.GetMaterialTypeWithGroups(dto.MaterialType);
+            var mt = await _refDataReadService.GetMaterialType(dto.MaterialType);
             if (!(mt?.MaterialTypeGroups.Any(x => x.Value == MaterialTypeGroups.ExtractedSample) ?? false))
                 return sample; //not invalid, but irrelevant, so no value
 
@@ -374,7 +374,7 @@ namespace Core.Submissions.Services
                 }
             }
 
-            var result = await _refDataReadService.GetMaterialTypeWithGroups(dto.MaterialType);
+            var result = await _refDataReadService.GetMaterialType(dto.MaterialType);
 
             if (result == null)
                 throw new ValidationException(

--- a/src/Submissions/Api/Settings/LegacyMaterialTypes.json
+++ b/src/Submissions/Api/Settings/LegacyMaterialTypes.json
@@ -50,7 +50,7 @@
           "materialType": "Blood spots"
         },
         "new": {
-          "materialType": "Dried whole blood"
+          "materialType": "Dried whole blood (e.g. Guthrie cards) DWB"
         }
       },
       {


### PR DESCRIPTION
- Removed filtering MaterialTypes without a MaterialTypeGroup from data validation
- Fixed legacy mapping of old MaterialTypes, where ExtractionProcedure was being omitted from the mapping
- Fixed legacy mapping of `Dried whole blood`