### PR TITLE
AB#36308: Facets no longer clear search term

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -57,6 +57,7 @@ namespace Biobanks.Web.Controllers
             // Build the base model.
             var model = new BaseSearchModel
             {
+                OntologyTerm = ontologyTerm,
                 // Extract the search facets.
                 SelectedFacets = ExtractSearchFacets(selectedFacets)
             };
@@ -91,7 +92,7 @@ namespace Biobanks.Web.Controllers
             model.Suggestions = await GetOntologyTermSearchResultsAsync(model.SearchType, model.OntologyTerm?.ToLower());
 
             //BIO-455 special case for cancer (will override this with a genericised approach in BIO-447
-            if (model.OntologyTerm.ToLower() == "cancer")
+            if (string.Equals(model.OntologyTerm, "cancer", StringComparison.CurrentCultureIgnoreCase))
             {
                 //get suggestions for the relevant correct searches
                 var malignant = await GetOntologyTermSearchResultsAsync(model.SearchType, "malignant");
@@ -163,7 +164,7 @@ namespace Biobanks.Web.Controllers
             // Build the base model.
             var model = new BaseSearchModel
             {
-                OntologyTerm = ontologyTerm ?? " "
+                OntologyTerm = ontologyTerm
             };
 
             // Extract the search facets.

--- a/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Search/_Facets.cshtml
@@ -108,7 +108,7 @@
                                                             <li>
                                                                 <a href="@Url.Action(Model.Action, "Search", new
 														                 {
-															                 diagnosis = Model.OntologyTerm,
+															                 ontologyTerm = Model.OntologyTerm,
 															                 selectedFacets = JsonConvert.SerializeObject(Model.SelectedFacets.Concat(new List<string>
 															                 {
 																                 facetValue.FacetId
@@ -125,7 +125,7 @@
                                                             <li>
                                                                 <a href="@Url.Action(Model.Action, "Search", new
 														                 {
-															                 diagnosis = Model.OntologyTerm,
+															                 ontologyTerm = Model.OntologyTerm,
 															                 selectedFacets = JsonConvert.SerializeObject(Model.SelectedFacets.Where(
 																                 x => x != facetValue.FacetId))
 														                 })">


### PR DESCRIPTION
## Overview

This PR fixes the issue when searching for Collections and clicking a facet, the original ontology term searched for is removed, and the results are no longer filtered by it.

## Notes

Some other minor tidy up while investigating this issue, including a particular facet case that was still using the `diagnosis` parameter instead of `ontologyTerm`