### PR TITLE
AB#35892: SuperUser Search Index Building uses configured index names

### DIFF
--- a/src/Directory/Biobanks.Web/App_Config/navigation.json
+++ b/src/Directory/Biobanks.Web/App_Config/navigation.json
@@ -9,6 +9,9 @@
 				"action": "adac"
 			},
 			{
+				"action": "superuser"
+			},
+			{
 				"action": "biobanks"
 			},
 			{

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -858,6 +858,7 @@
     <Content Include="Views\Biobank\Submissions.cshtml" />
     <Content Include="Views\ADAC\EmailConfig.cshtml" />
     <Content Include="Views\ADAC\BlockAllowList.cshtml" />
+    <Content Include="Views\Header\_NavItemSuperUser.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/src/Directory/Biobanks.Web/Views/Header/_NavItem.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Header/_NavItem.cshtml
@@ -8,6 +8,9 @@
     case "adac":
         Html.RenderPartial("_NavItemAdac", Model); break;
 
+    case "superuser":
+        Html.RenderPartial("_NavItemSuperUser", Model); break;
+
     case "biobanks":
         Html.RenderPartial("_NavItemBiobanks", Model); break;
 

--- a/src/Directory/Biobanks.Web/Views/Header/_NavItemSuperUser.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Header/_NavItemSuperUser.cshtml
@@ -1,0 +1,14 @@
+﻿@using Biobanks.Identity.Constants
+@model Biobanks.Web.Models.Header.NavItemModel
+
+@if (CurrentUser.Identity.IsAuthenticated)
+{
+	if (CurrentUser.IsInRole(Role.SuperUser.ToString()))
+	{
+		<li>
+			<a href="@Url.Action("Index", "SuperUser")">
+				<span class="fa fa-user labelled-icon"></span>Super User
+			</a>
+		</li>
+	}
+}


### PR DESCRIPTION
## Overview

The SuperUser tool for building the Search Index didn't use configuration as a source for the index names. It does now.

## Notes

Also added a SuperUser link to the Directory nav menu for SuperUsers. Been meaning to do that for years.