### PR TITLE
AB#36694: Fix Directory Build To Include Search Index Descriptions

### DIFF
--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -1182,7 +1182,7 @@
       <Compile Include="$(IntermediateOutputPath)Version.cs" />
     </ItemGroup>
   </Target>
-  <Target Name="AfterBuild">
+  <Target Name="BeforeBuild">
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\capabilities.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\collections.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
   </Target>

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -1185,11 +1185,5 @@
     <!-- Elastic Search Index Descriptions -->
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\capabilities.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\collections.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
-
-    <ItemGroup>
-      <Content Include="./App_Config/*.json">
-        <CopyToOutputDirectory>FooBar</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
   </Target>
 </Project>

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -1185,5 +1185,11 @@
     <!-- Elastic Search Index Descriptions -->
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\capabilities.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\collections.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
+
+    <ItemGroup>
+      <Content Include="./App_Config/*.json">
+        <CopyToOutputDirectory></CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -1181,9 +1181,15 @@
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)Version.cs" />
     </ItemGroup>
-  </Target>
-  <Target Name="BeforeBuild">
+    
+    <!-- Elastic Search Index Descriptions -->
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\capabilities.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
     <Copy SourceFiles="..\..\..\elastic-search\directory index setup\collections.json" DestinationFolder="..\..\..\src\Directory\Biobanks.Web\App_Config" />
+
+    <ItemGroup>
+      <Content Include="./App_Config/*.json">
+        <CopyToOutputDirectory>FooBar</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Changes the copying of the search index descriptions to before the build, such that they get packaged properly with the rest of the Directory code