### PR TITLE
AB#36668: Updated Block/Allow list valid values regex

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/RegistrationDomainRuleController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/RegistrationDomainRuleController.cs
@@ -7,6 +7,7 @@ using Biobanks.Services.Contracts;
 using Biobanks.Web.Models.ADAC;
 using Biobanks.Web.Models.Shared;
 using Biobanks.Web.Filters;
+using System.Text.RegularExpressions;
 
 namespace Biobanks.Web.ApiControllers
 {
@@ -42,7 +43,8 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Post(RegistrationDomainRuleModel model)
         {
             //Checking if the given value is valid
-            if (!model.Value.Contains(".") && !model.Value.Contains("@"))
+            var validPattern = new Regex(@"^[^@\s]*@?[^@\s]*\.[^@\s]+[^@\.]$");
+            if (!validPattern.IsMatch(model.Value))
             {
                 ModelState.AddModelError("Value", "That value is invalid and must contain at least one of '.' or '@'.");
             }

--- a/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/BlockAllowList.cshtml
@@ -163,8 +163,8 @@
                                 <div class="col-sm-9">
                                     <input type="text" id="Value" name="Value" class="form-control" 
                                            data-bind="value: modal.registrationDomainRule().value()"
-                                           pattern="^[a-zA-Z0-9_.+-]+(?:[@('@')a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]"
-                                           title="A valid email address e.g. 'john@doe.com' or domain name e.g. doe.com">
+                                           pattern="@(@"^[^@\s]*@?[^@\s]*\.[^@\s]+[^@\.]$")"
+                                           title="A valid full or partial email address containg at least one '.' e.g. 'john@doe.com' '@("@")doe.com', 'doe.com' or '.com'">
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Overview

This PR amends the validation logic for adding Registration Domain Block/Allow rules.

The previous frontend validation differed from the backend validation and didn't allow some necessary rules to be added.
The backend validation conversely was too lenient.