### PR TITLE
AB#36534: BUG Fix - Publications table doesn't load/populate on Test for Large datasets

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1782,7 +1782,15 @@ namespace Biobanks.Web.Controllers
                 });
             }
 
-            return Json(biobankPublications, JsonRequestBehavior.AllowGet);
+            return new JsonResult
+            {
+                Data = biobankPublications,
+                JsonRequestBehavior = JsonRequestBehavior.AllowGet,
+
+                // Handle biobanks with large amount of publications
+                // Ideally switch to server-side processing with multiple GET requests
+                MaxJsonLength = Int32.MaxValue
+            };
         }
 
         [HttpPost]


### PR DESCRIPTION
## Overview

Throws error when datatable tries to load publications for biobank with large number of publications.

Increased amount of data that can be sent per GET request.