### PR TITLE
AB#32642: Correct Collection Percentage calculation

### DIFF
--- a/src/Core/Jobs/AggregatorJob.cs
+++ b/src/Core/Jobs/AggregatorJob.cs
@@ -75,10 +75,11 @@ namespace Core.Jobs
                         foreach (var materialDetailSamples in _aggregationService.GroupIntoMaterialDetails(sampleSetSamples))
                         {
                             var materialDetail = _aggregationService.GenerateMaterialDetail(materialDetailSamples);
-                            var percentage = decimal.Divide(sampleSetSamples.Count(), materialDetailSamples.Count());
 
-                            // Set Collection Percetnage For Material Detail
-                            materialDetail.CollectionPercentageId = _refDataService.GetCollectionPercentage(percentage).Id;
+                            // Set Collection Percentage For Material Detail
+                            materialDetail.CollectionPercentage =
+                                _refDataService.GetCollectionPercentage(
+                                    100m * materialDetailSamples.Count() / sampleSetSamples.Count());
 
                             sampleSet.MaterialDetails.Add(materialDetail);
                         }


### PR DESCRIPTION
The CollectionPercentage mapped during aggregation was always 0-10%. This was due to a missing factor of 100 in the percentage calculation