### PR TITLE
AB#36825: Manually implemented cascade deletion for Collections

### DIFF
--- a/src/Core/Aggregator/Services/CollectionService.cs
+++ b/src/Core/Aggregator/Services/CollectionService.cs
@@ -38,11 +38,8 @@ namespace Biobanks.Aggregator.Services
             await _db.SaveChangesAsync();
         }
 
-        public async Task DeleteCollection(Collection collection)
-        {
-            await _db.Collections.Where(x => x.CollectionId == collection.CollectionId).DeleteAsync();
-            await _db.SaveChangesAsync();
-        }
+        public async Task DeleteCollection(int id)
+            => await _db.Collections.Where(x => x.CollectionId == id).DeleteAsync();
 
         public async Task DeleteSampleSetByIds(IEnumerable<int> ids)
         {

--- a/src/Core/Aggregator/Services/Contracts/ICollectionService.cs
+++ b/src/Core/Aggregator/Services/Contracts/ICollectionService.cs
@@ -12,7 +12,7 @@ namespace Biobanks.Aggregator.Services.Contracts
         
         Task AddCollection(Collection collection);
 
-        Task DeleteCollection(Collection collection);
+        Task DeleteCollection(int id);
 
         Task DeleteSampleSetByIds(IEnumerable<int> ids);
 

--- a/src/Core/Jobs/AggregatorJob.cs
+++ b/src/Core/Jobs/AggregatorJob.cs
@@ -101,7 +101,9 @@ namespace Core.Jobs
                 }
                 else
                 {
-                    await _collectionService.DeleteCollection(collection);
+                    await _collectionService.DeleteMaterialDetailsBySampleSetIds(collection.SampleSets.Select(x => x.Id));
+                    await _collectionService.DeleteSampleSetByIds(collection.SampleSets.Select(x => x.Id));
+                    await _collectionService.DeleteCollection(collection.CollectionId);
                 }
 
                 // Flag These Samples As Clean


### PR DESCRIPTION
Cascade deletion isn't correct configured for Collections, SampleSets and MaterialDetails in the Aggregator. This PR patches that behaviour by manually performing the cascade deletion where needed in the `AggregatorJob`

This work precedes work to resolve the cascade deletion configuration issue. 