### PR TITLE
AB#36572: Changed naming of Submission Public/Private Key to Client ID/Secret

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1981,19 +1981,15 @@ namespace Biobanks.Web.Controllers
         [Authorize(ClaimType = CustomClaimType.Biobank)]
         public async Task<ActionResult> GenerateApiKeyAjax(int biobankId)
         {
-            //update Organisations table
-            var existingclient = await _biobankReadService.IsBiobankAnApiClient(biobankId);
-            KeyValuePair<string, string> credentials;
-
-            if (existingclient)
-                credentials = await _biobankWriteService.GenerateNewSecretForBiobank(biobankId);
-            else
-                credentials = await _biobankWriteService.GenerateNewApiClientForBiobank(biobankId);
+            var credentials = 
+                await _biobankReadService.IsBiobankAnApiClient(biobankId)
+                    ? await _biobankWriteService.GenerateNewSecretForBiobank(biobankId)
+                    : await _biobankWriteService.GenerateNewApiClientForBiobank(biobankId);
 
             return Json(new
             {
-                publickey = credentials.Key,
-                privatekey = credentials.Value
+                ClientId = credentials.Key,
+                ClientSecret = credentials.Value
             });
         }
         #endregion

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1960,7 +1960,7 @@ namespace Biobanks.Web.Controllers
             model.BiobankId = biobankId;
             model.AccessCondition = biobank.AccessConditionId;
             model.CollectionType = biobank.CollectionTypeId;
-            model.PublicKey = biobank.ApiClients.FirstOrDefault()?.ClientId;
+            model.ClientId = biobank.ApiClients.FirstOrDefault()?.ClientId;
 
             return View(model);
         }

--- a/src/Directory/Biobanks.Web/Models/Biobank/SubmissionsModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Biobank/SubmissionsModel.cs
@@ -28,8 +28,8 @@ namespace Biobanks.Web.Models.Biobank
         [Display(Name = "Collection type")]
         public int? CollectionType { get; set; }
 
-        [Display(Name = "Public Key")]
-        public string PublicKey { get; set; }
+        [Display(Name = "Client ID")]
+        public string ClientId { get; set; }
 
         #endregion
     }

--- a/src/Directory/Biobanks.Web/Scripts/Biobank/help-popups.js
+++ b/src/Directory/Biobanks.Web/Scripts/Biobank/help-popups.js
@@ -267,16 +267,16 @@ $(".help-label-adac-macroscopicassessment-override").click(function () {
 
 $(".help-label-submissions-publickey").click(function () {
     bootbox.dialog({
-        message: "The public key used to encrypt data when using the submission API. Your public key is generated only once when you generate your first private key.",
-        title: "Public Key",
+        message: "The Client ID is used to identify the Organisation when making an authentication request to the Submissions API.",
+        title: "Client ID",
         buttons: helpIconBootboxButtons
     });
 });
 
 $(".help-label-submissions-privatekey").click(function () {
     bootbox.dialog({
-        message: "The private key used to encrypt and decrypt data when using the submission API. Should not be shared with unauthorised users",
-        title: "Private Key",
+        message: "As the Client Secret, it should NOT be shared. The Client Secret is used to identify the Organisation when making an authentication request to the Submissions API.",
+        title: "Client Secret",
         buttons: helpIconBootboxButtons
     });
 });

--- a/src/Directory/Biobanks.Web/Scripts/Biobank/submissions.js
+++ b/src/Directory/Biobanks.Web/Scripts/Biobank/submissions.js
@@ -18,13 +18,13 @@ $(".copy-text").click(function (e) {
     copyText(txtbox);
 });
 
-//generate private key
+//generate client id
 $("#generatekey").click(function (e) {
     var $btn = $(this);
     $.post($btn.data("generate-url"),
         { biobankId: $btn.data("biobank-id") }, data => {
-            $("#PrivateKey").val(data.privatekey);
-            $("#PublicKey").val(data.publickey);
-            $("#privateKeyWrapper").removeAttr("hidden");
+            $("#clientId").val(data.ClientId);
+            $("#clientSecret").val(data.ClientSecret);
+            $("#clientSecretWrapper").removeAttr("hidden");
     })
 })

--- a/src/Directory/Biobanks.Web/Views/Biobank/Submissions.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Biobank/Submissions.cshtml
@@ -99,10 +99,12 @@
 }
 
 <h3>Submission API Authentication</h3>
+
+<!-- Client ID -->
 <div class="row form-group">
     <div class="col-sm-2 col-sm-offset-1">
         <h4>
-            @Html.DisplayNameFor(x => x.PublicKey)
+            @Html.DisplayName("Client ID")
             <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-submissions-publickey"></span>
         </h4>
     </div>
@@ -116,18 +118,19 @@
     {
         <div class="col-sm-10 col-sm-offset-1 alert-container">
             <div class="alert alert-warning">
-                <label>Generating a new private key will override your previous key and display a new private key. Your public key will remain unchanged.</label>
+                <label>Generating a new Client Secret will override your previous Client Secret. Your Client ID will remain unchanged.</label>
             </div>
         </div>
     }
 </div>
 
+<!-- Client Secret -->
 <div id="privateKeyWrapper" class="row form-group" hidden>
     <div class="col-sm-2 col-sm-offset-1">
-        <h4>
-            Private Key
-            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-submissions-privatekey"></span>
-        </h4>
+		<h4>
+			@Html.DisplayName("Client Secret")
+			<span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-submissions-privatekey"></span>
+		</h4>
     </div>
     <div class="col-sm-5">
         <input type="text" id="PrivateKey" name="PrivateKey" class="form-control" readonly="readonly" />
@@ -137,16 +140,17 @@
     </div>
     <div class="col-sm-10 col-sm-offset-1 alert-container">
         <div class="alert alert-warning">
-            <label>This private key will be displayed only once! You are advised to copy it now and store it in a safe place.</label>
+            <label>Your Client ID will only be displayed once! You are advised to copy it now and store it in a safe place.</label>
         </div>
     </div>
 </div>
 
+<!-- Generate New Secret -->
 <div class="form-group row">
     <div class="col-sm-10">
         <button type="submit" id="generatekey" data-generate-url="GenerateApiKeyAjax" data-biobank-id="@Model.BiobankId"
                 class="btn btn-success pull-right">
-            Generate New Private Key
+            Generate New Client Secret
         </button>
     </div>
 </div>

--- a/src/Directory/Biobanks.Web/Views/Biobank/Submissions.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Biobank/Submissions.cshtml
@@ -109,12 +109,12 @@
         </h4>
     </div>
     <div class="col-sm-5">
-        <input type="text" id="PublicKey" name="PublicKey" value=@Model.PublicKey class="form-control" readonly="readonly" />
+        <input type="text" id="clientId" name="clientId" value=@Model.ClientId class="form-control" readonly="readonly" />
     </div>
     <div class="col-sm-2">
-        <button data-target="PublicKey" class="copy-text btn btn-default">Copy</button>
+        <button data-target="clientId" class="copy-text btn btn-default">Copy</button>
     </div>
-    @if (Model.PublicKey != null)
+    @if (Model.ClientId != null)
     {
         <div class="col-sm-10 col-sm-offset-1 alert-container">
             <div class="alert alert-warning">
@@ -125,7 +125,7 @@
 </div>
 
 <!-- Client Secret -->
-<div id="privateKeyWrapper" class="row form-group" hidden>
+<div id="clientSecretWrapper" class="row form-group" hidden>
     <div class="col-sm-2 col-sm-offset-1">
 		<h4>
 			@Html.DisplayName("Client Secret")
@@ -133,10 +133,10 @@
 		</h4>
     </div>
     <div class="col-sm-5">
-        <input type="text" id="PrivateKey" name="PrivateKey" class="form-control" readonly="readonly" />
+        <input type="text" id="clientSecret" name="clientSecret" class="form-control" readonly="readonly" />
     </div>
     <div class="col-sm-2">
-        <button data-target="PrivateKey" class="copy-text btn btn-default">Copy</button>
+        <button data-target="clientSecret" class="copy-text btn btn-default">Copy</button>
     </div>
     <div class="col-sm-10 col-sm-offset-1 alert-container">
         <div class="alert alert-warning">


### PR DESCRIPTION
- Renamed all variables named Public/Private key in to Client Id/Secret
- Renamed all occurrences of Public/Private key in the Submission Credentials View with Client Id/Secret
- Added corrected description for Client Id/Secret in Submissions Credentials View
