### PR TITLE
AB#35720: Diagnosis Status DisplayOnDirectory UI

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -7,6 +7,7 @@ using Biobanks.Web.Models.ADAC;
 using System.Collections;
 using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Web.Filters;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Biobanks.Web.ApiControllers
 {
@@ -35,7 +36,8 @@ namespace Biobanks.Web.ApiControllers
                     OntologyTermId = x.Id,
                     Description = x.Value,
                     CollectionCapabilityCount = await _biobankReadService.GetOntologyTermCollectionCapabilityCount(x.Id),
-                    OtherTerms = x.OtherTerms
+                    OtherTerms = x.OtherTerms,
+                    DisplayOnDirectory = x.DisplayOnDirectory
                 })
                 .Result
             )
@@ -100,7 +102,7 @@ namespace Biobanks.Web.ApiControllers
                 Id = model.OntologyTermId,
                 Value = model.Description,
                 OtherTerms = model.OtherTerms,
-                DisplayOnDirectory = true
+                DisplayOnDirectory = model.DisplayOnDirectory
             });
 
             //Everything went A-OK!
@@ -131,7 +133,7 @@ namespace Biobanks.Web.ApiControllers
                 Id = model.OntologyTermId,
                 Value = model.Description,
                 OtherTerms = model.OtherTerms,
-                DisplayOnDirectory = true
+                DisplayOnDirectory = model.DisplayOnDirectory
             });
 
             //Everything went A-OK!

--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -47,7 +47,7 @@ namespace Biobanks.Web.ApiControllers
         [Route("{id}")]
         public async Task<IHttpActionResult> Delete(string id)
         {
-            var model = (await _biobankReadService.ListDisplayableOntologyTerms()).Where(x => x.Id == id).First();
+            var model = (await _biobankReadService.ListOntologyTerms()).Where(x => x.Id == id).First();
 
             if (await _biobankReadService.IsOntologyTermInUse(id))
             {

--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -29,7 +29,7 @@ namespace Biobanks.Web.ApiControllers
         [Route("")]
         public async Task<IList> Get()
         {
-            return (await _biobankReadService.ListOntologyTermsAsync()).Select(x =>
+            return (await _biobankReadService.ListDisplayableOntologyTerms()).Select(x =>
 
                 Task.Run(async () => new ReadOntologyTermModel
                 {
@@ -48,7 +48,7 @@ namespace Biobanks.Web.ApiControllers
         [Route("{id}")]
         public async Task<IHttpActionResult> Delete(string id)
         {
-            var model = (await _biobankReadService.ListOntologyTermsAsync()).Where(x => x.Id == id).First();
+            var model = (await _biobankReadService.ListDisplayableOntologyTerms()).Where(x => x.Id == id).First();
 
             if (await _biobankReadService.IsOntologyTermInUse(id))
             {
@@ -87,7 +87,7 @@ namespace Biobanks.Web.ApiControllers
             if (await _biobankReadService.IsOntologyTermInUse(id))
             {
                 //Allow editing of only Other terms field if diagnosis in use
-                var diagnosis = (await _biobankReadService.ListOntologyTermsAsync()).Where(x => x.Id == id).First();
+                var diagnosis = (await _biobankReadService.ListDisplayableOntologyTerms()).Where(x => x.Id == id).First();
                 if ((diagnosis.Value != model.Description) || (diagnosis.Value != model.Description))
                     ModelState.AddModelError("Description", "This disease status is currently in use and cannot be edited.");
             }

--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -118,7 +118,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Post(OntologyTermModel model)
         {
             //if ontology term id is in use by another ontology term
-            if ((await _biobankReadService.ListOntologyTermsAsync()).Any(x => x.Id == model.OntologyTermId))
+            if ((await _biobankReadService.ListDiseaseOntologyTermsAsync()).Any(x => x.Id == model.OntologyTermId))
                 ModelState.AddModelError("OntologyTermId", "That ID is already in use. IDs must be unique across all ontology terms.");
 
             //If this description is valid, it already exists

--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -7,7 +7,6 @@ using Biobanks.Web.Models.ADAC;
 using System.Collections;
 using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Web.Filters;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Biobanks.Web.ApiControllers
 {

--- a/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
@@ -124,7 +124,7 @@ namespace Biobanks.Web.ApiControllers
             }
 
             //if ontology term id is in use by another ontology term
-            if ((await _biobankReadService.ListDiseaseOntologyTermsAsync()).Any(x => x.Id == model.OntologyTermId))
+            if ((await _biobankReadService.ListExtractionProceduresAsync()).Any(x => x.Id == model.OntologyTermId))
                 ModelState.AddModelError("OntologyTermId", "That ID is already in use. IDs must be unique across all ontology terms.");
 
             if (!ModelState.IsValid)

--- a/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
@@ -124,7 +124,7 @@ namespace Biobanks.Web.ApiControllers
             }
 
             //if ontology term id is in use by another ontology term
-            if ((await _biobankReadService.ListOntologyTermsAsync()).Any(x => x.Id == model.OntologyTermId))
+            if ((await _biobankReadService.ListDiseaseOntologyTermsAsync()).Any(x => x.Id == model.OntologyTermId))
                 ModelState.AddModelError("OntologyTermId", "That ID is already in use. IDs must be unique across all ontology terms.");
 
             if (!ModelState.IsValid)

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1163,7 +1163,7 @@ namespace Biobanks.Web.Controllers
             var searchValue = search.TryGetValue("value", out var s) ? s : "";
 
             // Get Disease Statuses
-            var ontologyTerms = await _biobankReadService.PaginateOntologyTerms(start, length, searchValue);
+            var ontologyTerms = await _biobankReadService.PaginateDiseaseOntologyTerms(start, length, searchValue);
             var filteredCount = await _biobankReadService.CountOntologyTerms(filter: searchValue);
             var totalCount = await _biobankReadService.CountOntologyTerms();
 

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1128,7 +1128,7 @@ namespace Biobanks.Web.Controllers
 
         #region RefData: Disease Status
         public ActionResult DiseaseStatuses()
-            => View(Enumerable.Empty<ReadOntologyTermModel>());
+            => View();
 
         public async Task<ActionResult> PagingatedDiseaseStatuses(int draw, int start, int length, IDictionary<string, string> search)
         {

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1164,8 +1164,8 @@ namespace Biobanks.Web.Controllers
 
             // Get Disease Statuses
             var ontologyTerms = await _biobankReadService.PaginateDiseaseOntologyTerms(start, length, searchValue);
-            var filteredCount = await _biobankReadService.CountOntologyTerms(filter: searchValue);
-            var totalCount = await _biobankReadService.CountOntologyTerms();
+            var filteredCount = await _biobankReadService.CountDiseaseOntologyTerms(filter: searchValue);
+            var totalCount = await _biobankReadService.CountDiseaseOntologyTerms();
 
             var data = ontologyTerms.Select(x =>
                 Task.Run(async () => new ReadOntologyTermModel

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1136,19 +1136,21 @@ namespace Biobanks.Web.Controllers
             var filteredCount = await _biobankReadService.CountOntologyTerms(filter: search);
             var totalCount = await _biobankReadService.CountOntologyTerms();
 
-            var data = ontologyTerms.Select(x => new ReadOntologyTermModel
-            {
-                OntologyTermId = x.Id,
-                Description = x.Value,
-                OtherTerms = x.OtherTerms,
-                CollectionCapabilityCount = 0,
-                DisplayOnDirectory = x.DisplayOnDirectory
-            });
+            var data = ontologyTerms.Select(x =>
+                Task.Run(async () => new ReadOntologyTermModel
+                {
+                    OntologyTermId = x.Id,
+                    Description = x.Value,
+                    CollectionCapabilityCount = await _biobankReadService.GetOntologyTermCollectionCapabilityCount(x.Id),
+                    OtherTerms = x.OtherTerms
+                })
+                .Result
+            );
 
             return Json(new
             {
                 draw,
-                data, 
+                data,
                 recordsTotal = totalCount,
                 recordsFiltered = filteredCount
             },

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1129,7 +1129,7 @@ namespace Biobanks.Web.Controllers
         #region RefData: Disease Status
         public async Task<ActionResult> DiseaseStatuses()
         {
-            return View((await _biobankReadService.ListOntologyTermsAsync()).Select(x =>
+            return View((await _biobankReadService.ListDisplayableOntologyTerms()).Select(x =>
 
                 Task.Run(async () => new ReadOntologyTermModel
                 {

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1130,10 +1130,14 @@ namespace Biobanks.Web.Controllers
         public ActionResult DiseaseStatuses()
             => View(Enumerable.Empty<ReadOntologyTermModel>());
 
-        public async Task<ActionResult> PagingatedDiseaseStatuses(int draw, int start, int length, string search = "")
+        public async Task<ActionResult> PagingatedDiseaseStatuses(int draw, int start, int length, IDictionary<string, string> search)
         {
-            var ontologyTerms = await _biobankReadService.PaginateOntologyTerms(start, length, search);
-            var filteredCount = await _biobankReadService.CountOntologyTerms(filter: search);
+            // Select Search By Value
+            var searchValue = search.TryGetValue("value", out var s) ? s : "";
+
+            // Get Disease Statuses
+            var ontologyTerms = await _biobankReadService.PaginateOntologyTerms(start, length, searchValue);
+            var filteredCount = await _biobankReadService.CountOntologyTerms(filter: searchValue);
             var totalCount = await _biobankReadService.CountOntologyTerms();
 
             var data = ontologyTerms.Select(x =>

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1136,7 +1136,8 @@ namespace Biobanks.Web.Controllers
                     OntologyTermId = x.Id,
                     Description = x.Value,
                     CollectionCapabilityCount = await _biobankReadService.GetOntologyTermCollectionCapabilityCount(x.Id),
-                    OtherTerms = x.OtherTerms
+                    OtherTerms = x.OtherTerms,
+                    DisplayOnDirectory = x.DisplayOnDirectory
                 })
                 .Result
             ));

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1141,8 +1141,9 @@ namespace Biobanks.Web.Controllers
                 {
                     OntologyTermId = x.Id,
                     Description = x.Value,
-                    CollectionCapabilityCount = await _biobankReadService.GetOntologyTermCollectionCapabilityCount(x.Id),
-                    OtherTerms = x.OtherTerms
+                    OtherTerms = x.OtherTerms,
+                    DisplayOnDirectory = x.DisplayOnDirectory,
+                    CollectionCapabilityCount = await _biobankReadService.GetOntologyTermCollectionCapabilityCount(x.Id)
                 })
                 .Result
             );

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -245,7 +245,7 @@ namespace Biobanks.Web.Controllers
         private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type, string wildcard)
         {
             var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
-            var directoryOntologyTerms = await _biobankReadService.ListDisplayableOntologyTerms();
+            var directoryOntologyTerms = await _biobankReadService.ListDiseaseOntologyTermsAsync("", onlyDisplayable: true);
 
             // Join Ontology Terms In Search and Directory Based On Ontology Term Value
             var model = directoryOntologyTerms.Join(searchOntologyTerms, 

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -245,7 +245,7 @@ namespace Biobanks.Web.Controllers
         private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type, string wildcard)
         {
             var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
-            var directoryOntologyTerms = await _biobankReadService.ListOntologyTermsAsync();
+            var directoryOntologyTerms = await _biobankReadService.ListDisplayableOntologyTerms();
 
             // Join Ontology Terms In Search and Directory Based On Ontology Term Value
             var model = directoryOntologyTerms.Join(searchOntologyTerms, 
@@ -275,7 +275,7 @@ namespace Biobanks.Web.Controllers
 
         private async Task<List<OntologyTermModel>> GetOntologyTermsAsync(string wildcard)
         {
-            var ontologyTerms = await _biobankReadService.ListOntologyTermsAsync(wildcard);
+            var ontologyTerms = await _biobankReadService.ListDisplayableOntologyTerms(wildcard);
 
             var model = ontologyTerms.Select(x =>
                new OntologyTermModel

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -14,8 +14,6 @@ using Microsoft.Ajax.Utilities;
 using Newtonsoft.Json;
 using Biobanks.Web.Extensions;
 using Biobanks.Web.Results;
-using Biobanks.Entities.Data.ReferenceData;
-using Biobanks.Services.Dto;
 
 namespace Biobanks.Web.Controllers
 {
@@ -266,6 +264,7 @@ namespace Biobanks.Web.Controllers
                         OntologyTermId = directoryTerm.Id,
                         Description = directoryTerm.Value,
                         OtherTerms = directoryTerm.OtherTerms ?? "",
+                        DisplayOnDirectory = directoryTerm.DisplayOnDirectory,
                         MatchingOtherTerms = searchTerm.MatchingOtherTerms,
                         NonMatchingOtherTerms = nonMatchingTerms ?? new List<string>()
                     };
@@ -283,7 +282,8 @@ namespace Biobanks.Web.Controllers
                {
                    OntologyTermId = x.Id,
                    Description = x.Value,
-                   OtherTerms = x.OtherTerms
+                   OtherTerms = x.OtherTerms,
+                   DisplayOnDirectory = x.DisplayOnDirectory
                }
             )
             .ToList();

--- a/src/Directory/Biobanks.Web/Models/ADAC/ReadOntologyTermModel.cs
+++ b/src/Directory/Biobanks.Web/Models/ADAC/ReadOntologyTermModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Biobanks.Web.Models.Shared;
+﻿using Biobanks.Web.Models.Shared;
 
 namespace Biobanks.Web.Models.ADAC
 {
@@ -7,7 +6,5 @@ namespace Biobanks.Web.Models.ADAC
     {
         //Sum of all Collections and Capabilities
         public int CollectionCapabilityCount { get; set; }
-        
-        public bool DisplayOnDirectory { get; set; }
     }
 }

--- a/src/Directory/Biobanks.Web/Models/ADAC/ReadOntologyTermModel.cs
+++ b/src/Directory/Biobanks.Web/Models/ADAC/ReadOntologyTermModel.cs
@@ -7,6 +7,7 @@ namespace Biobanks.Web.Models.ADAC
     {
         //Sum of all Collections and Capabilities
         public int CollectionCapabilityCount { get; set; }
-
+        
+        public bool DisplayOnDirectory { get; set; }
     }
 }

--- a/src/Directory/Biobanks.Web/Models/Shared/OntologyTermModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Shared/OntologyTermModel.cs
@@ -14,6 +14,8 @@ namespace Biobanks.Web.Models.Shared
 
         public string OtherTerms { get; set; }
 
+        public bool DisplayOnDirectory { get; set; }
+
         public List<string> MatchingOtherTerms { get; set; }
         public List<string> NonMatchingOtherTerms { get; set; }
     }

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -1,17 +1,18 @@
-function DiseaseStatus(ontologyTermId, description, otherTerms) {
+function DiseaseStatus(ontologyTermId, description, otherTerms, displayOnDirectory) {
     this.ontologyTermId = ko.observable(ontologyTermId);
     this.description = ko.observable(description);
     this.otherTerms = ko.observableArray(otherTerms);
+    this.displayOnDirectory = ko.observable(displayOnDirectory);
 }
 
-function DiseaseStatusModal(ontologyTermId, description, otherTerms) {
+function DiseaseStatusModal(ontologyTermId, description, otherTerms, displayOnDirectory) {
     this.modalModeAdd = "Add";
     this.modalModeEdit = "Update";
 
     this.mode = ko.observable(this.modalModeAdd);
 
     this.diseaseStatus = ko.observable(
-        new DiseaseStatus(ontologyTermId, description, otherTerms)
+        new DiseaseStatus(ontologyTermId, description, otherTerms, displayOnDirectory)
     );
 }
 
@@ -20,7 +21,7 @@ function AdacDiseaseStatusViewModel() {
     var _this = this;
 
     this.modalId = "#disease-status-modal";
-    this.modal = new DiseaseStatusModal("", "", []);
+    this.modal = new DiseaseStatusModal("", "", [], false);
     this.dialogErrors = ko.observableArray([]);
 
     this.showModal = function () {
@@ -36,7 +37,7 @@ function AdacDiseaseStatusViewModel() {
         $("#OntologyTermId").prop("readonly", false);
 
         _this.modal.mode(_this.modal.modalModeAdd);
-        _this.modal.diseaseStatus(new DiseaseStatus("", "",[]));
+        _this.modal.diseaseStatus(new DiseaseStatus("", "", [], false));
         _this.setPartialEdit(false);
         _this.showModal();
     };
@@ -53,8 +54,8 @@ function AdacDiseaseStatusViewModel() {
       new DiseaseStatus(
           diseaseStatus.OntologyTermId,
           diseaseStatus.Description,
-          otherTerms
-
+          otherTerms,
+          diseaseStatus.DisplayOnDirectory
       )
     );
 

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -148,7 +148,6 @@ $(function () {
                     });
 
                     if (row.CollectionCapabilityCount == 0) {
-
                         // Delete Link - Triggered By jQuery
                         var deleteLink = $('<a/>', {
                             "data-row": meta.row,
@@ -171,8 +170,7 @@ $(function () {
                             .html();
                     }
                     else {
-
-                        // In-Use Edit Only
+                        // In Use -> Edit Only
                         return $('<div/>')
                             .append(editLink)
                             .html();
@@ -181,7 +179,7 @@ $(function () {
             }
         ],
         createdRow: function (row, data, dataIndex) {
-            // Highlight In-Use Disease Statuses
+            // Highlight In Use Disease Statuses
             if (data.CollectionCapabilityCount > 0) {
                 $(row).addClass("info");
             }
@@ -206,11 +204,12 @@ $(function () {
 
         var rowIndex = $(this).data("row")
         var data = dataTable.row(rowIndex).data();
+        var url = apiUrl + "/" + data.OntologyTermId;
 
         bootbox.confirm("Are you sure you want to delete " + data.Description + "?",
             function (confirmation) {
                 if (confirmation) {
-                    deleteRefData(apiUrl, redirectUrl, refdataType);
+                    deleteRefData(url, redirectUrl, refdataType);
                 }
             }
         );

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -109,6 +109,10 @@ function AdacDiseaseStatusViewModel() {
     }
 }
 
+function capitalize(string) {
+    
+}
+
 // DataTables
 $(function () {
     dataTable = $("#disease-statuses").DataTable({
@@ -127,9 +131,15 @@ $(function () {
             { data: "OntologyTermId" },
             { data: "OtherTerms" },
             { data: "CollectionCapabilityCount" },
-            { data: "DisplayOnDirectory" },
             {
-                // Generate Action Links
+                data: "DisplayOnDirectory",
+                render: function (data, type, row) {
+                    var bool = data.toString();
+                    return bool.charAt(0).toUpperCase() + bool.slice(1);
+                }
+            },
+            {
+                // Action Links
                 data: function (row, type, val, meta) {
 
                     // Edit Link - Binds To Knockout Modal

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -120,6 +120,7 @@ $(function () {
         processing: true,
         serverSide: true,
         paging: true,
+        pageLength: 50,
         ordering: false,
         info: false,
         autoWidth: false,

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -82,11 +82,16 @@ function AdacDiseaseStatusViewModel() {
         // Get Action Type
         var action = _this.modal.mode();
         if (action == 'Add') {
-            addRefData(_this, form.data("resource-url"), form.serialize(),
-                form.data("success-redirect"), form.data("refdata-type")); // cf. adac-refdata-utility.js
-        } else if (action == 'Update') {
-            editRefData(_this, form.data("resource-url") + '/' + $(e.target.Id).val(), form.serialize(),
-                form.data("success-redirect"), form.data("refdata-type"));
+            addRefData(_this, apiUrl, form.serialize(), redirectUrl, refdataType);
+        }
+        else if (action == 'Update') {
+
+            // Parse Edit Url
+            var rowIndex = $(this).data("row")
+            var data = dataTable.row(rowIndex).data();
+            var url = apiUrl + "/" + data.OntologyTermId;
+
+            editRefData(_this, url, form.serialize(), redirectUrl, refdataType);
         }
     };
 
@@ -120,7 +125,7 @@ $(function () {
         processing: true,
         serverSide: true,
         paging: true,
-        pageLength: 50,
+        pageLength: 25,
         ordering: false,
         info: false,
         autoWidth: false,

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -1,3 +1,10 @@
+const refdataType = "Disease status";
+const redirectUrl = "/ADAC/DiseaseStatuses";
+const apiUrl = "/api/DiseaseStatus";
+
+var adacDiseaseStatusVM;
+var dataTable;
+
 function DiseaseStatus(ontologyTermId, description, otherTerms, displayOnDirectory) {
     this.ontologyTermId = ko.observable(ontologyTermId);
     this.description = ko.observable(description);
@@ -34,34 +41,36 @@ function AdacDiseaseStatusViewModel() {
     };
 
     this.openModalForAdd = function () {
-        $("#OntologyTermId").prop("readonly", false);
-
         _this.modal.mode(_this.modal.modalModeAdd);
         _this.modal.diseaseStatus(new DiseaseStatus("", "", [], false));
         _this.setPartialEdit(false);
         _this.showModal();
     };
 
-  this.openModalForEdit = function (_, event) {
-    _this.modal.mode(_this.modal.modalModeEdit);
+    this.openModalForEdit = function (_, event) {
 
-      var diseaseStatus = $(event.currentTarget).data("disease-status");
-      let otherTerms = (diseaseStatus.OtherTerms
+        _this.modal.mode(_this.modal.modalModeEdit);
+
+        // Get Row Data From DataTable
+        var rowIndex = $(event.currentTarget).data("row");
+        var diseaseStatus = dataTable.row(rowIndex).data();
+
+        let otherTerms = (diseaseStatus.OtherTerms
           ? diseaseStatus.OtherTerms.split(",").map(item => item.trim())
           : diseaseStatus.OtherTerms)
 
-    _this.modal.diseaseStatus(
-      new DiseaseStatus(
-          diseaseStatus.OntologyTermId,
-          diseaseStatus.Description,
-          otherTerms,
-          diseaseStatus.DisplayOnDirectory
-      )
-    );
+        _this.modal.diseaseStatus(
+            new DiseaseStatus(
+                diseaseStatus.OntologyTermId,
+                diseaseStatus.Description,
+                otherTerms,
+                diseaseStatus.DisplayOnDirectory
+            )
+        );
 
-    _this.setPartialEdit($(event.currentTarget).data("partial-edit"));
-    _this.showModal();
-  };
+        _this.setPartialEdit(diseaseStatus.CollectionCapabilityCount > 0);
+        _this.showModal();
+    };
 
     this.modalSubmit = function (e) {
         e.preventDefault();
@@ -81,7 +90,6 @@ function AdacDiseaseStatusViewModel() {
         }
     };
 
-    //Turns on/off partial editing of some input fields
     this.setPartialEdit = function (flag) {
         if (flag == true) {
             $("#OntologyTermId").prop('readonly', true);
@@ -101,12 +109,9 @@ function AdacDiseaseStatusViewModel() {
     }
 }
 
-var adacDiseaseStatusVM;
-
 // DataTables
 $(function () {
-
-    $("#disease-statuses")["DataTable"]({
+    dataTable = $("#disease-statuses").DataTable({
         ajax: "./PagingatedDiseaseStatuses",
         processing: true,
         serverSide: true,
@@ -114,6 +119,9 @@ $(function () {
         ordering: false,
         info: false,
         autoWidth: false,
+        language: {
+            search: "Filter: ",
+        },
         columns: [
             { data: "Description" },
             { data: "OntologyTermId" },
@@ -121,98 +129,145 @@ $(function () {
             { data: "CollectionCapabilityCount" },
             { data: "DisplayOnDirectory" },
             {
+                // Generate Action Links
                 data: function (row, type, val, meta) {
 
-                    // Cannot Edit As In Use
-                    if (row.CollectionCapabilityCount > 0) {
-                        return "Disease Status In Use";
+                    // Edit Link - Binds To Knockout Modal
+                    var editLink = $('<a/>', {
+                        "data-row": meta.row,
+                        "data-bind": "click: openModalForEdit",
+                        "class": "action-icon",
+                        "href": "#",
+                        "html":
+                            $('<span/>', {
+                                class: "fa fa-edit labelled-icon",
+                            })
+                            .add($('<span/>', {
+                                text: "Edit"
+                            }))
+                    });
+
+                    if (row.CollectionCapabilityCount == 0) {
+
+                        // Delete Link - Triggered By jQuery
+                        var deleteLink = $('<a/>', {
+                            "data-row": meta.row,
+                            "class": "action-icon click-delete", 
+                            "href": "#",
+                            "html":
+                                $('<span/>', {
+                                    class: "fa fa-trash labelled-icon",
+                                })
+                                .add($('<span/>', {
+                                    text: "Delete"
+                                }))
+
+                        });
+
+                        // Convert To HTML String
+                        return $('<div/>')
+                            .append(editLink)
+                            .append(deleteLink)
+                            .html();
                     }
                     else {
-                        return "Edit"
+
+                        // In-Use Edit Only
+                        return $('<div/>')
+                            .append(editLink)
+                            .html();
                     }
                 }
             }
         ],
-        language: {
-            search: "Filter: ",
-        },
+        createdRow: function (row, data, dataIndex) {
+            // Highlight In-Use Disease Statuses
+            if (data.CollectionCapabilityCount > 0) {
+                $(row).addClass("info");
+            }
+
+            // Bind Knockout View Model To Row
+            ko.applyBindingsToDescendants(adacDiseaseStatusVM, row);
+        }
     });
 });
 
 // Start-Up
 $(function () {
+
+    // Modal Submission Event Listener
+    $("#modal-disease-status-form").submit(function (e) {
+        adacDiseaseStatusVM.modalSubmit(e);
+    });
+
+    // Delete Row Link Listener
+    $(document.body).on("click", ".click-delete", function (e) {
+        e.preventDefault();
+
+        var rowIndex = $(this).data("row")
+        var data = dataTable.row(rowIndex).data();
+
+        bootbox.confirm("Are you sure you want to delete " + data.Description + "?",
+            function (confirmation) {
+                if (confirmation) {
+                    deleteRefData(apiUrl, redirectUrl, refdataType);
+                }
+            }
+        );
+    });
+
+    // Knockout View Model Binding
+    adacDiseaseStatusVM = new AdacDiseaseStatusViewModel();
+    ko.applyBindings(adacDiseaseStatusVM);
+
     // jquery plugin to serialise checkboxes as bools
     (function ($) {
         $.fn.serialize = function () {
-        return $.param(this.serializeArray());
+            return $.param(this.serializeArray());
         };
 
         $.fn.serializeArray = function () {
             var o = $.extend(
-            {
-                checkboxesAsBools: true,
-            },
-            {}
+                {
+                    checkboxesAsBools: true,
+                },
+                {}
             );
 
             var rselectTextarea = /select|textarea/i;
             var rinput = /text|hidden|password|search/i;
 
             return this.map(function () {
-            return this.elements ? $.makeArray(this.elements) : this;
+                return this.elements ? $.makeArray(this.elements) : this;
             })
-            .filter(function () {
-                return (
-                this.name &&
-                !this.disabled &&
-                (this.checked ||
-                    (o.checkboxesAsBools && this.type === "checkbox") ||
-                    rselectTextarea.test(this.nodeName) ||
-                    rinput.test(this.type))
-                );
-            })
-            .map(function (i, elem) {
-                const val = $(this).val();
-                return val == null
-                ? null
-                : $.isArray(val)
-                ? $.map(val, (innerVal) => ({ name: elem.name, value: innerVal }))
-                : {
-                    name: elem.name,
-                    value:
-                        o.checkboxesAsBools && this.type === "checkbox" //moar ternaries!
-                        ? this.checked
-                            ? "true"
-                            : "false"
-                        : val,
-                    };
-            })
-            .get();
+                .filter(function () {
+                    return (
+                        this.name &&
+                        !this.disabled &&
+                        (this.checked ||
+                            (o.checkboxesAsBools && this.type === "checkbox") ||
+                            rselectTextarea.test(this.nodeName) ||
+                            rinput.test(this.type))
+                    );
+                })
+                .map(function (i, elem) {
+                    const val = $(this).val();
+                    return val == null
+                        ? null
+                        : $.isArray(val)
+                            ? $.map(val, (innerVal) => ({ name: elem.name, value: innerVal }))
+                            : {
+                                name: elem.name,
+                                value:
+                                    o.checkboxesAsBools && this.type === "checkbox" //moar ternaries!
+                                        ? this.checked
+                                            ? "true"
+                                            : "false"
+                                        : val,
+                            };
+                })
+                .get();
         };
     }
     )(jQuery);
-
-    $("#modal-disease-status-form").submit(function (e) {
-        adacDiseaseStatusVM.modalSubmit(e);
-    });
-
-  $(".delete-confirm").click(function (e) {
-      e.preventDefault();
-
-      var $link = $(this);
-      var linkData = $link.data("refdata-model")
-      var url = $link.data("resource-url") + "/" + linkData.OntologyTermId;
-
-      bootbox.confirm("Are you sure you want to delete " + linkData.Description + "?",
-          function (confirmation) {
-              if (confirmation) {
-                  deleteRefData(url, $link.data("success-redirect"), $link.data("refdata-type"));
-              }
-          }
-      );
-  });
-
-    adacDiseaseStatusVM = new AdacDiseaseStatusViewModel();
-
-    ko.applyBindings(adacDiseaseStatusVM);
 });

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -103,6 +103,43 @@ function AdacDiseaseStatusViewModel() {
 
 var adacDiseaseStatusVM;
 
+// DataTables
+$(function () {
+
+    $("#disease-statuses")["DataTable"]({
+        ajax: "./PagingatedDiseaseStatuses",
+        processing: true,
+        serverSide: true,
+        paging: true,
+        ordering: false,
+        info: false,
+        autoWidth: false,
+        columns: [
+            { data: "Description" },
+            { data: "OntologyTermId" },
+            { data: "OtherTerms" },
+            { data: "CollectionCapabilityCount" },
+            { data: "DisplayOnDirectory" },
+            {
+                data: function (row, type, val, meta) {
+
+                    // Cannot Edit As In Use
+                    if (row.CollectionCapabilityCount > 0) {
+                        return "Disease Status In Use";
+                    }
+                    else {
+                        return "Edit"
+                    }
+                }
+            }
+        ],
+        language: {
+            search: "Filter: ",
+        },
+    });
+});
+
+// Start-Up
 $(function () {
     // jquery plugin to serialise checkboxes as bools
     (function ($) {
@@ -154,19 +191,6 @@ $(function () {
         };
     }
     )(jQuery);
-
-    $("#disease-statuses")["DataTable"]({
-        columnDefs: [
-            { orderable: false, targets: 4 },
-            { width: "180px", targets: 4 },
-        ],
-        paging: false,
-        info: false,
-        autoWidth: false,
-        language: {
-            search: "Filter: ",
-        },
-    });
 
     $("#modal-disease-status-form").submit(function (e) {
         adacDiseaseStatusVM.modalSubmit(e);

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -56,8 +56,8 @@ function AdacDiseaseStatusViewModel() {
         var diseaseStatus = dataTable.row(rowIndex).data();
 
         let otherTerms = (diseaseStatus.OtherTerms
-          ? diseaseStatus.OtherTerms.split(",").map(item => item.trim())
-          : diseaseStatus.OtherTerms)
+            ? diseaseStatus.OtherTerms.split(",").map(item => item.trim())
+            : diseaseStatus.OtherTerms)
 
         _this.modal.diseaseStatus(
             new DiseaseStatus(
@@ -68,9 +68,10 @@ function AdacDiseaseStatusViewModel() {
             )
         );
 
-    $("#OntologyTermId").prop('readonly', true);
+        $("#OntologyTermId").prop('readonly', true);
         _this.setPartialEdit(diseaseStatus.CollectionCapabilityCount > 0);
         _this.showModal();
+    }
 
     this.modalSubmit = function (e) {
         e.preventDefault();
@@ -106,12 +107,8 @@ function AdacDiseaseStatusViewModel() {
         _this.modal.diseaseStatus().otherTerms.push("");
     }
     this.removeOtherTerms = function (idx) {
-        _this.modal.diseaseStatus().otherTerms.splice(idx,1)
+        _this.modal.diseaseStatus().otherTerms.splice(idx, 1)
     }
-}
-
-function capitalize(string) {
-    
 }
 
 // DataTables
@@ -154,24 +151,24 @@ $(function () {
                             $('<span/>', {
                                 class: "fa fa-edit labelled-icon",
                             })
-                            .add($('<span/>', {
-                                text: "Edit"
-                            }))
+                                .add($('<span/>', {
+                                    text: "Edit"
+                                }))
                     });
 
                     if (row.CollectionCapabilityCount == 0) {
                         // Delete Link - Triggered By jQuery
                         var deleteLink = $('<a/>', {
                             "data-row": meta.row,
-                            "class": "action-icon click-delete", 
+                            "class": "action-icon click-delete",
                             "href": "#",
                             "html":
                                 $('<span/>', {
                                     class: "fa fa-trash labelled-icon",
                                 })
-                                .add($('<span/>', {
-                                    text: "Delete"
-                                }))
+                                    .add($('<span/>', {
+                                        text: "Delete"
+                                    }))
 
                         });
 

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -56,14 +56,8 @@
 				</div>
 			</div>
 
-            <form id="modal-disease-status-form"
-                  data-resource-url="/api/DiseaseStatus"
-                  data-success-redirect="@Url.Action("DiseaseStatuses")"
-                  data-refdata-type="Disease status"
-                  class="form-horizontal">
-
+            <form id="modal-disease-status-form" class="form-horizontal">
 				<div class="modal-body">
-
 					<div class="row">
 						<div class="col-sm-12">
 

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -20,7 +20,6 @@
 	<div class="col-sm-12">
 		<br />
 		<table id="disease-statuses" class="table table-striped table-fixed">
-
 			<thead>
 				<tr>
 					<th>Name</th>
@@ -31,58 +30,6 @@
 					<th>@* Actions *@</th>
 				</tr>
 			</thead>
-
-			<tbody>
-				@foreach (var ontologyTerm in Model)
-				{
-					<tr class="@(ontologyTerm.CollectionCapabilityCount > 0 ? "info" : "")">
-                        <td>@Html.DisplayFor(x => ontologyTerm.Description)</td>
-						<td>@Html.DisplayFor(x => ontologyTerm.OntologyTermId)</td>
-						<td>@Html.DisplayFor(x => ontologyTerm.OtherTerms)</td>
-						<td>@ontologyTerm.CollectionCapabilityCount</td>
-                        <td>@ontologyTerm.DisplayOnDirectory</td>
-
-                        <!-- Actions -->
-                        <td class="text-right">
-                            @if (ontologyTerm.CollectionCapabilityCount > 0)
-                            {
-                                <span class="fa fa-info-circle labelled-icon"></span>@Html.Raw("Disease status in use")
-                                //Allow editing of 'other terms' only
-                                <a title="Edit"
-                                   class="action-icon"
-                                   href="#"
-                                   data-target="#disease-status-modal"
-                                   data-disease-status="@Json.Encode(ontologyTerm)"
-                                   data-bind="click: openModalForEdit"
-                                   data-partial-edit="true">
-                                    <span class="fa fa-edit labelled-icon"></span>Edit
-                                </a>
-                            }
-                            else
-                            {
-                                <a title="Edit"
-                                   class="action-icon"
-                                   href="#"
-                                   data-target="#disease-status-modal"
-                                   data-disease-status="@Json.Encode(ontologyTerm)"
-                                   data-bind="click: openModalForEdit">
-                                    <span class="fa fa-edit labelled-icon"></span>Edit
-                                </a>
-
-                                <a title="Delete"
-                                   class="action-icon delete-confirm"
-                                   data-refdata-model="@Json.Encode(ontologyTerm)"
-                                   data-resource-url="/api/DiseaseStatus"
-                                   data-success-redirect="@Url.Action("DiseaseStatuses")"
-                                   data-refdata-type="Disease status"
-                                   href="#">
-                                    <span class="fa fa-trash labelled-icon"></span>Delete
-                                </a>
-                            }
-                        </td>
-                    </tr>
-                }
-            </tbody>
         </table>
     </div>
 </div>
@@ -122,8 +69,6 @@
 
 							<input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
 							<input type="hidden" id="OtherTerms" name="OtherTerms">
-
-
 
 							<!-- SNOMED ID -->
 							<div class="form-group">

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -27,6 +27,7 @@
 					<th>Ontology Term ID</th>
 					<th>Other Terms</th>
 					<th>Collection and Capability Count</th>
+                    <th>Displayed On Directory</th>
 					<th>@* Actions *@</th>
 				</tr>
 			</thead>
@@ -35,54 +36,52 @@
 				@foreach (var ontologyTerm in Model)
 				{
 					<tr class="@(ontologyTerm.CollectionCapabilityCount > 0 ? "info" : "")">
-						<td>
-							<div class="wrappable-td">@Html.DisplayFor(x => ontologyTerm.Description)</div>
-						</td>
-						<td>
-							@Html.DisplayFor(x => ontologyTerm.OntologyTermId)
-						</td>
-						<td><div class="wrappable-td">@Html.DisplayFor(x => ontologyTerm.OtherTerms)</div></td>
+                        <td>@Html.DisplayFor(x => ontologyTerm.Description)</td>
+						<td>@Html.DisplayFor(x => ontologyTerm.OntologyTermId)</td>
+						<td>@Html.DisplayFor(x => ontologyTerm.OtherTerms)</td>
 						<td>@ontologyTerm.CollectionCapabilityCount</td>
+                        <td>@ontologyTerm.DisplayOnDirectory</td>
 
-                    <td class="text-right">
-                        @if (ontologyTerm.CollectionCapabilityCount > 0)
-                        {
-                            <span class="fa fa-info-circle labelled-icon"></span>@Html.Raw("Disease status in use")
-                            //Allow editing of 'other terms' only
-                            <a title="Edit"
-                               class="action-icon"
-                               href="#"
-                               data-target="#disease-status-modal"
-                               data-disease-status="@Json.Encode(ontologyTerm)"
-                               data-bind="click: openModalForEdit"
-                               data-partial-edit="true">
-                                <span class="fa fa-edit labelled-icon"></span>Edit
-                            </a>
-                        }
-                        else
-                        {
-                            <a title="Edit"
-                               class="action-icon"
-                               href="#"
-                               data-target="#disease-status-modal"
-                               data-disease-status="@Json.Encode(ontologyTerm)"
-                               data-bind="click: openModalForEdit">
-                                <span class="fa fa-edit labelled-icon"></span>Edit
-                            </a>
+                        <!-- Actions -->
+                        <td class="text-right">
+                            @if (ontologyTerm.CollectionCapabilityCount > 0)
+                            {
+                                <span class="fa fa-info-circle labelled-icon"></span>@Html.Raw("Disease status in use")
+                                //Allow editing of 'other terms' only
+                                <a title="Edit"
+                                   class="action-icon"
+                                   href="#"
+                                   data-target="#disease-status-modal"
+                                   data-disease-status="@Json.Encode(ontologyTerm)"
+                                   data-bind="click: openModalForEdit"
+                                   data-partial-edit="true">
+                                    <span class="fa fa-edit labelled-icon"></span>Edit
+                                </a>
+                            }
+                            else
+                            {
+                                <a title="Edit"
+                                   class="action-icon"
+                                   href="#"
+                                   data-target="#disease-status-modal"
+                                   data-disease-status="@Json.Encode(ontologyTerm)"
+                                   data-bind="click: openModalForEdit">
+                                    <span class="fa fa-edit labelled-icon"></span>Edit
+                                </a>
 
-                            <a title="Delete"
-                               class="action-icon delete-confirm"
-                               data-refdata-model="@Json.Encode(ontologyTerm)"
-                               data-resource-url="/api/DiseaseStatus"
-                               data-success-redirect="@Url.Action("DiseaseStatuses")"
-                               data-refdata-type="Disease status"
-                               href="#">
-                                <span class="fa fa-trash labelled-icon"></span>Delete
-                            </a>
-                        }
-                    </td>
-                </tr>
-            }
+                                <a title="Delete"
+                                   class="action-icon delete-confirm"
+                                   data-refdata-model="@Json.Encode(ontologyTerm)"
+                                   data-resource-url="/api/DiseaseStatus"
+                                   data-success-redirect="@Url.Action("DiseaseStatuses")"
+                                   data-refdata-type="Disease status"
+                                   href="#">
+                                    <span class="fa fa-trash labelled-icon"></span>Delete
+                                </a>
+                            }
+                        </td>
+                    </tr>
+                }
             </tbody>
         </table>
     </div>
@@ -119,43 +118,57 @@
 				<div class="modal-body">
 
 					<div class="row">
-                        <div class="col-sm-12">
+						<div class="col-sm-12">
 
-                            <input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
-                            <input type="hidden" id="OtherTerms" name="OtherTerms">
-                            <!-- SNOMED ID -->
-                            <div class="form-group">
-                                <label class="col-sm-3 control-label">Ontology Term ID</label>
-                                <div class="col-sm-9">
-                                    <input type="text" id="OntologyTermId" name="OntologyTermId" class="form-control"
-                                           data-bind="value: modal.diseaseStatus().ontologyTermId()" maxlength="20">
-                                </div>
-                            </div>
+							<input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
+							<input type="hidden" id="OtherTerms" name="OtherTerms">
 
-                            <!-- Description -->
-                            <div class="form-group">
-                                <label class="col-sm-3 control-label">Name</label>
-                                <div class="col-sm-9">
-                                    <input type="text" id="Description" name="Description" class="form-control"
-                                           data-bind="value: modal.diseaseStatus().description()">
-                                </div>
-                            </div>
 
-                            <!-- Other Terms -->
-                            <div data-bind="foreach: modal.diseaseStatus().otherTerms()">
-                                <div class="form-group">
-                                    <label class="col-sm-3 control-label" data-bind="visible: $index() < 1">Other Terms</label>
-                                    <div class="col-sm-8" data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
-                                        <input type="text" class="form-control"
-                                               data-bind="textInput: $parent.modal.diseaseStatus().otherTerms()[$index()]">
-                                    </div>
-                                    <div class="col-sm-1">
-                                        <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right"
-                                                data-bind="click: function() { $parent.removeOtherTerms($index())}" />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+
+							<!-- SNOMED ID -->
+							<div class="form-group">
+								<label class="col-sm-3 control-label">Ontology Term ID</label>
+								<div class="col-sm-9">
+									<input type="text" id="OntologyTermId" name="OntologyTermId" class="form-control"
+										   data-bind="value: modal.diseaseStatus().ontologyTermId()" maxlength="20">
+								</div>
+							</div>
+
+							<!-- Description -->
+							<div class="form-group">
+								<label class="col-sm-3 control-label">Name</label>
+								<div class="col-sm-9">
+									<input type="text" id="Description" name="Description" class="form-control"
+										   data-bind="value: modal.diseaseStatus().description()">
+								</div>
+							</div>
+
+							<!-- Other Terms -->
+							<div data-bind="foreach: modal.diseaseStatus().otherTerms()">
+								<div class="form-group">
+									<label class="col-sm-3 control-label" data-bind="visible: $index() < 1">Other Terms</label>
+									<div class="col-sm-8" data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
+										<input type="text" class="form-control"
+											   data-bind="textInput: $parent.modal.diseaseStatus().otherTerms()[$index()]">
+									</div>
+									<div class="col-sm-1">
+										<button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right"
+												data-bind="click: function() { $parent.removeOtherTerms($index())}" />
+									</div>
+								</div>
+							</div>
+
+							<!-- Displayed On Directory Checkbox -->
+							<div>
+								<div class="form-group">
+									<label class="col-sm-3 control-label">Displayed On Directory</label>
+									<div class="col-sm-1">
+										<input type="checkbox" id="DisplayOnDirectory" name="DisplayOnDirectory" class=" form-control" 
+											   data-bind="checked: modal.diseaseStatus().displayOnDirectory()"/>
+									</div>
+								</div>
+							</div>
+						</div>
                     </div>
 				</div>
                 <div class="modal-footer">

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -1,7 +1,5 @@
 ﻿@using System.Web.Optimization
 @using Biobanks.Web.Models.ADAC
-@model IEnumerable<ReadOntologyTermModel>
-
 @{
 	ViewBag.Title = "Disease statuses";
 }

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1169,9 +1169,6 @@ namespace Biobanks.Services
 
         #region RefData: OntologyTerm
 
-        public async Task<int> CountOntologyTerms(string filter = "")
-            => await _ontologyTermRepository.CountAsync(x => x.Value.Contains(filter));
-
         public async Task<OntologyTerm> GetOntologyTermByDescription(string description)
             => (await _ontologyTermRepository.ListAsync(filter: x => x.Value == description && x.DisplayOnDirectory)).SingleOrDefault();
 
@@ -1199,6 +1196,9 @@ namespace Biobanks.Services
         #endregion
 
         #region RefData: Disease Statuses
+
+        public async Task<int> CountDiseaseOntologyTerms(string filter = "")
+            => await _ontologyTermRepository.CountAsync(x => x.Value.Contains(filter) && x.SnomedTag.Value == DiseaseTag);
 
         public async Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "")
             => await _context.OntologyTerms

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1151,7 +1151,7 @@ namespace Biobanks.Services
         public async Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string filter = "")
             => await _context.OntologyTerms
                     .Where(x => x.Value.Contains(filter))
-                    .OrderByDescending(x => x.DisplayOnDirectory).ThenBy(x => x.Id)
+                    .OrderByDescending(x => x.DisplayOnDirectory).ThenBy(x => x.Value)
                     .Skip(start)
                     .Take(length)
                     .ToListAsync();

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -21,6 +21,8 @@ namespace Biobanks.Services
 {
     public class BiobankReadService : IBiobankReadService
     {
+        private const string DiseaseTag = "Disease";
+
         #region Properties and ctor
 
         private readonly ILogoStorageProvider _logoStorageProvider;
@@ -1166,30 +1168,9 @@ namespace Biobanks.Services
         #endregion
 
         #region RefData: OntologyTerm
-        public async Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string filter = "")
-            => await _context.OntologyTerms
-                    .Where(x => x.Value.Contains(filter))
-                    .OrderByDescending(x => x.DisplayOnDirectory).ThenBy(x => x.Value)
-                    .Skip(start)
-                    .Take(length)
-                    .ToListAsync();
 
         public async Task<int> CountOntologyTerms(string filter = "")
             => await _ontologyTermRepository.CountAsync(x => x.Value.Contains(filter));
-
-        public async Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string filter = "", bool onlyDisplayable = false)
-            => await _ontologyTermRepository.ListAsync(filter: x => x.Value.Contains(filter) && (x.DisplayOnDirectory || !onlyDisplayable));
-
-        public async Task<IEnumerable<OntologyTerm>> ListDisplayableOntologyTerms(string filter = "")
-            => await ListOntologyTerms(filter, onlyDisplayable: true);
-
-        public async Task<IEnumerable<OntologyTerm>> GetUsedOntologyTermsAsync()
-        {
-            var collections = await _collectionRepository.ListAsync(false);
-            var ontologyTerms = await ListDisplayableOntologyTerms();
-
-            return ontologyTerms.Where(x => collections.Any(y => y.OntologyTermId == x.Id));
-        }
 
         public async Task<OntologyTerm> GetOntologyTermByDescription(string description)
             => (await _ontologyTermRepository.ListAsync(filter: x => x.Value == description && x.DisplayOnDirectory)).SingleOrDefault();
@@ -1214,18 +1195,29 @@ namespace Biobanks.Services
         public async Task<int> GetOntologyTermCollectionCapabilityCount(string id)
             => await _collectionRepository.CountAsync(x => x.OntologyTermId == id) 
                + await _capabilityRepository.CountAsync(x => x.OntologyTermId == id);
+
         #endregion
 
         #region RefData: Disease Statuses
-        public async Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTermsAsync(string wildcard = "")
-            => await _ontologyTermRepository.ListAsync(filter: x => 
-                x.SnomedTag.Value == "Disease" && 
-                x.Value.Contains(wildcard) && 
-                x.DisplayOnDirectory);
+
+        public async Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "")
+            => await _context.OntologyTerms
+                    .Where(x => x.Value.Contains(filter) && x.SnomedTag.Value == DiseaseTag)
+                    .OrderByDescending(x => x.DisplayOnDirectory).ThenBy(x => x.Value)
+                    .Skip(start)
+                    .Take(length)
+                    .ToListAsync();
+
+        public async Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTermsAsync(string wildcard = "", bool onlyDisplayable = false)
+            => await _ontologyTermRepository.ListAsync(filter: x =>
+                x.SnomedTag.Value == DiseaseTag &&
+                x.Value.Contains(wildcard) &&
+                (x.DisplayOnDirectory || !onlyDisplayable));
+
         public async Task<bool> ValidDiseaseOntologyTermDescriptionAsync(string ontologyTermDescription)
             => (await _ontologyTermRepository.ListAsync(
                 filter: x =>
-                    x.SnomedTag.Value == "Disease" &&
+                    x.SnomedTag.Value == DiseaseTag &&
                     x.Value == ontologyTermDescription &&
                     x.DisplayOnDirectory
                 ))

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1141,13 +1141,17 @@ namespace Biobanks.Services
         #endregion
 
         #region RefData: OntologyTerm
-        public async Task<IEnumerable<OntologyTerm>> ListOntologyTermsAsync(string wildcard = "")
-            => await _ontologyTermRepository.ListAsync(filter: x => x.Value.Contains(wildcard) && x.DisplayOnDirectory);
+        public async Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string filter = "", bool onlyDisplayable = false)
+            => await _ontologyTermRepository.ListAsync(filter: x => x.Value.Contains(filter) && (x.DisplayOnDirectory || !onlyDisplayable));
+
+        public async Task<IEnumerable<OntologyTerm>> ListDisplayableOntologyTerms(string filter = "")
+            => await ListOntologyTerms(filter, onlyDisplayable: true);
+
 
         public async Task<IEnumerable<OntologyTerm>> GetUsedOntologyTermsAsync()
         {
             var collections = await _collectionRepository.ListAsync(false);
-            var ontologyTerms = await ListOntologyTermsAsync();
+            var ontologyTerms = await ListDisplayableOntologyTerms();
 
             return ontologyTerms.Where(x => collections.Any(y => y.OntologyTermId == x.Id));
         }

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -131,17 +131,15 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(string procurementDescription);
 
         Task<int> CountOntologyTerms(string filter = "");
-        Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string filter = "");
-        Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string filter = "", bool onlyDisplayable = false);
-        Task<IEnumerable<OntologyTerm>> ListDisplayableOntologyTerms(string filter = "");
         Task<bool> ValidOntologyTermDescriptionAsync(string OntologyTermDescription);
         Task<bool> ValidOntologyTermDescriptionAsync(string ontologyTermId, string ontologyDescription);
         Task<OntologyTerm> GetOntologyTermByDescription(string description);
         Task<int> GetOntologyTermCollectionCapabilityCount(string id);
         Task<bool> IsOntologyTermInUse(string id);
 
-        Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTermsAsync(string wildcard = "");
+        Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTermsAsync(string wildcard = "", bool onlyDisplayable = false);
         Task<bool> ValidDiseaseOntologyTermDescriptionAsync(string ontologyTermDescription);
+        Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "");
 
         Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "");
         Task<OntologyTerm> GetExtractionProcedureById(string id);

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -123,7 +123,8 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(int procurementId, string procurementDescription);
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(string procurementDescription);
 
-        Task<IEnumerable<OntologyTerm>> ListOntologyTermsAsync(string wildcard = "");
+        Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string filter = "", bool onlyDisplayable = false);
+        Task<IEnumerable<OntologyTerm>> ListDisplayableOntologyTerms(string filter = "");
         Task<bool> ValidOntologyTermDescriptionAsync(string OntologyTermDescription);
         Task<bool> ValidOntologyTermDescriptionAsync(string ontologyTermId, string ontologyDescription);
         Task<OntologyTerm> GetOntologyTermByDescription(string description);

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -123,6 +123,8 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(int procurementId, string procurementDescription);
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(string procurementDescription);
 
+        Task<int> CountOntologyTerms(string filter = "");
+        Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string filter = "");
         Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string filter = "", bool onlyDisplayable = false);
         Task<IEnumerable<OntologyTerm>> ListDisplayableOntologyTerms(string filter = "");
         Task<bool> ValidOntologyTermDescriptionAsync(string OntologyTermDescription);

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -130,7 +130,6 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(int procurementId, string procurementDescription);
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(string procurementDescription);
 
-        Task<int> CountOntologyTerms(string filter = "");
         Task<bool> ValidOntologyTermDescriptionAsync(string OntologyTermDescription);
         Task<bool> ValidOntologyTermDescriptionAsync(string ontologyTermId, string ontologyDescription);
         Task<OntologyTerm> GetOntologyTermByDescription(string description);
@@ -140,6 +139,7 @@ namespace Biobanks.Services.Contracts
         Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTermsAsync(string wildcard = "", bool onlyDisplayable = false);
         Task<bool> ValidDiseaseOntologyTermDescriptionAsync(string ontologyTermDescription);
         Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "");
+        Task<int> CountDiseaseOntologyTerms(string filter = "");
 
         Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "");
         Task<OntologyTerm> GetExtractionProcedureById(string id);


### PR DESCRIPTION
- Disease Status ADAC UI
  - Added DisplayOnDirectory Column
  - Added DisplayOnDirectory Checkbox on Add/Edit Modal
  - Displays all OntologyTerms rather than those just flagged DisplayOnDirectory
  - Moved from static generated DataTable to dynamic ajax DataTable
    - New PaginatedDiseaseStatus endpoint
    - Action links are generated on the frontend instead
    - Removal of legacy data bindings where applicable
  - Removal of model on DiseaseStatus View  