### PR TITLE
AB#36805: BUG-FIX - The selected biobank could not be deleted

### DIFF
--- a/src/Data/Migrations/20210629174100_SampleSetCascadeDelete.Designer.cs
+++ b/src/Data/Migrations/20210629174100_SampleSetCascadeDelete.Designer.cs
@@ -4,14 +4,16 @@ using Biobanks.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Biobanks.Data.Migrations
 {
     [DbContext(typeof(BiobanksDbContext))]
-    partial class BiobanksDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210629174100_SampleSetCascadeDelete")]
+    partial class SampleSetCascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Data/Migrations/20210629174100_SampleSetCascadeDelete.cs
+++ b/src/Data/Migrations/20210629174100_SampleSetCascadeDelete.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Biobanks.Data.Migrations
+{
+    public partial class SampleSetCascadeDelete : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MaterialDetails_SampleSets_SampleSetId",
+                table: "MaterialDetails");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MaterialDetails_SampleSets_SampleSetId",
+                table: "MaterialDetails",
+                column: "SampleSetId",
+                principalTable: "SampleSets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MaterialDetails_SampleSets_SampleSetId",
+                table: "MaterialDetails");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MaterialDetails_SampleSets_SampleSetId",
+                table: "MaterialDetails",
+                column: "SampleSetId",
+                principalTable: "SampleSets",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/Entities/Data/MaterialDetail.cs
+++ b/src/Entities/Data/MaterialDetail.cs
@@ -11,6 +11,7 @@ namespace Biobanks.Entities.Data
         public int Id { get; set; }
 
         public int SampleSetId { get; set; } //"Sample Code" in the model
+        public virtual SampleSet SampleSet { get; set; }
 
         public int MaterialTypeId { get; set; }
         public virtual MaterialType MaterialType { get; set; }


### PR DESCRIPTION
## Repro

ADAC > Biobanks > "Admin" For A Given Biobank > Delete

The Biobank is actually deleted, but the page responds with "The selected biobank could not be deleted"

## Investigation

Deleting biobank fails when biobank has collections with sample sets and material details. 

## Fix

Deleting biobank should delete related collections and sample sets 

