### PR TITLE
AB#37084: BUG-FIX: Publications doesn't populate a number of fields in the DB 

### DIFF
--- a/src/Core/Publications/Dto/PublicationDto.cs
+++ b/src/Core/Publications/Dto/PublicationDto.cs
@@ -22,8 +22,10 @@ namespace Biobanks.Publications.Dto
 
     public class PublicationDto
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
+        [JsonPropertyName("title")]
         public string Title { get; set; }
 
         [JsonPropertyName("authorString")]
@@ -35,8 +37,10 @@ namespace Biobanks.Publications.Dto
         [JsonPropertyName("pubYear")]
         public string Year { get; set; }
 
+        [JsonPropertyName("doi")]
         public string Doi { get; set; }
-        
+
+        [JsonPropertyName("source")]
         public string Source { get; set; }
 
     }


### PR DESCRIPTION
## Repro
Look at publications table in DB on Test.
Title fields and some other columns are missing info.

Is this a bug in the publication service/hangfire that downloads the publications?

## Fix

Specify JSON mappings
Reset publications table on Test