### PR TITLE
AB#37838: Analytics null check

### DIFF
--- a/src/Core/Analytics/Services/GoogleAnalyticsReportingService.cs
+++ b/src/Core/Analytics/Services/GoogleAnalyticsReportingService.cs
@@ -119,22 +119,25 @@ namespace Biobanks.Analytics.Services
             var eventData = reportResponse.Reports[0].Data.Rows;
             var metricData = reportResponse.Reports[1].Data.Rows;
 
-            foreach (ReportRow events in eventData)
+            if (eventData != null)
             {
-                _db.DirectoryAnalyticEvents.Add(new DirectoryAnalyticEvent
+                foreach (ReportRow events in eventData)
                 {
-                    Date = ConvertToDateTime(events.Dimensions[0], "yyyyMMdd"),
-                    EventCategory = events.Dimensions[1],
-                    EventAction = events.Dimensions[2],
-                    Biobank = events.Dimensions[3],
-                    Segment = events.Dimensions[4],
-                    Source = events.Dimensions[5],
-                    Hostname = events.Dimensions[6],
-                    City = events.Dimensions[7],
-                    Counts = int.Parse(events.Metrics[0].Values[0]),
-                });
+                    _db.DirectoryAnalyticEvents.Add(new DirectoryAnalyticEvent
+                    {
+                        Date = ConvertToDateTime(events.Dimensions[0], "yyyyMMdd"),
+                        EventCategory = events.Dimensions[1],
+                        EventAction = events.Dimensions[2],
+                        Biobank = events.Dimensions[3],
+                        Segment = events.Dimensions[4],
+                        Source = events.Dimensions[5],
+                        Hostname = events.Dimensions[6],
+                        City = events.Dimensions[7],
+                        Counts = int.Parse(events.Metrics[0].Values[0]),
+                    });
+                }
+                await _db.SaveChangesAsync();
             }
-            await _db.SaveChangesAsync();
 
             foreach (ReportRow metric in metricData)
             {


### PR DESCRIPTION
Fix for analytics - falling over on another null value intermittently pulled from the google API.