### PR TITLE
AB#36916: Config Service

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/DonorCountController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DonorCountController.cs
@@ -17,12 +17,14 @@ namespace Biobanks.Web.ApiControllers
     {
         private readonly IBiobankReadService _biobankReadService;
         private readonly IBiobankWriteService _biobankWriteService;
+        private readonly IConfigService _configService;
 
         public DonorCountController(IBiobankReadService biobankReadService,
-                                          IBiobankWriteService biobankWriteService)
+                                          IBiobankWriteService biobankWriteService, IConfigService configService)
         {
             _biobankReadService = biobankReadService;
             _biobankWriteService = biobankWriteService;
+            _configService = configService;
         }
 
         [HttpGet]
@@ -53,7 +55,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Post(DonorCountModel model)
         {
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.DonorCountName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.DonorCountName);
 
             // Validate model
             if (await _biobankReadService.ValidDonorCountAsync(model.Description))
@@ -92,7 +94,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Put(int id, DonorCountModel model)
         {
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.DonorCountName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.DonorCountName);
 
             // Validate model
             if (await _biobankReadService.ValidDonorCountAsync(model.Description))
@@ -135,7 +137,7 @@ namespace Biobanks.Web.ApiControllers
             var model = (await _biobankReadService.ListDonorCountsAsync(true)).Where(x => x.Id == id).First();
 
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.DonorCountName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.DonorCountName);
 
             // If in use, prevent update
             if (await _biobankReadService.IsDonorCountInUse(id))

--- a/src/Directory/Biobanks.Web/ApiControllers/MacroscopicAssessmentController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/MacroscopicAssessmentController.cs
@@ -17,12 +17,14 @@ namespace Biobanks.Web.ApiControllers
     {
         private readonly IBiobankReadService _biobankReadService;
         private readonly IBiobankWriteService _biobankWriteService;
+        private readonly IConfigService _configService;
 
         public MacroscopicAssessmentController(IBiobankReadService biobankReadService,
-                                          IBiobankWriteService biobankWriteService)
+                                          IBiobankWriteService biobankWriteService, IConfigService configService)
         {
             _biobankReadService = biobankReadService;
             _biobankWriteService = biobankWriteService;
+            _configService = configService;
         }
 
         [HttpGet]
@@ -51,7 +53,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Post(MacroscopicAssessmentModel model)
         {
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.MacroscopicAssessmentName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.MacroscopicAssessmentName);
 
             // Validate model
             if (await _biobankReadService.ValidMacroscopicAssessmentAsync(model.Description))
@@ -88,7 +90,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Put(int id, MacroscopicAssessmentModel model)
         {
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.MacroscopicAssessmentName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.MacroscopicAssessmentName);
 
             // Validate model
             if (await _biobankReadService.ValidMacroscopicAssessmentAsync(model.Description))
@@ -129,7 +131,7 @@ namespace Biobanks.Web.ApiControllers
             var model = (await _biobankReadService.ListMacroscopicAssessmentsAsync()).Where(x => x.Id == id).First();
             
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.MacroscopicAssessmentName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.MacroscopicAssessmentName);
 
             if (await _biobankReadService.IsMacroscopicAssessmentInUse(id))
             {

--- a/src/Directory/Biobanks.Web/ApiControllers/StorageTemperatureController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/StorageTemperatureController.cs
@@ -18,12 +18,14 @@ namespace Biobanks.Web.ApiControllers
     {
         private readonly IBiobankReadService _biobankReadService;
         private readonly IBiobankWriteService _biobankWriteService;
+        private readonly IConfigService _configService;
 
         public StorageTemperatureController(IBiobankReadService biobankReadService,
-                                          IBiobankWriteService biobankWriteService)
+                                          IBiobankWriteService biobankWriteService, IConfigService configService)
         {
             _biobankReadService = biobankReadService;
             _biobankWriteService = biobankWriteService;
+            _configService = configService;
         }
 
         [HttpGet]
@@ -57,7 +59,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Post(StorageTemperatureModel model)
         {
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.StorageTemperatureName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.StorageTemperatureName);
 
             // Validate model
             if (await _biobankReadService.ValidStorageTemperatureAsync(model.Value))
@@ -93,7 +95,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Put(int id, StorageTemperatureModel model)
         {
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.StorageTemperatureName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.StorageTemperatureName);
 
             // Validate model
             if (await _biobankReadService.ValidStorageTemperatureAsync(model.Value))
@@ -134,7 +136,7 @@ namespace Biobanks.Web.ApiControllers
             var model = (await _biobankReadService.ListStorageTemperaturesAsync()).Where(x => x.Id == id).First();
 
             //Getting the name of the reference type as stored in the config
-            Config currentReferenceName = await _biobankReadService.GetSiteConfig(ConfigKey.StorageTemperatureName);
+            Config currentReferenceName = await _configService.GetSiteConfig(ConfigKey.StorageTemperatureName);
 
             // If in use, prevent update
             if (await _biobankReadService.IsStorageTemperatureInUse(id) || await _biobankReadService.IsStorageTemperatureAssigned(id))

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -927,7 +927,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Analytics(int year = 0, int endQuarter = 0, int reportPeriod = 0)
         {
             //If turned off in site config
-            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayAnalytics)))
+            if (await _configService.GetFlagConfigValue(ConfigKey.DisplayAnalytics) == false)
                 return RedirectToAction("LockedRef");
 
             //set default options
@@ -1210,7 +1210,7 @@ namespace Biobanks.Web.Controllers
                     .Result
                 )
                 .ToList();
-            if (await _configService.GetSiteConfigStatus("site.display.preservation.percent"))
+            if (await _configService.GetFlagConfigValue("site.display.preservation.percent") == true)
             {
                 return View(new CollectionPercentagesModel()
                 {
@@ -1527,7 +1527,7 @@ namespace Biobanks.Web.Controllers
         #region RefData: County
         public async Task<ActionResult> County()
         {
-            if (await _configService.GetSiteConfigStatus("site.display.counties"))
+            if (await _configService.GetFlagConfigValue("site.display.counties") == true)
             {
                 var countries = await _biobankReadService.ListCountriesAsync();
 

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -25,6 +25,7 @@ using System.Data.Entity;
 using Newtonsoft.Json;
 using System.Net.Http;
 using Microsoft.ApplicationInsights;
+using static Biobanks.Services.ConfigService;
 
 namespace Biobanks.Web.Controllers
 {

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -37,6 +37,7 @@ namespace Biobanks.Web.Controllers
         private readonly IApplicationUserManager<ApplicationUser, string, IdentityResult> _userManager;
         private readonly IEmailService _emailService;
         private readonly IRegistrationDomainService _registrationDomainService;
+        private readonly IConfigService _configService;
 
         private readonly IBiobankIndexService _indexService;
 
@@ -52,6 +53,7 @@ namespace Biobanks.Web.Controllers
             IApplicationUserManager<ApplicationUser, string, IdentityResult> userManager,
             IEmailService emailService,
             IRegistrationDomainService registrationDomainService,
+            IConfigService configService,
             IBiobankIndexService indexService,
             ISearchProvider searchProvider,
             IMapper mapper,
@@ -63,6 +65,7 @@ namespace Biobanks.Web.Controllers
             _userManager = userManager;
             _emailService = emailService;
             _registrationDomainService = registrationDomainService;
+            _configService = configService;
             _indexService = indexService;
             _searchProvider = searchProvider;
             _mapper = mapper;
@@ -924,7 +927,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Analytics(int year = 0, int endQuarter = 0, int reportPeriod = 0)
         {
             //If turned off in site config
-            if (!(await _biobankReadService.GetSiteConfigStatus(ConfigKey.DisplayAnalytics)))
+            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayAnalytics)))
                 return RedirectToAction("LockedRef");
 
             //set default options
@@ -1175,7 +1178,7 @@ namespace Biobanks.Web.Controllers
                     .Result
                 )
                 .ToList();
-            if (await _biobankReadService.GetSiteConfigStatus("site.display.preservation.percent"))
+            if (await _configService.GetSiteConfigStatus("site.display.preservation.percent"))
             {
                 return View(new CollectionPercentagesModel()
                 {
@@ -1492,7 +1495,7 @@ namespace Biobanks.Web.Controllers
         #region RefData: County
         public async Task<ActionResult> County()
         {
-            if (await _biobankReadService.GetSiteConfigStatus("site.display.counties"))
+            if (await _configService.GetSiteConfigStatus("site.display.counties"))
             {
                 var countries = await _biobankReadService.ListCountriesAsync();
 
@@ -1823,7 +1826,7 @@ namespace Biobanks.Web.Controllers
         #region Site Config
         public async Task<ActionResult> SiteConfig()
         {
-            return View((await _biobankReadService.ListSiteConfigsAsync("site.display"))
+            return View((await _configService.ListSiteConfigsAsync("site.display"))
                 .Select(x => new SiteConfigModel
                 {
                     Key = x.Key,
@@ -1868,7 +1871,7 @@ namespace Biobanks.Web.Controllers
         #region Sample Resource Config
         public async Task<ActionResult> SampleResourceConfig()
         {
-            return View((await _biobankReadService.ListSiteConfigsAsync("site.sampleresource"))
+            return View((await _configService.ListSiteConfigsAsync("site.sampleresource"))
                 .Select(x => new SiteConfigModel
                 {
                     Key = x.Key,

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1662,7 +1662,7 @@ namespace Biobanks.Web.Controllers
         [HttpPost]
         public async Task<ActionResult> SaveHomepageConfig(HomepageContentModel homepage)
         {
-            await _biobankWriteService.UpdateSiteConfigsAsync(
+            await _configService.UpdateSiteConfigsAsync(
                 new List<Config>
                 {
                     new Config { Key = ConfigKey.HomepageTitle, Value = homepage.Title ?? "" },
@@ -1733,7 +1733,7 @@ namespace Biobanks.Web.Controllers
         [HttpPost]
         public async Task<ActionResult> SaveTermpageConfig(TermpageContentModel termpage)
         {
-            await _biobankWriteService.UpdateSiteConfigsAsync(
+            await _configService.UpdateSiteConfigsAsync(
                 new List<Config>
                 {
                     new Config { Key = ConfigKey.TermpageInfo, Value = termpage.PageInfo ?? "" }
@@ -1802,7 +1802,7 @@ namespace Biobanks.Web.Controllers
         [HttpPost]
         public async Task<ActionResult> SaveRegisterPagesConfig(RegisterConfigModel registerConfigModel)
         {
-            await _biobankWriteService.UpdateSiteConfigsAsync(
+            await _configService.UpdateSiteConfigsAsync(
                 new List<Config>
                 {
                     new Config { Key = ConfigKey.RegisterBiobankTitle, Value = registerConfigModel.BiobankTitle ?? ""},
@@ -1841,7 +1841,7 @@ namespace Biobanks.Web.Controllers
         public async Task<JsonResult> UpdateSiteConfig(IEnumerable<SiteConfigModel> values)
         {
             // Update Database Config
-            await _biobankWriteService.UpdateSiteConfigsAsync(
+            await _configService.UpdateSiteConfigsAsync(
                 values
                     .OrderBy(x => x.Key)
                     .Select(x => new Config
@@ -1904,7 +1904,7 @@ namespace Biobanks.Web.Controllers
 
 
             // Update Database Config
-            await _biobankWriteService.UpdateSiteConfigsAsync(values);
+            await _configService.UpdateSiteConfigsAsync(values);
 
             // Invalidate current config (Refreshed in SiteConfigAttribute filter)
             HttpContext.Application["Config"] = null;

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1753,7 +1753,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Publications()
         {
             //If turned off in site config
-            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
+            if (await _configService.GetFlagConfigValue(ConfigKey.DisplayPublications) == false)
                 return HttpNotFound();
 
             return View(SessionHelper.GetBiobankId(Session));
@@ -1765,7 +1765,7 @@ namespace Biobanks.Web.Controllers
         public async Task<JsonResult> GetPublicationsAjax()
         {
             //If turned off in site config
-            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
+            if (await _configService.GetFlagConfigValue(ConfigKey.DisplayPublications) == false)
                 return Json(new EmptyResult(), JsonRequestBehavior.AllowGet);
 
             var biobankId = SessionHelper.GetBiobankId(Session);
@@ -1995,7 +1995,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Analytics(int year = 0, int endQuarter = 0, int reportPeriod = 0)
         {
             //If turned off in site config
-            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayAnalytics)))
+            if (await _configService.GetFlagConfigValue(ConfigKey.DisplayAnalytics) == false)
                 return HttpNotFound();
 
             var biobankId = SessionHelper.GetBiobankId(Session);

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -43,6 +43,7 @@ namespace Biobanks.Web.Controllers
     {
         private readonly IBiobankReadService _biobankReadService;
         private readonly IBiobankWriteService _biobankWriteService;
+        private readonly IConfigService _configService;
         private readonly IAnalyticsReportGenerator _analyticsReportGenerator;
 
         private readonly IApplicationUserManager<ApplicationUser, string, IdentityResult> _userManager;
@@ -57,6 +58,7 @@ namespace Biobanks.Web.Controllers
 
         public BiobankController(IBiobankReadService biobankReadService,
             IBiobankWriteService biobankWriteService,
+            IConfigService configService,
             IAnalyticsReportGenerator analyticsReportGenerator,
             IApplicationUserManager<ApplicationUser, string, IdentityResult> userManager,
             IEmailService emailService,
@@ -66,6 +68,7 @@ namespace Biobanks.Web.Controllers
         {
             _biobankReadService = biobankReadService;
             _biobankWriteService = biobankWriteService;
+            _configService = configService;
             _analyticsReportGenerator = analyticsReportGenerator;
             _userManager = userManager;
             _emailService = emailService;
@@ -190,7 +193,7 @@ namespace Biobanks.Web.Controllers
 
         public async Task<ActionResult> Edit(bool detailsIncomplete = false)
         {
-            var sampleResource = await _biobankReadService.GetSiteConfigValue(ConfigKey.SampleResourceName);
+            var sampleResource = await _configService.GetSiteConfigValue(ConfigKey.SampleResourceName);
 
             if (detailsIncomplete)
                 SetTemporaryFeedbackMessage("Please fill in the details below for your " + sampleResource + ". Once you have completed these, you'll be able to perform other administration tasks",
@@ -318,7 +321,7 @@ namespace Biobanks.Web.Controllers
                     _biobankWriteService.DeleteBiobankRegistrationReasonAsync(biobank.OrganisationId,
                         inactiveRegistrationReason.RegistrationReasonId);
             }
-            var sampleResource = await _biobankReadService.GetSiteConfigValue(ConfigKey.SampleResourceName);
+            var sampleResource = await _configService.GetSiteConfigValue(ConfigKey.SampleResourceName);
             SetTemporaryFeedbackMessage(sampleResource + " details updated!", FeedbackMessageType.Success);
 
             //Back to the profile to view your saved changes
@@ -1750,7 +1753,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Publications()
         {
             //If turned off in site config
-            if (!(await _biobankReadService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
+            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
                 return HttpNotFound();
 
             return View(SessionHelper.GetBiobankId(Session));
@@ -1762,7 +1765,7 @@ namespace Biobanks.Web.Controllers
         public async Task<JsonResult> GetPublicationsAjax()
         {
             //If turned off in site config
-            if (!(await _biobankReadService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
+            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
                 return Json(new EmptyResult(), JsonRequestBehavior.AllowGet);
 
             var biobankId = SessionHelper.GetBiobankId(Session);
@@ -1992,7 +1995,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Analytics(int year = 0, int endQuarter = 0, int reportPeriod = 0)
         {
             //If turned off in site config
-            if (!(await _biobankReadService.GetSiteConfigStatus(ConfigKey.DisplayAnalytics)))
+            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayAnalytics)))
                 return HttpNotFound();
 
             var biobankId = SessionHelper.GetBiobankId(Session);

--- a/src/Directory/Biobanks.Web/Controllers/NetworkController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/NetworkController.cs
@@ -32,6 +32,7 @@ namespace Biobanks.Web.Controllers
     {
         private readonly IBiobankReadService _biobankReadService;
         private readonly IBiobankWriteService _biobankWriteService;
+        private readonly IConfigService _configService;
 
         private readonly IApplicationUserManager<ApplicationUser, string, IdentityResult> _userManager;
         private readonly IEmailService _emailService;
@@ -46,6 +47,7 @@ namespace Biobanks.Web.Controllers
         public NetworkController(
             IBiobankReadService biobankReadService,
             IBiobankWriteService biobankWriteService,
+            IConfigService configService,
             IApplicationUserManager<ApplicationUser, string, IdentityResult> userManager,
             IEmailService emailService,
             CustomClaimsManager claimsManager,
@@ -644,7 +646,7 @@ namespace Biobanks.Web.Controllers
             biobankEmails.Add(biobank.ContactEmail);
 
 
-            Config trustedBiobanks = await _biobankReadService.GetSiteConfig(ConfigKey.TrustBiobanks);
+            Config trustedBiobanks = await _configService.GetSiteConfig(ConfigKey.TrustBiobanks);
 
             if (biobank == null)
             {

--- a/src/Directory/Biobanks.Web/Controllers/ProfileController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ProfileController.cs
@@ -150,7 +150,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Publications(string id)
         {
             //If turned off in site config
-            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
+            if (await _configService.GetFlagConfigValue(ConfigKey.DisplayPublications) == false)
                 return HttpNotFound();
 
             // Get the Organisation

--- a/src/Directory/Biobanks.Web/Controllers/ProfileController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ProfileController.cs
@@ -17,11 +17,13 @@ namespace Biobanks.Web.Controllers
     public class ProfileController : ApplicationBaseController
     {
         private readonly IBiobankReadService _biobankReadService;
+        private readonly IConfigService _configService;
 
         public ProfileController(
-            IBiobankReadService biobankReadService)
+            IBiobankReadService biobankReadService, IConfigService configService)
         {
             _biobankReadService = biobankReadService;
+            _configService = configService;
         }
 
         public ActionResult Biobanks()
@@ -148,7 +150,7 @@ namespace Biobanks.Web.Controllers
         public async Task<ActionResult> Publications(string id)
         {
             //If turned off in site config
-            if (!(await _biobankReadService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
+            if (!(await _configService.GetSiteConfigStatus(ConfigKey.DisplayPublications)))
                 return HttpNotFound();
 
             // Get the Organisation

--- a/src/Directory/Biobanks.Web/Controllers/RegisterController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/RegisterController.cs
@@ -173,7 +173,7 @@ namespace Biobanks.Web.Controllers
             }
             else
             {
-                if (await _configService.GetSiteConfigStatus(ConfigKey.RegistrationEmails))
+                if (await _configService.GetFlagConfigValue(ConfigKey.RegistrationEmails) == true)
                 {
                     // Non ADAC Invited requests should notify ADAC users
                     await _emailService.SendDirectoryAdminNewRegisterRequestNotification(
@@ -271,7 +271,7 @@ namespace Biobanks.Web.Controllers
             }
             else
             {
-                if (await _configService.GetSiteConfigStatus(ConfigKey.RegistrationEmails))
+                if (await _configService.GetFlagConfigValue(ConfigKey.RegistrationEmails) == true)
                 {
                     // Non ADAC Invited requests should notify ADAC users
                     await _emailService.SendDirectoryAdminNewRegisterRequestNotification(

--- a/src/Directory/Biobanks.Web/Controllers/RegisterController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/RegisterController.cs
@@ -21,6 +21,7 @@ namespace Biobanks.Web.Controllers
         private readonly IBiobankWriteService _biobankWriteService;
         private readonly IEmailService _emailService;
         private readonly IRegistrationDomainService _registrationDomainService;
+        private readonly IConfigService _configService;
 
         private readonly IApplicationUserManager<ApplicationUser, string, IdentityResult> _userManager;
 
@@ -29,13 +30,15 @@ namespace Biobanks.Web.Controllers
             IBiobankWriteService biobankWriteService,
             IApplicationUserManager<ApplicationUser, string, IdentityResult> userManager,
             IEmailService emailService, 
-            IRegistrationDomainService registrationDomainService)
+            IRegistrationDomainService registrationDomainService,
+            IConfigService configService)
         {
             _biobankReadService = biobankReadService;
             _biobankWriteService = biobankWriteService;
             _userManager = userManager;
             _emailService = emailService;
             _registrationDomainService = registrationDomainService;
+            _configService = configService;
         }
 
         // GET: Register
@@ -170,7 +173,7 @@ namespace Biobanks.Web.Controllers
             }
             else
             {
-                if (await _biobankReadService.GetSiteConfigStatus(ConfigKey.RegistrationEmails))
+                if (await _configService.GetSiteConfigStatus(ConfigKey.RegistrationEmails))
                 {
                     // Non ADAC Invited requests should notify ADAC users
                     await _emailService.SendDirectoryAdminNewRegisterRequestNotification(
@@ -268,7 +271,7 @@ namespace Biobanks.Web.Controllers
             }
             else
             {
-                if (await _biobankReadService.GetSiteConfigStatus(ConfigKey.RegistrationEmails))
+                if (await _configService.GetSiteConfigStatus(ConfigKey.RegistrationEmails))
                 {
                     // Non ADAC Invited requests should notify ADAC users
                     await _emailService.SendDirectoryAdminNewRegisterRequestNotification(

--- a/src/Directory/Biobanks.Web/Filters/SiteConfigAttribute.cs
+++ b/src/Directory/Biobanks.Web/Filters/SiteConfigAttribute.cs
@@ -13,8 +13,7 @@ namespace Biobanks.Web.Filters
 {
     public class SiteConfigAttribute : FilterAttribute, IActionFilter
     {
-
-        public IBiobankReadService BiobankReadService { get; set; }
+        public IConfigService ConfigService { get; set; }
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
@@ -24,7 +23,7 @@ namespace Biobanks.Web.Filters
 
                 if (app["Config"] == null)
                 {
-                    app["Config"] = BiobankReadService.ListSiteConfigs().ToDictionary(x => x.Key, x => x.Value);
+                    app["Config"] = ConfigService.ListSiteConfigs().ToDictionary(x => x.Key, x => x.Value);
                 }
             }
         }

--- a/src/Directory/Biobanks.Web/Windsor/WindsorInstaller.cs
+++ b/src/Directory/Biobanks.Web/Windsor/WindsorInstaller.cs
@@ -112,6 +112,10 @@ namespace Biobanks.Web.Windsor
                     .ImplementedBy(typeof(ContentPageService))
                     .LifeStyle.Transient,
 
+                Component.For(typeof(IConfigService))
+                    .ImplementedBy(typeof(ConfigService))
+                    .LifeStyle.Transient,
+
                 Component.For(typeof(IRegistrationDomainService))
                     .ImplementedBy(typeof(RegistrationDomainService))
                     .LifeStyle.Transient,

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -39,7 +39,6 @@ namespace Biobanks.Services
         private readonly IGenericEFRepository<OntologyTerm> _ontologyTermRepository;
         private readonly IGenericEFRepository<SnomedTag> _snomedTagRepository;
         private readonly IGenericEFRepository<SampleSet> _sampleSetRepository;
-        private readonly IGenericEFRepository<Config> _siteConfigRepository;
         private readonly IGenericEFRepository<AssociatedDataProcurementTimeframe> _associatedDataProcurementTimeFrameModelRepository;
         
         private readonly IGenericEFRepository<Network> _networkRepository;
@@ -107,7 +106,6 @@ namespace Biobanks.Services
             IGenericEFRepository<OntologyTerm> ontologyTermRepository,
             IGenericEFRepository<SnomedTag> snomedTagRepository,
             IGenericEFRepository<SampleSet> sampleSetRepository,
-            IGenericEFRepository<Config> siteConfigRepository,
             IGenericEFRepository<AssociatedDataProcurementTimeframe> associatedDataProcurementTimeFrameModelRepository,
             IGenericEFRepository<AssociatedDataTypeGroup> associatedDataTypeGroupRepository,
 
@@ -171,7 +169,6 @@ namespace Biobanks.Services
             _ontologyTermRepository = ontologyTermRepository;
             _snomedTagRepository = snomedTagRepository;
             _sampleSetRepository = sampleSetRepository;
-            _siteConfigRepository = siteConfigRepository;
             _associatedDataProcurementTimeFrameModelRepository = associatedDataProcurementTimeFrameModelRepository;
             _associatedDataTypeGroupRepository = associatedDataTypeGroupRepository;
 
@@ -1246,26 +1243,6 @@ namespace Biobanks.Services
             => (await _snomedTagRepository.ListAsync(filter: x => x.Value == description)).SingleOrDefault();
 
         #endregion
-
-        #region Site Config
-        public IEnumerable<Config> ListSiteConfigs(string wildcard = "")
-            => _siteConfigRepository.List(false, x => x.Key.Contains(wildcard));
-
-        public async Task<IEnumerable<Config>> ListSiteConfigsAsync(string wildcard = "")
-            => await _siteConfigRepository.ListAsync(false, x => x.Key.Contains(wildcard));
-
-        public async Task<Config> GetSiteConfig(string key)
-            => (await ListSiteConfigsAsync(key)).FirstOrDefault();
-
-        public async Task<string> GetSiteConfigValue(string key, string defaultValue = "")
-            => (await GetSiteConfig(key))?.Value ?? defaultValue;
-
-        public async Task<bool> GetSiteConfigStatus(string siteConfigValue)
-        {
-            return (await _siteConfigRepository.ListAsync(false, x => x.Key == siteConfigValue && x.Value == "true")).Any();
-        }
-        #endregion
-
 
         public async Task<bool> ValidConsentRestrictionDescriptionAsync(string consentDescription)
             => (await _collectionConsentRestrictionRepository.ListAsync(false, x => x.Value == consentDescription)).Any();

--- a/src/Directory/Services/BiobankWriteService.cs
+++ b/src/Directory/Services/BiobankWriteService.cs
@@ -1719,18 +1719,6 @@ namespace Biobanks.Services
         }
         #endregion
 
-        public async Task UpdateSiteConfigsAsync(IEnumerable<Config> configs)
-        {
-            foreach (var config in configs) {
-                var oldConfig = await _configService.GetSiteConfig(config.Key);
-                oldConfig.Value = config.Value;
-
-                _siteConfigRepository.Update(oldConfig);
-            }
-
-            await _siteConfigRepository.SaveChangesAsync();
-        }
-
         //delete adt
         public async Task DeleteAssociatedDataTypeAsync(AssociatedDataType associatedDataType)
         {

--- a/src/Directory/Services/BiobankWriteService.cs
+++ b/src/Directory/Services/BiobankWriteService.cs
@@ -24,6 +24,7 @@ namespace Biobanks.Services
         #region Properties and ctor
 
         private readonly IBiobankReadService _biobankReadService;
+        private readonly IConfigService _configService;
 
         private readonly ILogoStorageProvider _logoStorageProvider;
 
@@ -85,6 +86,7 @@ namespace Biobanks.Services
 
         public BiobankWriteService(
             IBiobankReadService biobankReadService,
+            IConfigService configService,
             ILogoStorageProvider logoStorageProvider,
             IGenericEFRepository<OntologyTerm> ontologyTermRepository,
             IGenericEFRepository<MaterialType> materialTypeRepository,
@@ -139,7 +141,7 @@ namespace Biobanks.Services
             IGenericEFRepository<Funder> funderRepository)
         {
             _biobankReadService = biobankReadService;
-
+            _configService = configService;
             _logoStorageProvider = logoStorageProvider;
 
             _ontologyTermRepository = ontologyTermRepository;
@@ -1720,7 +1722,7 @@ namespace Biobanks.Services
         public async Task UpdateSiteConfigsAsync(IEnumerable<Config> configs)
         {
             foreach (var config in configs) {
-                var oldConfig = await _biobankReadService.GetSiteConfig(config.Key);
+                var oldConfig = await _configService.GetSiteConfig(config.Key);
                 oldConfig.Value = config.Value;
 
                 _siteConfigRepository.Update(oldConfig);

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -53,6 +53,23 @@ namespace Biobanks.Services
             await _db.SaveChangesAsync();
         }
 
+        //Boolean Read Method
+
+
+        //Boolean Write Method
+
+        private bool? ConvertStringToBool(string boolStr)
+        {
+            bool convertedBool;
+            if (Boolean.TryParse(boolStr, out var converted))
+            {
+                convertedBool = converted;
+                return convertedBool;
+            }
+
+            return null;
+        }
+
 
     }
 }

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -4,6 +4,7 @@ using Biobanks.Services.Contracts;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Migrations;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -20,8 +21,7 @@ namespace Biobanks.Services
             _db = db;
         }
 
-        // ReadService methods
-        #region ReadService Methods
+        // ReadService Methods
         public IEnumerable<Config> ListSiteConfigs(string wildcard = "")
             => _db.Configs.Where(x => x.Key.Contains(wildcard)).ToList();
 
@@ -38,7 +38,20 @@ namespace Biobanks.Services
         {
             return await _db.Configs.Where(x => x.Key == siteConfigValue && x.Value == "true").AnyAsync();
         }
-        #endregion
+
+        //WriteService Methods
+        public async Task UpdateSiteConfigsAsync(IEnumerable<Config> configs)
+        {
+            foreach (var config in configs)
+            {
+                var oldConfig = await GetSiteConfig(config.Key);
+                oldConfig.Value = config.Value;
+
+                _db.Configs.AddOrUpdate(oldConfig);
+
+            }
+            await _db.SaveChangesAsync();
+        }
 
 
     }

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -31,11 +31,6 @@ namespace Biobanks.Services
         public async Task<string> GetSiteConfigValue(string key, string defaultValue = "")
             => (await GetSiteConfig(key))?.Value ?? defaultValue;
 
-        public async Task<bool> GetSiteConfigStatus(string siteConfigValue)
-        {
-            return await _db.Configs.Where(x => x.Key == siteConfigValue && x.Value == "true").AnyAsync();
-        }
-
         //WriteService Methods
         public async Task UpdateSiteConfigsAsync(IEnumerable<Config> configs)
         {

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -57,6 +57,9 @@ namespace Biobanks.Services
         public async Task<bool?> GetFlagConfigValue(string key)
             => (ConvertStringToBool((await GetSiteConfig(key)).Value));
 
+        public async Task<IEnumerable<Config>> ListFeatureFlags(string wildcard = "")
+            => await _db.Configs.Where(x => x.Key.Contains(wildcard)).Where(x => x.IsFeatureFlag == true).ToListAsync();
+
 
         // Setter - Updates given flag with passed boolean value
         public async Task UpdateFlag(string key, bool value)

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -21,6 +21,7 @@ namespace Biobanks.Services
         }
 
         // ReadService methods
+        #region ReadService Methods
         public IEnumerable<Config> ListSiteConfigs(string wildcard = "")
             => _db.Configs.Where(x => x.Key.Contains(wildcard)).ToList();
 
@@ -37,5 +38,8 @@ namespace Biobanks.Services
         {
             return await _db.Configs.Where(x => x.Key == siteConfigValue && x.Value == "true").AnyAsync();
         }
+        #endregion
+
+
     }
 }

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -1,0 +1,14 @@
+﻿using Biobanks.Services.Contracts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Biobanks.Services
+{
+    public class ConfigService : IConfigService
+    {
+
+    }
+}

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -1,7 +1,11 @@
-﻿using Biobanks.Services.Contracts;
+﻿using Biobanks.Directory.Data;
+using Biobanks.Entities.Data;
+using Biobanks.Services.Contracts;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,6 +13,29 @@ namespace Biobanks.Services
 {
     public class ConfigService : IConfigService
     {
+        private readonly BiobanksDbContext _db;
 
+        public ConfigService(BiobanksDbContext db)
+        {
+            _db = db;
+        }
+
+        // ReadService methods
+        public IEnumerable<Config> ListSiteConfigs(string wildcard = "")
+            => _db.Configs.Where(x => x.Key.Contains(wildcard)).ToList();
+
+        public async Task<IEnumerable<Config>> ListSiteConfigsAsync(string wildcard = "")
+            => await _db.Configs.Where(x => x.Key.Contains(wildcard)).ToListAsync();
+
+        public async Task<Config> GetSiteConfig(string key)
+             => (await ListSiteConfigsAsync(key)).FirstOrDefault();
+
+        public async Task<string> GetSiteConfigValue(string key, string defaultValue = "")
+            => (await GetSiteConfig(key))?.Value ?? defaultValue;
+
+        public async Task<bool> GetSiteConfigStatus(string siteConfigValue)
+        {
+            return await _db.Configs.Where(x => x.Key == siteConfigValue && x.Value == "true").AnyAsync();
+        }
     }
 }

--- a/src/Directory/Services/ConfigService.cs
+++ b/src/Directory/Services/ConfigService.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Migrations;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Biobanks.Services
@@ -53,20 +51,37 @@ namespace Biobanks.Services
             await _db.SaveChangesAsync();
         }
 
-        //Boolean Read Method
+        // Boolean typesafe methods
+
+        // Getter - Returns boolean value of flag, null if not flag
+        public async Task<bool?> GetFlagConfigValue(string key)
+            => (ConvertStringToBool((await GetSiteConfig(key)).Value));
 
 
-        //Boolean Write Method
+        // Setter - Updates given flag with passed boolean value
+        public async Task UpdateFlag(string key, bool value)
+        {
+            var oldConfig = await GetSiteConfig(key);
+            oldConfig.Value = value.ToString();
+            _db.Configs.AddOrUpdate(oldConfig);
 
+            await _db.SaveChangesAsync();
+
+        }
+
+        /// <summary>
+        /// Returns value of boolean flag
+        /// If not a bool will return null
+        /// </summary>
+        /// <param name="boolStr"></param>
+        /// <returns></returns>
         private bool? ConvertStringToBool(string boolStr)
         {
-            bool convertedBool;
             if (Boolean.TryParse(boolStr, out var converted))
             {
-                convertedBool = converted;
-                return convertedBool;
+                return converted;
             }
-
+            // Return null if not a flag/bool
             return null;
         }
 

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -177,14 +177,6 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidSexDescriptionAsync(string sexDescription);
         Task<bool> ValidSexDescriptionAsync(int sexId, string sexDescription);
 
-        IEnumerable<Config> ListSiteConfigs(string wildcard = "");
-        Task<IEnumerable<Config>> ListSiteConfigsAsync(string wildcard = "");
-        Task<Config> GetSiteConfig(string key);
-        Task<string> GetSiteConfigValue(string key, string defaultValue = "");
-        Task<bool> GetSiteConfigStatus(string siteConfigValue);
-        
-        
-
         Task<IEnumerable<OrganisationServiceOffering>> ListBiobankServiceOfferingsAsync(int biobankId);
         Task<IEnumerable<ServiceOffering>> ListServiceOfferingsAsync();
 

--- a/src/Directory/Services/Contracts/IBiobankWriteService.cs
+++ b/src/Directory/Services/Contracts/IBiobankWriteService.cs
@@ -22,7 +22,6 @@ namespace Biobanks.Services.Contracts
 
         Task AddCapabilityAsync(CapabilityDTO capability, IEnumerable<CapabilityAssociatedData> associatedData);
         Task UpdateCapabilityAsync(CapabilityDTO capability, IEnumerable<CapabilityAssociatedData> associatedData);
-        Task UpdateSiteConfigsAsync(IEnumerable<Config> configs);
         Task DeleteCapabilityAsync(int id);
 
         Task<string> StoreLogoAsync(Stream logoFileStream, string logoFileName, string logoContentType, string reference);

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -21,5 +21,9 @@ namespace Biobanks.Services.Contracts
 
         Task UpdateSiteConfigsAsync(IEnumerable<Config> configs);
 
+        Task<bool?> GetFlagConfigValue(string key);
+
+        Task UpdateFlag(string key, bool value);
+
     }
 }

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Biobanks.Services.Contracts
+{
+    public interface IConfigService
+    {
+    }
+}

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -23,7 +23,7 @@ namespace Biobanks.Services.Contracts
 
         Task<bool?> GetFlagConfigValue(string key);
 
-        Task<IEnumerable<Config>> ListFeatureFlags(string wildcard = "");
+        Task<List<Config>> ListBooleanFlags(bool includeFeatures, string wildcard = "");
 
         Task UpdateFlag(string key, bool value);
 

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -17,8 +17,6 @@ namespace Biobanks.Services.Contracts
 
         Task<string> GetSiteConfigValue(string key, string defaultValue = "");
 
-        Task<bool> GetSiteConfigStatus(string siteConfigValue);
-
         Task UpdateSiteConfigsAsync(IEnumerable<Config> configs);
 
         Task<bool?> GetFlagConfigValue(string key);

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -19,5 +19,7 @@ namespace Biobanks.Services.Contracts
 
         Task<bool> GetSiteConfigStatus(string siteConfigValue);
 
+        Task UpdateSiteConfigsAsync(IEnumerable<Config> configs);
+
     }
 }

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -23,7 +23,10 @@ namespace Biobanks.Services.Contracts
 
         Task<bool?> GetFlagConfigValue(string key);
 
+        Task<IEnumerable<Config>> ListFeatureFlags(string wildcard = "");
+
         Task UpdateFlag(string key, bool value);
+
 
     }
 }

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -4,25 +4,79 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Biobanks.Services.ConfigService;
 
 namespace Biobanks.Services.Contracts
 {
+    /// <summary>
+    /// Domain specific service
+    /// Config Services moved from read/write services
+    /// Specific methods dealing with boolean flags only
+    /// </summary>
     public interface IConfigService
     {
+        /// <summary>
+        /// Lists all site config options
+        /// </summary>
+        /// <param name="wildcard"> Optional, specifies area/type of config </param>
+        /// <returns>List of Site Configs</returns>
         IEnumerable<Config> ListSiteConfigs(string wildcard = "");
 
+        /// <summary>
+        /// Async version of ListSiteConfigs()
+        /// </summary>
+        /// <param name="wildcard"> Optional, specifies area/type of config </param>
+        /// <returns>List of Site Configs</returns>
         Task<IEnumerable<Config>> ListSiteConfigsAsync(string wildcard = "");
 
+        /// <summary>
+        /// Get Site Config given its key
+        /// </summary>
+        /// <param name="key">Config key</param>
+        /// <returns>Config obj</returns>
         Task<Config> GetSiteConfig(string key);
 
+        /// <summary>
+        /// Gets site Config value given its key
+        /// </summary>
+        /// <param name="key">Config key</param>
+        /// <param name="defaultValue">Default value string</param>
+        /// <returns>Config value string</returns>
         Task<string> GetSiteConfigValue(string key, string defaultValue = "");
 
+        /// <summary>
+        /// Updates specified Configs
+        /// </summary>
+        /// <param name="configs">List of Config objs to be updatd</param>
+        /// <returns></returns>
         Task UpdateSiteConfigsAsync(IEnumerable<Config> configs);
 
+        /// <summary>
+        /// Gets Flag Config Value
+        /// </summary>
+        /// <param name="key">Config key</param>
+        /// <returns>Bool? - null if given key does not correspond to a boolean flag</returns>
         Task<bool?> GetFlagConfigValue(string key);
 
-        Task<List<Config>> ListBooleanFlags(bool includeFeatures, string wildcard = "");
+        /// <summary>
+        /// Lists Boolean configs with option to include/exclude feature flags
+        /// </summary>
+        /// <param name="selection">
+        /// Three different options:
+        /// Feature Flags Only - Boolean flags with IsFeatureFlag == true
+        /// ExcludeFeatureFlags - 
+        /// AllBooleanConfigs - 
+        /// </param>
+        /// <param name="wildcard">Optional, specifies area/type of config</param>
+        /// <returns>List of Config objs</returns>
+        Task<List<Config>> ListBooleanFlags(BooleanConfigSelection selection, string wildcard = "");
 
+        /// <summary>
+        /// Updates boolean flag value
+        /// </summary>
+        /// <param name="key">Config key</param>
+        /// <param name="value">Config bool value</param>
+        /// <returns></returns>
         Task UpdateFlag(string key, bool value);
 
 

--- a/src/Directory/Services/Contracts/IConfigService.cs
+++ b/src/Directory/Services/Contracts/IConfigService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Biobanks.Entities.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,5 +9,15 @@ namespace Biobanks.Services.Contracts
 {
     public interface IConfigService
     {
+        IEnumerable<Config> ListSiteConfigs(string wildcard = "");
+
+        Task<IEnumerable<Config>> ListSiteConfigsAsync(string wildcard = "");
+
+        Task<Config> GetSiteConfig(string key);
+
+        Task<string> GetSiteConfigValue(string key, string defaultValue = "");
+
+        Task<bool> GetSiteConfigStatus(string siteConfigValue);
+
     }
 }


### PR DESCRIPTION
- Take existing config services from the read/write services
- Specific methods dealing with boolean flags only. Handles the conversion from strings to bools within the method to avoid any type issues doing it manually. Instances where a boolean value is being used should make use of this method.

- Will be creating FlagController with SuperUser flag view in PBI #36740 which will make use of the ConfigService and methods created for this PR.