### PR TITLE
AB#37404: Amend "Publication not found" messaging to clarify use of the EPMC source

### DIFF
--- a/src/Directory/Biobanks.Web/Scripts/Biobank/publications.js
+++ b/src/Directory/Biobanks.Web/Scripts/Biobank/publications.js
@@ -280,7 +280,7 @@ function PublicationsViewModel() {
                 }
                 else {
                     // no results
-                    _this.searchResult("No publication found for the given PubMed Id.");
+                    _this.searchResult("<b>No publication found for the given PubMed Id.</b><br/>Please supply a PubMed ID for the publication you want to add. We use the EuroPMC database to extract the details, therefore if your publication is not found, please check it is available on EuroPMC.");
                 }
             });
         } else if (action == _this.modal.modalModeApprove) {


### PR DESCRIPTION
## Overview

The message when a publication cannot be found with the searched for PubMed ID isn't clear enough for users.

It needs to be clear that we are searching EPMC and that's where it cannot be found. Otherwise Biobanks will complain that they know it exists.
