### PR TITLE
AB#38414: Include Findings in Search Typeahead

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
@@ -79,7 +79,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Put(string id, ReadExtractionProcedureModel model)
         {
             //If this description is valid, it already exists
-            if (await _biobankReadService.ValidOntologyTermDescriptionAsync(id, model.Description))
+            if (await _biobankReadService.ValidOntologyTerm(id, description: model.Description))
             {
                 ModelState.AddModelError("Description", "That description is already in use. Descriptions must be unique across all ontology terms.");
             }
@@ -123,7 +123,7 @@ namespace Biobanks.Web.ApiControllers
         public async Task<IHttpActionResult> Post(ReadExtractionProcedureModel model)
         {
             //If this description is valid, it already exists
-            if (await _biobankReadService.ValidOntologyTermDescriptionAsync(model.Description))
+            if (await _biobankReadService.ValidOntologyTerm(description: model.Description))
             {
                 ModelState.AddModelError("Description", "That description is already in use. Descriptions must be unique across all ontology terms.");
             }

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -25,6 +25,7 @@ using System.Data.Entity;
 using Newtonsoft.Json;
 using System.Net.Http;
 using Microsoft.ApplicationInsights;
+using Biobanks.Directory.Services.Constants;
 
 namespace Biobanks.Web.Controllers
 {
@@ -1148,7 +1149,12 @@ namespace Biobanks.Web.Controllers
         #region RefData: Disease Status
         public async Task<ActionResult> DiseaseStatuses()
         {
-            return View((await _biobankReadService.ListDiseaseOntologyTerms()).Select(x =>
+            var diseaseTerms = await _biobankReadService.ListOntologyTerms(tags: new List<string>
+            {
+                SnomedTags.Disease
+            });
+
+            return View(diseaseTerms.Select(x =>
 
                 Task.Run(async () => new ReadOntologyTermModel
                 {
@@ -1165,13 +1171,14 @@ namespace Biobanks.Web.Controllers
         {
             // Select Search By Value
             var searchValue = search.TryGetValue("value", out var s) ? s : "";
+            var tags = new List<string> { SnomedTags.Disease };
 
             // Get Disease Statuses
-            var ontologyTerms = await _biobankReadService.PaginateDiseaseOntologyTerms(start, length, searchValue);
-            var filteredCount = await _biobankReadService.CountDiseaseOntologyTerms(filter: searchValue);
-            var totalCount = await _biobankReadService.CountDiseaseOntologyTerms();
+            var diseaseTerms = await _biobankReadService.PaginateOntologyTerms(start, length, searchValue, tags);
+            var filteredCount = await _biobankReadService.CountOntologyTerms(description: searchValue, tags: tags);
+            var totalCount = await _biobankReadService.CountOntologyTerms(tags: tags);
 
-            var data = ontologyTerms.Select(x =>
+            var data = diseaseTerms.Select(x =>
                 Task.Run(async () => new ReadOntologyTermModel
                 {
                     OntologyTermId = x.Id,

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -245,10 +245,13 @@ namespace Biobanks.Web.Controllers
         private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type, string wildcard)
         {
             var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
-            var directoryOntologyTerms = await _biobankReadService.ListDiseaseOntologyTermsAsync("", onlyDisplayable: true);
+            var directoryDiseaseTerms = await _biobankReadService.ListDiseaseOntologyTermsAsync(onlyDisplayable: true);
+            var directoryFindingTerms = await _biobankReadService.ListFindings(onlyDisplayable: true);
 
             // Join Ontology Terms In Search and Directory Based On Ontology Term Value
-            var model = directoryOntologyTerms.Join(searchOntologyTerms, 
+            var model = directoryDiseaseTerms
+                .Concat(directoryFindingTerms)
+                .Join(searchOntologyTerms, 
                 outer => outer.Value.ToLower(), 
                 inner => inner.OntologyTerm, 
                 (directoryTerm, searchTerm) =>

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -14,6 +14,8 @@ using Microsoft.Ajax.Utilities;
 using Newtonsoft.Json;
 using Biobanks.Web.Extensions;
 using Biobanks.Web.Results;
+using Biobanks.Entities.Shared.ReferenceData;
+using Biobanks.Directory.Services.Constants;
 
 namespace Biobanks.Web.Controllers
 {
@@ -40,7 +42,7 @@ namespace Biobanks.Web.Controllers
             // Check If Valid and Visible Term
             if (!string.IsNullOrWhiteSpace(ontologyTerm))
             {
-                var term = await _biobankReadService.GetOntologyTermByDescription(ontologyTerm);
+                var term = await _biobankReadService.GetOntologyTerm(description: ontologyTerm);
 
                 if (term is null)
                 {
@@ -147,7 +149,7 @@ namespace Biobanks.Web.Controllers
             // Check If Valid and Visible Term
             if (!string.IsNullOrEmpty(ontologyTerm))
             {
-                var term = await _biobankReadService.GetOntologyTermByDescription(ontologyTerm);
+                var term = await _biobankReadService.GetOntologyTerm(description: ontologyTerm);
 
                 if (term is null)
                 {
@@ -245,13 +247,14 @@ namespace Biobanks.Web.Controllers
         private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type, string wildcard)
         {
             var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
-            var directoryDiseaseTerms = await _biobankReadService.ListDiseaseOntologyTerms(onlyDisplayable: true);
-            var directoryFindingTerms = await _biobankReadService.ListFindingOntologyTerms(onlyDisplayable: true);
+            var directoryOntologyTerms = await _biobankReadService.ListOntologyTerms(wildcard, onlyDisplayable: true, tags: new List<string>
+            {
+                SnomedTags.Disease,
+                SnomedTags.Finding
+            });
 
             // Join Ontology Terms In Search and Directory Based On Ontology Term Value
-            var model = directoryDiseaseTerms
-                .Concat(directoryFindingTerms)
-                .Join(searchOntologyTerms, 
+            var model = directoryOntologyTerms.Join(searchOntologyTerms, 
                 outer => outer.Value.ToLower(), 
                 inner => inner.OntologyTerm, 
                 (directoryTerm, searchTerm) =>
@@ -278,9 +281,11 @@ namespace Biobanks.Web.Controllers
 
         private async Task<List<OntologyTermModel>> GetOntologyTermsAsync(string wildcard)
         {
-            var diseaseOntologyTerms = await _biobankReadService.ListDiseaseOntologyTerms(wildcard, true);
-            var findingOntologyTerms = await _biobankReadService.ListFindingOntologyTerms(wildcard, true);
-            var ontologyTerms = diseaseOntologyTerms.Concat(findingOntologyTerms);
+            var ontologyTerms = await _biobankReadService.ListOntologyTerms(wildcard, onlyDisplayable: true, tags: new List<string>
+            {
+                SnomedTags.Disease,
+                SnomedTags.Finding
+            });
 
             var model = ontologyTerms.Select(x =>
                new OntologyTermModel

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -246,7 +246,7 @@ namespace Biobanks.Web.Controllers
         {
             var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
             var directoryDiseaseTerms = await _biobankReadService.ListDiseaseOntologyTerms(onlyDisplayable: true);
-            var directoryFindingTerms = await _biobankReadService.ListFindings(onlyDisplayable: true);
+            var directoryFindingTerms = await _biobankReadService.ListFindingOntologyTerms(onlyDisplayable: true);
 
             // Join Ontology Terms In Search and Directory Based On Ontology Term Value
             var model = directoryDiseaseTerms

--- a/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCapabilityModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCapabilityModel.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using Biobanks.Directory.Services.Constants;
 using Biobanks.Services.Contracts;
 using DataAnnotationsExtensions;
 
@@ -31,7 +33,7 @@ namespace Biobanks.Web.Models.Biobank
         {
             if (modelState != null && modelState.IsValid)
             {
-                if (!await biobankReadService.ValidDiseaseOntologyTermDescription(Diagnosis))
+                if (!await biobankReadService.ValidOntologyTerm(description: Diagnosis, tags: new List<string> { SnomedTags.Disease }))
                 {
                     modelState.AddModelError("Diagnosis",
                         "Please enter a valid Diagnosis or select one from the type ahead results.");

--- a/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCollectionModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Biobank/AbstractCRUDCollectionModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using Biobanks.Directory.Services.Constants;
 using Biobanks.Services.Contracts;
 
 namespace Biobanks.Web.Models.Biobank
@@ -61,7 +62,12 @@ namespace Biobanks.Web.Models.Biobank
         {
             if (modelState != null && modelState.IsValid)
             {
-                if (!await biobankReadService.ValidDiseaseOntologyTermDescription(Diagnosis) || !await biobankReadService.ValidFindingOntologyTermDescription(Diagnosis))
+                var valid = await biobankReadService.ValidOntologyTerm(description: Diagnosis, tags: new List<string>
+                {
+                    SnomedTags.Disease, SnomedTags.Finding
+                });
+
+                if (!valid)
                 {
                     modelState.AddModelError("Diagnosis",
                         "Please enter a valid Diagnosis or select one from the type ahead results.");

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1206,6 +1206,27 @@ namespace Biobanks.Services
                     .Take(length)
                     .ToListAsync();
 
+        public async Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string wildcard = "", List<string> tags = null, bool onlyDisplayable = false)
+        {
+            var result = _context.OntologyTerms
+                .Include(x => x.SnomedTag)
+                .Where(x => x.DisplayOnDirectory || !onlyDisplayable);
+
+            // Filter By Wildcard
+            if (!string.IsNullOrEmpty(wildcard))
+                result = result.Where(x => x.Value.Contains(wildcard));
+
+            // Filter By SnomedTag
+            if (tags != null)
+                result = result.Where(x =>
+                    tags.Any()
+                        ? x.SnomedTag != null && tags.Contains(x.SnomedTag.Value) // Term With Included Tag
+                        : x.SnomedTag == null); // Terms Without Tags
+
+            return await result.ToListAsync();
+        }
+         
+
         public async Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTerms(string wildcard = "", bool onlyDisplayable = false)
             => await _ontologyTermRepository.ListAsync(
                 filter: x =>

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1192,6 +1192,16 @@ namespace Biobanks.Services
 
         #endregion
 
+        #region RefFata: Findings
+        public async Task<IEnumerable<OntologyTerm>> ListFindings(string wildcard = "", bool onlyDisplayable = false)
+            => await _ontologyTermRepository.ListAsync(
+                filter: x =>
+                    x.Value.Contains("finding") && // TODO: Replace With Filtering By Finding SnomedTag
+                    x.Value.Contains(wildcard) &&
+                    (x.DisplayOnDirectory || !onlyDisplayable)
+                );
+        #endregion
+
         #region RefData: Disease Statuses
 
         public async Task<int> CountDiseaseOntologyTerms(string filter = "")

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1193,16 +1193,6 @@ namespace Biobanks.Services
 
         #endregion
 
-        #region RefFata: Findings
-        public async Task<IEnumerable<OntologyTerm>> ListFindings(string wildcard = "", bool onlyDisplayable = false)
-            => await _ontologyTermRepository.ListAsync(
-                filter: x =>
-                    x.Value.Contains("finding") && // TODO: Replace With Filtering By Finding SnomedTag
-                    x.Value.Contains(wildcard) &&
-                    (x.DisplayOnDirectory || !onlyDisplayable)
-                );
-        #endregion
-
         #region RefData: Disease Statuses
 
         public async Task<int> CountDiseaseOntologyTerms(string filter = "")
@@ -1217,16 +1207,18 @@ namespace Biobanks.Services
                     .ToListAsync();
 
         public async Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTerms(string wildcard = "", bool onlyDisplayable = false)
-            => await _ontologyTermRepository.ListAsync(filter: x =>
-                x.SnomedTag.Value == DiseaseTag &&
-                x.Value.Contains(wildcard) &&
-                (x.DisplayOnDirectory || !onlyDisplayable));
+            => await _ontologyTermRepository.ListAsync(
+                filter: x =>
+                    x.Value.Contains(wildcard) &&
+                    x.SnomedTag.Value == DiseaseTag &&
+                    (x.DisplayOnDirectory || !onlyDisplayable));
 
         public async Task<IEnumerable<OntologyTerm>> ListFindingOntologyTerms(string wildcard = "", bool onlyDisplayable = false)
-            => await _ontologyTermRepository.ListAsync(filter: x =>
-                x.SnomedTag.Value == FindingTag &&
-                x.Value.Contains(wildcard) &&
-                (x.DisplayOnDirectory || !onlyDisplayable));
+            => await _ontologyTermRepository.ListAsync(
+                filter: x =>
+                    x.Value.Contains(wildcard) && 
+                    x.SnomedTag.Value == FindingTag &&
+                    (x.DisplayOnDirectory || !onlyDisplayable));
 
         public async Task<bool> ValidDiseaseOntologyTermDescription(string ontologyTermDescription)
             => (await _ontologyTermRepository.ListAsync(

--- a/src/Directory/Services/BiobankWriteService.cs
+++ b/src/Directory/Services/BiobankWriteService.cs
@@ -207,7 +207,7 @@ namespace Biobanks.Services
             IEnumerable<CollectionAssociatedData> associatedData,
             IEnumerable<int> consentRestrictionIds)
         {
-            var ontologyTerm = await _biobankReadService.GetOntologyTermByDescription(ontologyTermDescription);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: ontologyTermDescription);
             var consentRestrictions = (await _consentRestrictionRepository.ListAsync(true,
                         x => consentRestrictionIds.Contains(x.Id))).ToList();
 
@@ -238,7 +238,7 @@ namespace Biobanks.Services
             existingCollection.AssociatedData.Clear();
             existingCollection.ConsentRestrictions.Clear();
 
-            var ontologyTerm = await _biobankReadService.GetOntologyTermByDescription(ontologyTermDescription);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: ontologyTermDescription);
             var consentRestrictions = (await _consentRestrictionRepository.ListAsync(true,
                         x => consentRestrictionIds.Contains(x.Id))).ToList();
 
@@ -377,7 +377,7 @@ namespace Biobanks.Services
 
         public async Task AddCapabilityAsync(CapabilityDTO capabilityDTO, IEnumerable<CapabilityAssociatedData> associatedData)
         {
-            var ontologyTerm = await _biobankReadService.GetOntologyTermByDescription(capabilityDTO.OntologyTerm);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: capabilityDTO.OntologyTerm);
 
             var capability = new DiagnosisCapability
             {
@@ -406,7 +406,7 @@ namespace Biobanks.Services
 
             existingCapability.AssociatedData.Clear();
 
-            var ontologyTerm = await _biobankReadService.GetOntologyTermByDescription(capabilityDTO.OntologyTerm);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: capabilityDTO.OntologyTerm);
 
             existingCapability.OntologyTermId = ontologyTerm.Id;
             existingCapability.AnnualDonorExpectation = capabilityDTO.AnnualDonorExpectation.Value;

--- a/src/Directory/Services/Constants/SnomedTags.cs
+++ b/src/Directory/Services/Constants/SnomedTags.cs
@@ -1,0 +1,8 @@
+﻿namespace Biobanks.Directory.Services.Constants
+{
+    public static class SnomedTags
+    {
+        public const string Disease = "Disease";
+        public const string Finding = "Finding";
+    }
+}

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -131,18 +131,13 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(int procurementId, string procurementDescription);
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(string procurementDescription);
 
-        Task<bool> ValidOntologyTermDescriptionAsync(string OntologyTermDescription);
-        Task<bool> ValidOntologyTermDescriptionAsync(string ontologyTermId, string ontologyDescription);
-        Task<OntologyTerm> GetOntologyTermByDescription(string description);
-        Task<int> GetOntologyTermCollectionCapabilityCount(string id);
+        Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string description = null, List<string> tags = null, bool onlyDisplayable = false);
+        Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string description = null, List<string> tags = null);
+        Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null);
+        Task<bool> ValidOntologyTerm(string id = null, string description = null, List<string> tags = null);
         Task<bool> IsOntologyTermInUse(string id);
-
-        Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTerms(string wildcard = "", bool onlyDisplayable = false);
-        Task<IEnumerable<OntologyTerm>> ListFindingOntologyTerms(string wildcard = "", bool onlyDisplayable = false);
-        Task<bool> ValidDiseaseOntologyTermDescription(string ontologyTermDescription);
-        Task<bool> ValidFindingOntologyTermDescription(string ontologyTermDescription);
-        Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "");
-        Task<int> CountDiseaseOntologyTerms(string filter = "");
+        Task<int> CountOntologyTerms(string description = null, List<string> tags = null);
+        Task<int> GetOntologyTermCollectionCapabilityCount(string id);
 
         Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "");
         Task<OntologyTerm> GetExtractionProcedureById(string id);

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -137,6 +137,8 @@ namespace Biobanks.Services.Contracts
         Task<int> GetOntologyTermCollectionCapabilityCount(string id);
         Task<bool> IsOntologyTermInUse(string id);
 
+        Task<IEnumerable<OntologyTerm>> ListFindings(string wildcard = "", bool onlyDisplayable = false);
+
         Task<IEnumerable<OntologyTerm>> ListDiseaseOntologyTermsAsync(string wildcard = "", bool onlyDisplayable = false);
         Task<bool> ValidDiseaseOntologyTermDescriptionAsync(string ontologyTermDescription);
         Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "");


### PR DESCRIPTION
Currently the search typeahead will only show results for Ontology Disease Terms that are found in the search index. This means the often used `Fit and well (finding)` term is excluded, as it is a Finding. 

This PR introduces findings to be included in the search typeahead