### PR TITLE
AB#38420: Extraction Procedure config page does not display displayinDirectory=0 entries

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
@@ -54,10 +54,10 @@ namespace Biobanks.Web.ApiControllers
         [Route("{id}")]
         public async Task<IHttpActionResult> Delete(string id)
         {
-            var model = await _biobankReadService.GetOntologyTerm(id, null, new List<string>
+            var model = await _biobankReadService.GetOntologyTerm(id, tags: new List<string>
             {
                 SnomedTags.ExtractionProcedure
-            }, false);
+            });
 
             if (await _biobankReadService.IsExtractionProcedureInUse(id))
             {
@@ -97,10 +97,10 @@ namespace Biobanks.Web.ApiControllers
             if (model.MaterialTypeIds == null || model.MaterialTypeIds.Count == 0)
                 ModelState.AddModelError("MaterialTypeIds", "Add at least one material type to the extraction procedure.");
 
-            var ontologyTerm = await _biobankReadService.GetOntologyTerm(id, null, new List<string>
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(id, tags: new List<string>
             {
                 SnomedTags.ExtractionProcedure
-            },false);
+            });
             if (await _biobankReadService.IsExtractionProcedureInUse(id))
             {
                 //Allow editing of only Other terms field if ontologyterm in use

--- a/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/ExtractionProcedureController.cs
@@ -37,7 +37,8 @@ namespace Biobanks.Web.ApiControllers
                     Description = x.Value,
                     MaterialDetailsCount = await _biobankReadService.GetExtractionProcedureMaterialDetailsCount(x.Id),
                     OtherTerms = x.OtherTerms,
-                    MaterialTypeIds = x.MaterialTypes.Select(x => x.Id).ToList()
+                    MaterialTypeIds = x.MaterialTypes.Select(x => x.Id).ToList(),
+                    DisplayOnDirectory = x.DisplayOnDirectory
                 })
                 .Result
             )
@@ -107,7 +108,7 @@ namespace Biobanks.Web.ApiControllers
                 Value = model.Description,
                 OtherTerms = model.OtherTerms,
                 SnomedTagId = ontologyTerm.SnomedTagId,
-                DisplayOnDirectory = true
+                DisplayOnDirectory = model.DisplayOnDirectory
             },model.MaterialTypeIds);
 
             //Everything went A-OK!
@@ -147,7 +148,7 @@ namespace Biobanks.Web.ApiControllers
                 Value = model.Description,
                 OtherTerms = model.OtherTerms,
                 SnomedTagId = (await _biobankReadService.GetSnomedTagByDescription("Extraction Procedure")).Id,
-                DisplayOnDirectory = true
+                DisplayOnDirectory = model.DisplayOnDirectory
             }, model.MaterialTypeIds);
 
             //Everything went A-OK!

--- a/src/Directory/Biobanks.Web/ApiControllers/MaterialTypeController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/MaterialTypeController.cs
@@ -167,6 +167,6 @@ namespace Biobanks.Web.ApiControllers
         [AllowAnonymous]
         [Route("{materialType}/extractionprocedure")]
         public async Task<IList> GetValidExtractionProcedures(int materialType)
-        => (await _biobankReadService.GetMaterialTypeExtractionProcedures(materialType)).Select(x => new { x.Id, x.Value }).ToList();
+        => (await _biobankReadService.GetMaterialTypeExtractionProcedures(materialType,true)).Select(x => new { x.Id, x.Value }).ToList();
     }
 }

--- a/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
+++ b/src/Directory/Biobanks.Web/App_Start/BundleConfig.cs
@@ -287,6 +287,7 @@ namespace Biobanks.Web
                 "~/Scripts/ADAC/adac-refdata-utility.js"));
             bundles.Add(new ScriptBundle("~/bundles/adac/extraction-procedure").Include(
                 "~/Scripts/bootbox*",
+                "~/Scripts/Shared/serialize-checkbox-as-bool.js",
                 "~/Scripts/ADAC/adac-extraction-procedure.js",
                 "~/Scripts/ADAC/adac-refdata-utility.js"));
 

--- a/src/Directory/Biobanks.Web/Biobanks.Web.csproj
+++ b/src/Directory/Biobanks.Web/Biobanks.Web.csproj
@@ -641,6 +641,7 @@
     <Content Include="Scripts\Home\home-contactlist.js" />
     <Content Include="Scripts\plotly-latest.min.js" />
     <Content Include="Scripts\Profile\publications.js" />
+    <Content Include="Scripts\Shared\serialize-checkbox-as-bool.js" />
     <Content Include="Scripts\Term\diseasetable.js" />
     <Content Include="Views\Shared\Error.cshtml" />
     <Content Include="App_Config\navigation.json" />

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1666,7 +1666,8 @@ namespace Biobanks.Web.Controllers
                     Description = x.Value,
                     MaterialDetailsCount = await _biobankReadService.GetExtractionProcedureMaterialDetailsCount(x.Id),
                     OtherTerms = x.OtherTerms,
-                    MaterialTypeIds = x.MaterialTypes.Select(x=>x.Id).ToList()
+                    MaterialTypeIds = x.MaterialTypes.Select(x=>x.Id).ToList(),
+                    DisplayOnDirectory = x.DisplayOnDirectory
                 })
                 .Result
             ).ToList(),

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1662,9 +1662,16 @@ namespace Biobanks.Web.Controllers
         #region RefData: Extraction Procedure
         public async Task<ActionResult> ExtractionProcedure()
         {
+            var ExtractionProcedures = (await _biobankReadService.ListOntologyTerms(tags: new List<string>
+                {
+                    SnomedTags.ExtractionProcedure
+                }));
             return View(new ExtractionProceduresModel
             {
-                ExtractionProcedures = (await _biobankReadService.ListExtractionProceduresAsync())
+                ExtractionProcedures = (await _biobankReadService.ListOntologyTerms(tags: new List<string>
+                {
+                    SnomedTags.ExtractionProcedure
+                }))
                 .Select(x =>
 
                 Task.Run(async () => new ReadExtractionProcedureModel

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1076,7 +1076,8 @@ namespace Biobanks.Web.Controllers
                     MaterialTypes = Join(" / ", sampleSet.MaterialDetails.Select(x => x.MaterialType.Value).Distinct()),
                     PreservationTypes = Join(" / ", sampleSet.MaterialDetails.Select(x => x.PreservationType?.Value).Distinct()),
                     StorageTemperatures = Join(" / ", sampleSet.MaterialDetails.Select(x => x.StorageTemperature.Value).Distinct()),
-                    ExtractionProcedures = Join(" / ", sampleSet.MaterialDetails.Select(x => x.ExtractionProcedure?.Value).Distinct())
+                    ExtractionProcedures = Join(" / ", sampleSet.MaterialDetails.Where(x=>x.ExtractionProcedure?.DisplayOnDirectory == true)
+                                           .Select(x=>x.ExtractionProcedure?.Value).Distinct())
                 })
             };
 
@@ -1295,7 +1296,7 @@ namespace Biobanks.Web.Controllers
                     MaterialType = x.MaterialType.Value,
                     PreservationType = x.PreservationType?.Value,
                     StorageTemperature = x.StorageTemperature.Value,
-                    ExtractionProcedure = x.ExtractionProcedure?.Value
+                    ExtractionProcedure = x.ExtractionProcedure?.DisplayOnDirectory == true ? x.ExtractionProcedure.Value : null
                     
                 }),
                 ShowMacroscopicAssessment = (assessments.Count() > 1)

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1445,10 +1445,10 @@ namespace Biobanks.Web.Controllers
                         })
                 .OrderBy(x => x.SortOrder);
 
-            model.ExtractionProcedures = (await _biobankReadService.ListOntologyTerms(null, new List<string>
+            model.ExtractionProcedures = (await _biobankReadService.ListOntologyTerms(tags: new List<string>
                 {
                     SnomedTags.ExtractionProcedure
-                },true))
+                }, onlyDisplayable: true))
                 .Select(
                     x =>
                         new OntologyTermModel

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1443,7 +1443,7 @@ namespace Biobanks.Web.Controllers
                         })
                 .OrderBy(x => x.SortOrder);
 
-            model.ExtractionProcedures = (await _biobankReadService.ListExtractionProceduresAsync())
+            model.ExtractionProcedures = (await _biobankReadService.ListExtractionProceduresAsync(onlyDisplayable: true))
                 .Select(
                     x =>
                         new OntologyTermModel

--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 
 using Biobanks.Directory.Data.Constants;
 using Biobanks.Directory.Data.Transforms.Url;
+using Biobanks.Directory.Services.Constants;
 using Biobanks.Entities.Data;
 using Biobanks.Entities.Data.ReferenceData;
 using Biobanks.Identity.Constants;
@@ -1444,7 +1445,10 @@ namespace Biobanks.Web.Controllers
                         })
                 .OrderBy(x => x.SortOrder);
 
-            model.ExtractionProcedures = (await _biobankReadService.ListExtractionProceduresAsync(onlyDisplayable: true))
+            model.ExtractionProcedures = (await _biobankReadService.ListOntologyTerms(null, new List<string>
+                {
+                    SnomedTags.ExtractionProcedure
+                },true))
                 .Select(
                     x =>
                         new OntologyTermModel

--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -42,7 +42,7 @@ namespace Biobanks.Web.Controllers
             // Check If Valid and Visible Term
             if (!string.IsNullOrWhiteSpace(ontologyTerm))
             {
-                var term = await _biobankReadService.GetOntologyTerm(description: ontologyTerm);
+                var term = await _biobankReadService.GetOntologyTerm(description: ontologyTerm, onlyDisplayable: true);
 
                 if (term is null)
                 {
@@ -149,7 +149,7 @@ namespace Biobanks.Web.Controllers
             // Check If Valid and Visible Term
             if (!string.IsNullOrEmpty(ontologyTerm))
             {
-                var term = await _biobankReadService.GetOntologyTerm(description: ontologyTerm);
+                var term = await _biobankReadService.GetOntologyTerm(description: ontologyTerm, onlyDisplayable: true);
 
                 if (term is null)
                 {

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
@@ -25,7 +25,7 @@ function AdacExtractionProcedureViewModel() {
     this.modalId = "#extraction-procedure-modal";
     this.materialTypes = $(this.modalId).data("material-types");
     
-    this.modal = new ExtractionProcedureModal("", "", 0, this.materialTypes);
+    this.modal = new ExtractionProcedureModal("", "", 0, this.materialTypes, false);
     this.dialogErrors = ko.observableArray([]);
 
     this.showModal = function () {
@@ -41,7 +41,7 @@ function AdacExtractionProcedureViewModel() {
         $("#OntologyTermId").prop("readonly", false);
 
         _this.modal.mode(_this.modal.modalModeAdd);
-        _this.modal.extractionProcedure(new ExtractionProcedure("", "", 0, this.materialTypes));
+        _this.modal.extractionProcedure(new ExtractionProcedure("", "", 0, this.materialTypes, false));
         _this.setPartialEdit(false);
         _this.showModal();
     };
@@ -55,7 +55,8 @@ function AdacExtractionProcedureViewModel() {
       new ExtractionProcedure(
           extractionProcedure.OntologyTermId,
           extractionProcedure.Description,
-          extractionProcedure.MaterialTypeIds
+          extractionProcedure.MaterialTypeIds,
+          diseaseStatus.DisplayOnDirectory
       )
     );
     $("#OntologyTermId").prop('readonly', true);

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
@@ -41,7 +41,7 @@ function AdacExtractionProcedureViewModel() {
         $("#OntologyTermId").prop("readonly", false);
 
         _this.modal.mode(_this.modal.modalModeAdd);
-        _this.modal.extractionProcedure(new ExtractionProcedure("", "", 0, this.materialTypes, false));
+        _this.modal.extractionProcedure(new ExtractionProcedure("", "", 0, false));
         _this.setPartialEdit(false);
         _this.showModal();
     };
@@ -56,7 +56,7 @@ function AdacExtractionProcedureViewModel() {
           extractionProcedure.OntologyTermId,
           extractionProcedure.Description,
           extractionProcedure.MaterialTypeIds,
-          diseaseStatus.DisplayOnDirectory
+          extractionProcedure.DisplayOnDirectory
       )
     );
     $("#OntologyTermId").prop('readonly', true);

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
@@ -1,17 +1,18 @@
-function ExtractionProcedure(ontologyTermId, description, materialTypeIds) {
+function ExtractionProcedure(ontologyTermId, description, materialTypeIds, displayOnDirectory) {
     this.ontologyTermId = ko.observable(ontologyTermId);
     this.description = ko.observable(description);
     this.materialTypeIds = ko.observableArray(materialTypeIds);
+    this.displayOnDirectory = ko.observable(displayOnDirectory);
 }
 
-function ExtractionProcedureModal(ontologyTermId, description, materialTypeIds, materialTypes) {
+function ExtractionProcedureModal(ontologyTermId, description, materialTypeIds, materialTypes, displayOnDirectory) {
     this.modalModeAdd = "Add";
     this.modalModeEdit = "Update";
 
     this.mode = ko.observable(this.modalModeAdd);
 
     this.extractionProcedure = ko.observable(
-        new ExtractionProcedure(ontologyTermId, description, materialTypeIds)
+        new ExtractionProcedure(ontologyTermId, description, materialTypeIds, displayOnDirectory)
     );
     this.materialTypes = materialTypes;
 }

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-extraction-procedure.js
@@ -98,8 +98,8 @@ var adacExtractionProcedureVM;
 $(function () {
     $("#extraction-procedures")["DataTable"]({
         columnDefs: [
-            { orderable: false, targets: 4 },
-            { width: "180px", targets: 4 },
+            { orderable: false, targets: 5 },
+            { width: "180px", targets: 5 },
         ],
         paging: false,
         info: false,

--- a/src/Directory/Biobanks.Web/Scripts/Shared/serialize-checkbox-as-bool.js
+++ b/src/Directory/Biobanks.Web/Scripts/Shared/serialize-checkbox-as-bool.js
@@ -1,0 +1,50 @@
+﻿// jquery plugin to serialise checkboxes as bools
+(function ($) {
+    $.fn.serialize = function () {
+        return $.param(this.serializeArray());
+    };
+
+    $.fn.serializeArray = function () {
+        var o = $.extend(
+            {
+                checkboxesAsBools: true,
+            },
+            {}
+        );
+
+        var rselectTextarea = /select|textarea/i;
+        var rinput = /text|hidden|password|search/i;
+
+        return this.map(function () {
+            return this.elements ? $.makeArray(this.elements) : this;
+        })
+            .filter(function () {
+                return (
+                    this.name &&
+                    !this.disabled &&
+                    (this.checked ||
+                        (o.checkboxesAsBools && this.type === "checkbox") ||
+                        rselectTextarea.test(this.nodeName) ||
+                        rinput.test(this.type))
+                );
+            })
+            .map(function (i, elem) {
+                const val = $(this).val();
+                return val == null
+                    ? null
+                    : $.isArray(val)
+                        ? $.map(val, (innerVal) => ({ name: elem.name, value: innerVal }))
+                        : {
+                            name: elem.name,
+                            value:
+                                o.checkboxesAsBools && this.type === "checkbox" //moar ternaries!
+                                    ? this.checked
+                                        ? "true"
+                                        : "false"
+                                    : val,
+                        };
+            })
+            .get();
+    };
+}
+)(jQuery);

--- a/src/Directory/Biobanks.Web/Views/ADAC/ExtractionProcedure.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/ExtractionProcedure.cshtml
@@ -27,6 +27,7 @@
                     <th>Extraction Procedure ID</th>
                     <th>Material Types</th>
                     <th>Material Details Count</th>
+                    <th>Displayed On Directory</th>
                     <th>@* Actions *@</th>
                 </tr>
             </thead>
@@ -43,6 +44,7 @@
                         </td>
                         <td><div class="wrappable-td">@string.Join(" / ", Model.MaterialTypes.Where(x=>ontologyTerm.MaterialTypeIds.Contains(x.Id)).Select(x=>x.Value))</div></td>
                         <td>@ontologyTerm.MaterialDetailsCount</td>
+                        <td>@ontologyTerm.DisplayOnDirectory.ToString()</td>
 
                         <td class="text-right">
                             @if (ontologyTerm.MaterialDetailsCount > 0)

--- a/src/Directory/Biobanks.Web/Views/ADAC/ExtractionProcedure.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/ExtractionProcedure.cshtml
@@ -166,7 +166,7 @@
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label">Displayed On Directory</label>
                                     <div class="col-sm-1">
-                                        <input type="checkbox" id="DisplayOnDirectory" name="DisplayOnDirectory" class=" form-control"
+                                        <input type="checkbox" id="DisplayOnDirectory" name="DisplayOnDirectory" class="form-control"
                                                data-bind="checked: modal.extractionProcedure().displayOnDirectory()" />
                                     </div>
                                 </div>

--- a/src/Directory/Biobanks.Web/Views/ADAC/ExtractionProcedure.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/ExtractionProcedure.cshtml
@@ -149,14 +149,25 @@
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label" data-bind="visible: $index() < 1">Material Type</label>
                                     <div class="col-sm-8" data-bind="css: { 'col-sm-offset-3': $index() > 0 }">
-                                        <select name ="MaterialTypeIds" class="form-control"
-                                            data-bind="options: $parent.modal.materialTypes, optionsText: 'value', optionsValue: 'id', value: $parent.modal.extractionProcedure().materialTypeIds()[$index()]">
+                                        <select name="MaterialTypeIds" class="form-control"
+                                                data-bind="options: $parent.modal.materialTypes, optionsText: 'value', optionsValue: 'id', value: $parent.modal.extractionProcedure().materialTypeIds()[$index()]">
                                         </select>
 
                                     </div>
                                     <div class="col-sm-1">
                                         <button type="button" class="fa fa-minus-circle btn btn-default form-control-static pull-right"
                                                 data-bind="click: function() { $parent.removeMaterialType($index())}" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Displayed On Directory Checkbox -->
+                            <div>
+                                <div class="form-group">
+                                    <label class="col-sm-3 control-label">Displayed On Directory</label>
+                                    <div class="col-sm-1">
+                                        <input type="checkbox" id="DisplayOnDirectory" name="DisplayOnDirectory" class=" form-control"
+                                               data-bind="checked: modal.extractionProcedure().displayOnDirectory()" />
                                     </div>
                                 </div>
                             </div>

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1205,7 +1205,7 @@ namespace Biobanks.Services
                     .ToListAsync();
         }
 
-        public async Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null, bool onlyDisplayable = true)
+        public async Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null, bool onlyDisplayable = false)
             => await QueryOntologyTerms(id, description, tags, onlyDisplayable).SingleOrDefaultAsync();
 
         public async Task<bool> ValidOntologyTerm(string id = null, string description = null, List<string> tags = null)

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1243,19 +1243,19 @@ namespace Biobanks.Services
         .FirstOrDefault()?.ExtractionProcedures
         .ToList();
 
-        public async Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "")
+        public async Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "", bool onlyDisplayable = false)
             => await _ontologyTermRepository.ListAsync(false, 
                 x => x.SnomedTag.Value == "Extraction Procedure" 
                      && x.Value.Contains(wildcard) 
-                     && x.DisplayOnDirectory,
+                     && (x.DisplayOnDirectory || !onlyDisplayable),
                 null,
                 x=>x.MaterialTypes);
 
-        public async Task<OntologyTerm> GetExtractionProcedureById(string id)
+        public async Task<OntologyTerm> GetExtractionProcedureById(string id, bool onlyDisplayable = false)
             => (await _ontologyTermRepository.ListAsync(filter:
                 x => x.SnomedTag.Value == "Extraction Procedure"
                      && x.Id == id
-                     && x.DisplayOnDirectory)).FirstOrDefault();
+                     && (x.DisplayOnDirectory || !onlyDisplayable))).FirstOrDefault();
         public async Task<int> GetExtractionProcedureMaterialDetailsCount(string id)
             => await _materialDetailRepository.CountAsync(x => x.ExtractionProcedureId == id);
 

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1238,9 +1238,10 @@ namespace Biobanks.Services
         #endregion
         #region RefData: Extraction Procedure
 
-        public async Task<IEnumerable<OntologyTerm>> GetMaterialTypeExtractionProcedures(int id)
+        public async Task<IEnumerable<OntologyTerm>> GetMaterialTypeExtractionProcedures(int id, bool onlyDisplayable = false)
         => (await _materialTypeRepository.ListAsync(false, x => x.Id == id, null, x => x.ExtractionProcedures))
         .FirstOrDefault()?.ExtractionProcedures
+        .Where(x=> x.DisplayOnDirectory || !onlyDisplayable)
         .ToList();
 
         public async Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "", bool onlyDisplayable = false)

--- a/src/Directory/Services/BiobankWriteService.cs
+++ b/src/Directory/Services/BiobankWriteService.cs
@@ -207,7 +207,7 @@ namespace Biobanks.Services
             IEnumerable<CollectionAssociatedData> associatedData,
             IEnumerable<int> consentRestrictionIds)
         {
-            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: ontologyTermDescription);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: ontologyTermDescription, onlyDisplayable: true);
             var consentRestrictions = (await _consentRestrictionRepository.ListAsync(true,
                         x => consentRestrictionIds.Contains(x.Id))).ToList();
 
@@ -238,7 +238,7 @@ namespace Biobanks.Services
             existingCollection.AssociatedData.Clear();
             existingCollection.ConsentRestrictions.Clear();
 
-            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: ontologyTermDescription);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: ontologyTermDescription, onlyDisplayable: true);
             var consentRestrictions = (await _consentRestrictionRepository.ListAsync(true,
                         x => consentRestrictionIds.Contains(x.Id))).ToList();
 
@@ -377,7 +377,7 @@ namespace Biobanks.Services
 
         public async Task AddCapabilityAsync(CapabilityDTO capabilityDTO, IEnumerable<CapabilityAssociatedData> associatedData)
         {
-            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: capabilityDTO.OntologyTerm);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: capabilityDTO.OntologyTerm, onlyDisplayable: true);
 
             var capability = new DiagnosisCapability
             {
@@ -406,7 +406,7 @@ namespace Biobanks.Services
 
             existingCapability.AssociatedData.Clear();
 
-            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: capabilityDTO.OntologyTerm);
+            var ontologyTerm = await _biobankReadService.GetOntologyTerm(description: capabilityDTO.OntologyTerm, onlyDisplayable: true);
 
             existingCapability.OntologyTermId = ontologyTerm.Id;
             existingCapability.AnnualDonorExpectation = capabilityDTO.AnnualDonorExpectation.Value;

--- a/src/Directory/Services/Constants/SnomedTags.cs
+++ b/src/Directory/Services/Constants/SnomedTags.cs
@@ -4,5 +4,6 @@
     {
         public const string Disease = "Disease";
         public const string Finding = "Finding";
+        public const string ExtractionProcedure = "Extraction Procedure";
     }
 }

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -133,7 +133,7 @@ namespace Biobanks.Services.Contracts
 
         Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string description = null, List<string> tags = null, bool onlyDisplayable = false);
         Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string description = null, List<string> tags = null);
-        Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null, bool onlyDisplayable = true);
+        Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null, bool onlyDisplayable = false);
         Task<bool> ValidOntologyTerm(string id = null, string description = null, List<string> tags = null);
         Task<bool> IsOntologyTermInUse(string id);
         Task<int> CountOntologyTerms(string description = null, List<string> tags = null);

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -144,8 +144,8 @@ namespace Biobanks.Services.Contracts
         Task<IEnumerable<OntologyTerm>> PaginateDiseaseOntologyTerms(int start, int length, string filter = "");
         Task<int> CountDiseaseOntologyTerms(string filter = "");
 
-        Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "");
-        Task<OntologyTerm> GetExtractionProcedureById(string id);
+        Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "", bool onlyDisplayable = false);
+        Task<OntologyTerm> GetExtractionProcedureById(string id, bool onlyDisplayable = false);
         Task<int> GetExtractionProcedureMaterialDetailsCount(string id);
         Task<bool> IsExtractionProcedureInUse(string id);
 

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -133,14 +133,12 @@ namespace Biobanks.Services.Contracts
 
         Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string description = null, List<string> tags = null, bool onlyDisplayable = false);
         Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string description = null, List<string> tags = null);
-        Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null);
+        Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null, bool onlyDisplayable = true);
         Task<bool> ValidOntologyTerm(string id = null, string description = null, List<string> tags = null);
         Task<bool> IsOntologyTermInUse(string id);
         Task<int> CountOntologyTerms(string description = null, List<string> tags = null);
         Task<int> GetOntologyTermCollectionCapabilityCount(string id);
 
-        Task<IEnumerable<OntologyTerm>> ListExtractionProceduresAsync(string wildcard = "", bool onlyDisplayable = false);
-        Task<OntologyTerm> GetExtractionProcedureById(string id, bool onlyDisplayable = false);
         Task<int> GetExtractionProcedureMaterialDetailsCount(string id);
         Task<bool> IsExtractionProcedureInUse(string id);
 

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -12,7 +12,7 @@ namespace Biobanks.Services.Contracts
 {
     public interface IBiobankReadService
     {
-        Task<IEnumerable<OntologyTerm>> GetMaterialTypeExtractionProcedures(int id);
+        Task<IEnumerable<OntologyTerm>> GetMaterialTypeExtractionProcedures(int id, bool onlyDisplayable = false);
         Task<OrganisationRegisterRequest> GetBiobankRegisterRequestByUserEmailAsync(string email);
 
         Task<NetworkRegisterRequest> GetNetworkRegisterRequestByUserEmailAsync(string email);


### PR DESCRIPTION
## Overview

Adds option to turn on and off DisplayOnDirectory for extraction procedures.

Extraction procedure service methods replaced with new ontology term methods