### PR TITLE
AB#38847: Disease Status edit action modifies wrong entry

### DIFF
--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -88,10 +88,7 @@ function AdacDiseaseStatusViewModel() {
         else if (action == 'Update') {
 
             // Parse Edit Url
-            var rowIndex = $(this).data("row")
-            var data = dataTable.row(rowIndex).data();
-            var url = apiUrl + "/" + data.OntologyTermId;
-
+            var url = apiUrl + "/" + $(e.target.Id).val();
             editRefData(_this, url, form.serialize(), redirectUrl, refdataType);
         }
     };


### PR DESCRIPTION
## Overview

Editing a disease status edits the wrong row