### PR TITLE
AB#38848: Fix for cannot add ontology term ref data where desc is part of another ontology term

### DIFF
--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1179,7 +1179,7 @@ namespace Biobanks.Services
 
             // Filter By Description
             if (!string.IsNullOrEmpty(description))
-                query = query.Where(x => x.Value.Contains(description));
+                query = query.Where(x => x.Value == description);
 
             // Filter By SnomedTag
             if (tags != null)


### PR DESCRIPTION
- Was using a .Contains() check to see if description was already present rather than direct comparison of descriptions. 