### PR TITLE
AB#39733: Fix Add/Delete CollectionService Methods

### DIFF
--- a/src/Directory/Services/CollectionService.cs
+++ b/src/Directory/Services/CollectionService.cs
@@ -45,6 +45,13 @@ namespace Biobanks.Directory.Services
         /// <inheritdoc/>
         public async Task<Collection> Add(Collection collection)
         {
+            // Match Consent Restritions
+            var consentIds = collection.ConsentRestrictions?.Select(x => x.Id) ?? Enumerable.Empty<int>();
+
+            collection.ConsentRestrictions = await _db.ConsentRestrictions
+                .Where(x => consentIds.Contains(x.Id))
+                .ToListAsync();
+
             // Update Timestamp
             collection.LastUpdated = DateTime.Now;
 

--- a/src/Directory/Services/CollectionService.cs
+++ b/src/Directory/Services/CollectionService.cs
@@ -34,8 +34,7 @@ namespace Biobanks.Directory.Services
             if (await HasSampleSets(id))
                 return false;
 
-            var collection = new Collection { OrganisationId = id };
-            _db.Collections.Attach(collection);
+            var collection = await _db.Collections.FindAsync(id);
             _db.Collections.Remove(collection);
 
             await _db.SaveChangesAsync();


### PR DESCRIPTION
- `Add` Service method was incorrectly referencing `ConsentRestrictions`
- `Delete` Service now uses work around to reference existing `Collection`