### PR TITLE
AB#40514: Search Type-Ahead Bug Fix

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/SearchController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/SearchController.cs
@@ -247,7 +247,7 @@ namespace Biobanks.Web.Controllers
         private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type, string wildcard)
         {
             var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
-            var directoryOntologyTerms = await _biobankReadService.ListOntologyTerms(wildcard, onlyDisplayable: true, tags: new List<string>
+            var directoryOntologyTerms = await _biobankReadService.SearchOntologyTerms(wildcard, tags: new List<string>
             {
                 SnomedTags.Disease,
                 SnomedTags.Finding
@@ -281,7 +281,7 @@ namespace Biobanks.Web.Controllers
 
         private async Task<List<OntologyTermModel>> GetOntologyTermsAsync(string wildcard)
         {
-            var ontologyTerms = await _biobankReadService.ListOntologyTerms(wildcard, onlyDisplayable: true, tags: new List<string>
+            var ontologyTerms = await _biobankReadService.SearchOntologyTerms(wildcard, tags: new List<string>
             {
                 SnomedTags.Disease,
                 SnomedTags.Finding

--- a/src/Directory/Services/BiobankReadService.cs
+++ b/src/Directory/Services/BiobankReadService.cs
@@ -1094,7 +1094,7 @@ namespace Biobanks.Services
         #region RefData: OntologyTerm
 
         protected IQueryable<OntologyTerm> QueryOntologyTerms(
-            string id = null, string description = null,  List<string> tags = null, bool onlyDisplayable = false)
+            string id = null, string description = null,  List<string> tags = null, bool onlyDisplayable = false, bool fuzzyMatch = false)
         {
             var query = _context.OntologyTerms
                 .AsNoTracking()
@@ -1108,7 +1108,9 @@ namespace Biobanks.Services
 
             // Filter By Description
             if (!string.IsNullOrEmpty(description))
-                query = query.Where(x => x.Value == description);
+                query = fuzzyMatch
+                    ? query.Where(x => x.Value.Contains(description))
+                    : query.Where(x => x.Value == description);
 
             // Filter By SnomedTag
             if (tags != null)
@@ -1119,6 +1121,9 @@ namespace Biobanks.Services
 
             return query;
         }
+
+        public async Task<IEnumerable<OntologyTerm>> SearchOntologyTerms(string description = null, List<string> tags = null)
+            => await QueryOntologyTerms(id: null, description, tags, onlyDisplayable: true, fuzzyMatch: true).ToListAsync();
 
         public async Task<IEnumerable<OntologyTerm>> ListOntologyTerms(
             string description = null, List<string> tags = null, bool onlyDisplayable = false)

--- a/src/Directory/Services/Contracts/IBiobankReadService.cs
+++ b/src/Directory/Services/Contracts/IBiobankReadService.cs
@@ -128,6 +128,7 @@ namespace Biobanks.Services.Contracts
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(int procurementId, string procurementDescription);
         Task<bool> ValidAssociatedDataProcurementTimeFrameDescriptionAsync(string procurementDescription);
 
+        Task<IEnumerable<OntologyTerm>> SearchOntologyTerms(string description = null, List<string> tags = null);
         Task<IEnumerable<OntologyTerm>> ListOntologyTerms(string description = null, List<string> tags = null, bool onlyDisplayable = false);
         Task<IEnumerable<OntologyTerm>> PaginateOntologyTerms(int start, int length, string description = null, List<string> tags = null);
         Task<OntologyTerm> GetOntologyTerm(string id = null, string description = null, List<string> tags = null, bool onlyDisplayable = false);


### PR DESCRIPTION
The Search Type-Ahead was not working until the exact search phrase was used. This was because the underlying service method filters `Description` by exact match.

This PR adds a new service method that treats the description as a wildcard. This is mostly a temporary solution as #299 reworks all `OntologyTerm` service methods.

#299 should take care to ensure the `Description` field is properly match, either partially or exactly in the correct context