### PR TITLE
AB#43859: A-Z List of Biobanks not alphabetically ordered fix

### DIFF
--- a/src/Directory/Biobanks.Web/Views/Profile/Biobanks.cshtml
+++ b/src/Directory/Biobanks.Web/Views/Profile/Biobanks.cshtml
@@ -67,7 +67,7 @@
 					<th width="250">County</th>}
 					<th>Description</th>
 
-					@foreach (var organisation in Model)
+					@foreach (var organisation in Model.OrderBy(x => x.Name))
 					{
 						<tr>
 							<td></td>


### PR DESCRIPTION
A-Z List of Biobanks on /Profile/Biobanks were not alphabetically ordered.