### PR TITLE
AB#43745:  Couldn't create disease status 

### DIFF
--- a/src/Directory/Services/OntologyTermService.cs
+++ b/src/Directory/Services/OntologyTermService.cs
@@ -91,7 +91,7 @@ namespace Biobanks.Directory.Services
         public async Task<OntologyTerm> Create(OntologyTerm ontologyTerm)
         {
             // Get Attached References To MaterialType
-            var materialTypeIds = ontologyTerm?.MaterialTypes.Select(x => x.Id) ?? new List<int>();
+            var materialTypeIds = ontologyTerm?.MaterialTypes?.Select(x => x.Id) ?? new List<int>();
             
             var materialTypes = await _db.MaterialTypes
                 .Where(x => materialTypeIds.Contains(x.Id))


### PR DESCRIPTION
Was throwing a null exception when trying to grab associated material types. 