### PR TITLE
AB#48529: Directory Typeahead fix

### DIFF
--- a/src/Directory/Biobanks.Web/Scripts/Shared/search-diagnosis-type-ahead.js
+++ b/src/Directory/Biobanks.Web/Scripts/Shared/search-diagnosis-type-ahead.js
@@ -38,7 +38,7 @@ $(function() {
     searchElement.typeahead({
         hint: false,
         highlight: true,
-        minLength: 1,
+        minLength: 3,
         autoselect: true
     },
     {

--- a/src/Directory/Services/OntologyTermService.cs
+++ b/src/Directory/Services/OntologyTermService.cs
@@ -38,7 +38,7 @@ namespace Biobanks.Directory.Services
 
             // Filter By Description
             if (!string.IsNullOrEmpty(value))
-                query = query.Where(x => x.Value == value);
+                query = query.Where(x => x.Value.Contains(value));
 
             // Filter By SnomedTag
             if (tags != null)


### PR DESCRIPTION
- Typeahead fix for search diagnosis terms
- Changed min length of characters to 3 before typeahead is triggered