### PR TITLE
AB#49478: Copy Collection fix

### DIFF
--- a/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/BiobankController.cs
@@ -1036,8 +1036,10 @@ namespace Biobanks.Web.Controllers
             // Copy and Add New Collection  
             var newCollection = await _collectionService.Copy(id, biobankId);
 
+            var originalCollection = await _collectionService.Get(id);
+
             // Copy Sample Set 
-            foreach (SampleSet sampleSet in newCollection.SampleSets)
+            foreach (SampleSet sampleSet in originalCollection.SampleSets)
             {
                 var newSampleSet = new SampleSet
                 {
@@ -1059,9 +1061,8 @@ namespace Biobanks.Web.Controllers
                       .ToList()
                 };
 
-                // Add New SampleSet
-                await _biobankWriteService.AddSampleSetAsync(newSampleSet);
-     
+                    // Add New SampleSet
+                    await _biobankWriteService.AddSampleSetAsync(newSampleSet);
             }
 
 

--- a/src/Directory/Services/CollectionService.cs
+++ b/src/Directory/Services/CollectionService.cs
@@ -147,8 +147,6 @@ namespace Biobanks.Directory.Services
                 {
                     await _indexService.UpdateCollectionDetails(newCollection.CollectionId);
                 }
-
-            newCollection.SampleSets = collectionToCopy.SampleSets;
            
             return newCollection;
         }


### PR DESCRIPTION
Copying collection caused an error. This was because the SampleSets to be copied were directly assigned to the copied collection, before copying them. SampleSets are now directly pulled from original collection from dB. 