### PR TITLE
AB#47374: AssociatedDataOntologyTerms bug fixes

### DIFF
--- a/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
+++ b/src/Directory/Biobanks.Web/ApiControllers/DiseaseStatusController.cs
@@ -12,6 +12,8 @@ using System.Collections.Generic;
 using Biobanks.Directory.Services.Constants;
 using Biobanks.Directory.Services.Contracts;
 using Biobanks.Entities.Data.ReferenceData;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
 
 namespace Biobanks.Web.ApiControllers
 {
@@ -139,8 +141,10 @@ namespace Biobanks.Web.ApiControllers
 
         [HttpPost]
         [Route("")]
-        public async Task<IHttpActionResult> Post(OntologyTermModel model)
+        public async Task<IHttpActionResult> Post([System.Web.Mvc.Bind(Exclude = "Value",Include ="OntologyTermId, Description",Prefix = "")] OntologyTermModel model)
         {
+            // Had to do this as it is not binding to ontology term model
+            ModelState.Clear();
             //if ontology term id is in use by another ontology term
             if (await _ontologyTermService.Exists(id: model.OntologyTermId))
                 ModelState.AddModelError("OntologyTermId", "That ID is already in use. IDs must be unique across all ontology terms.");
@@ -151,11 +155,25 @@ namespace Biobanks.Web.ApiControllers
                 ModelState.AddModelError("Description", "That description is already in use. Descriptions must be unique across all ontology terms.");
             }
 
+            var context = new ValidationContext( model,serviceProvider: null, items: null);
+            var validationResults = new List<ValidationResult>();
+            bool isValid = Validator.TryValidateObject(model,context, validationResults, true);
+            if (!isValid)
+            {
+                foreach(var item in validationResults)
+                {
+                    ModelState.AddModelError(item.ToString(),item.ErrorMessage);
+                }
+            }
+
+
+
             if (!ModelState.IsValid)
             {
                 return JsonModelInvalidResponse(ModelState);
             }
-
+            var associatedData = ((List<AssociatedDataTypeModel>)JsonConvert.DeserializeObject(model.AssociatedDataTypesJson, typeof(List<AssociatedDataTypeModel>)));
+            List<AssociatedDataType> types = await _ontologyTermService.GetAssociatedDataFromList(associatedData.Select(x => x.Id).ToList());
             await _ontologyTermService.Create(new OntologyTerm
             {
                 Id = model.OntologyTermId,
@@ -163,7 +181,7 @@ namespace Biobanks.Web.ApiControllers
                 OtherTerms = model.OtherTerms,
                 SnomedTagId = (await _biobankReadService.GetSnomedTagByDescription("Disease")).Id,
                 DisplayOnDirectory = model.DisplayOnDirectory,
-                AssociatedDataTypes = model.AssociatedDataTypes
+                AssociatedDataTypes = types
             });
 
             //Everything went A-OK!

--- a/src/Directory/Biobanks.Web/Controllers/ADACController.cs
+++ b/src/Directory/Biobanks.Web/Controllers/ADACController.cs
@@ -1297,7 +1297,16 @@ namespace Biobanks.Web.Controllers
                     Description = x.Value,
                     OtherTerms = x.OtherTerms,
                     DisplayOnDirectory = x.DisplayOnDirectory,
-                    CollectionCapabilityCount = await _ontologyTermService.CountCollectionCapabilityUsage(x.Id)
+                    CollectionCapabilityCount = await _ontologyTermService.CountCollectionCapabilityUsage(x.Id),
+                    AssociatedDataTypes = x.AssociatedDataTypes==null?
+                        null
+                        :
+                        x.AssociatedDataTypes.Select(y => new AssociatedDataTypeModel
+                        {
+                            Id = y.Id,
+                            Name = y.Value,
+                            Message = y.Message
+                        }).ToList()
                 })
                 .Result
             );
@@ -1463,8 +1472,17 @@ namespace Biobanks.Web.Controllers
                         Message = x.Message,
                         CollectionCapabilityCount = await _associatedDataTypeService.GetUsageCount(x.Id),
                         AssociatedDataTypeGroupId = x.AssociatedDataTypeGroupId,
-                        AssociatedDataTypeGroupName = x.AssociatedDataTypeGroup?.Value
-
+                        AssociatedDataTypeGroupName = x.AssociatedDataTypeGroup?.Value,
+                        OntologyTerms = (x.OntologyTerms != null)?
+                            x.OntologyTerms.Select(y=> new OntologyTermModel
+                            {
+                                OntologyTermId = y.Id,
+                                Description = y.Value,
+                                OtherTerms = y.OtherTerms,
+                                DisplayOnDirectory= y.DisplayOnDirectory
+                            }).ToList()
+                            :
+                            null
                     })
                     .Result
                 )

--- a/src/Directory/Biobanks.Web/Models/ADAC/AssociatedDataTypesModel.cs
+++ b/src/Directory/Biobanks.Web/Models/ADAC/AssociatedDataTypesModel.cs
@@ -26,6 +26,8 @@ namespace Biobanks.Web.Models.ADAC
         public string Message { get; set; }
         public int CollectionCapabilityCount { get; set; }
 
-        public List<OntologyTerm> OntologyTerms { get; set; }
+        public List<OntologyTermModel> OntologyTerms { get; set; }
+
+        public string OntologyTermsJson { get; set; } = "";
     }
 }

--- a/src/Directory/Biobanks.Web/Models/Shared/OntologyTermModel.cs
+++ b/src/Directory/Biobanks.Web/Models/Shared/OntologyTermModel.cs
@@ -1,4 +1,5 @@
 ﻿using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Web.Models.ADAC;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
@@ -17,9 +18,10 @@ namespace Biobanks.Web.Models.Shared
 
         public bool DisplayOnDirectory { get; set; }
 
-        public List<string> MatchingOtherTerms { get; set; }
-        public List<string> NonMatchingOtherTerms { get; set; }
+        public List<string> MatchingOtherTerms { get; set; } = new List<string>();
+        public List<string> NonMatchingOtherTerms { get; set; } = new List<string>();
 
-        public List<AssociatedDataType> AssociatedDataTypes {get; set;}
+        public List<AssociatedDataTypeModel> AssociatedDataTypes {get; set;}
+        public string AssociatedDataTypesJson {get; set; }
     }
 }

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-associated-data-types.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-associated-data-types.js
@@ -61,9 +61,9 @@ function AdacAssociatedDataTypeViewModel() {
 
     var associatedDataType = $(event.currentTarget).data("associated-types");
 
-    let ontologyTerms = associatedDataType.ontologyTerms
-      ? associatedDataType.ontologyTerms.split(",").map((item) => item.trim())
-      : associatedDataType.ontologyTerms;
+    let ontologyTerms = associatedDataType.OntologyTerms
+      ? associatedDataType.OntologyTerms
+      : [];
 
     _this.modal.associatedDataType(
       new AssociatedDataType(
@@ -110,7 +110,8 @@ function AdacAssociatedDataTypeViewModel() {
         .ontologyTerms()
         .find(
           (item) =>
-            item.Id == JSON.parse($(".diagnosis-search").attr("data-id")).Id
+            item.OntologyTermId ==
+            JSON.parse($(".diagnosis-search").attr("data-id")).OntologyTermId
         ) == undefined
     ) {
       _this.modal

--- a/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
+++ b/src/Directory/Biobanks.Web/Scripts/ADAC/adac-disease-statuses.js
@@ -76,9 +76,9 @@ function AdacDiseaseStatusViewModel() {
       ? diseaseStatus.OtherTerms.split(",").map((item) => item.trim())
       : diseaseStatus.OtherTerms;
 
-    let associatedData = diseaseStatus.associatedData
-      ? diseaseStatus.associatedData.split(",").map((item) => item.trim())
-      : diseaseStatus.associatedData;
+    let associatedData = diseaseStatus.AssociatedDataTypes
+      ? diseaseStatus.AssociatedDataTypes
+      : [];
 
     _this.modal.diseaseStatus(
       new DiseaseStatus(

--- a/src/Directory/Biobanks.Web/Scripts/Shared/diagnosis-type-ahead.js
+++ b/src/Directory/Biobanks.Web/Scripts/Shared/diagnosis-type-ahead.js
@@ -18,7 +18,7 @@ $(function () {
         return $.map(x, function (item) {
           return {
             desc: item.Description,
-            id: item.Id,
+            id: item.OntologyTermId,
           };
         });
       },

--- a/src/Directory/Biobanks.Web/Views/ADAC/AssociatedDataTypes.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/AssociatedDataTypes.cshtml
@@ -62,7 +62,7 @@
                                 {
                                     // map list of ontology terms to their names and print out
                                     // the array of names
-                                    string[] stringList = item.OntologyTerms.Select(r => "<li>"+r.Value+"</li>").ToArray();
+                                    string[] stringList = item.OntologyTerms.Select(r => "<li>"+r.Description+"</li>").ToArray();
                                     string outputString = "<ul>" + String.Join("", stringList) + "</ul>";
                                     @Html.Raw(outputString)
 
@@ -140,7 +140,7 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <input type="hidden" id="Id" name="Id" data-bind="value: modal.associatedDataType().id">
-                            <input type="hidden" id="OntologyTerms" name="OntologyTerms" data-bind="value: modal.associatedDataType().ontologyTerms()">
+                            <input type="hidden" id="OntologyTermsJson" name="OntologyTermsJson" data-bind="value: ko.toJSON(modal.associatedDataType().ontologyTerms)">
 
                             <!-- Annual Statistic -->
                             <div class="form-group">

--- a/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
+++ b/src/Directory/Biobanks.Web/Views/ADAC/DiseaseStatuses.cshtml
@@ -61,7 +61,7 @@
 
                             <input type="hidden" id="Id" name="Id" data-bind="value: modal.diseaseStatus().ontologyTermId()">
                             <input type="hidden" id="OtherTerms" name="OtherTerms">
-                            <input type="hidden" id="AssociatedDataTypes" name="AssociatedDataTypes" data-bind="value: modal.diseaseStatus().associatedData()">
+                            <input type="hidden" id="AssociatedDataTypesJson" name="AssociatedDataTypesJson" data-bind="value: ko.toJSON(modal.diseaseStatus().associatedData)">
 
                             <!-- SNOMED ID -->
                             <div class="form-group">

--- a/src/Directory/Services/AssociatedDataTypeService.cs
+++ b/src/Directory/Services/AssociatedDataTypeService.cs
@@ -1,5 +1,7 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Entities.Shared.ReferenceData;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
@@ -27,9 +29,20 @@ namespace Biobanks.Directory.Services
             existing.AssociatedDataTypeGroup = entity.AssociatedDataTypeGroup;
             existing.AssociatedDataTypeGroupId = entity.AssociatedDataTypeGroupId;
             existing.Message = entity.Message;
+            existing.OntologyTerms = entity.OntologyTerms;
             await _db.SaveChangesAsync();
 
             return existing;
         }
+
+        public override async Task<ICollection<AssociatedDataType>> List(string wildcard)
+            => await _db.AssociatedDataTypes
+                .AsNoTracking()
+                .Include(x => x.OntologyTerms)
+                .Where(x => x.Value.Contains(wildcard))
+                .OrderBy(x => x.SortOrder)
+                .ToListAsync();
+
+
     }
 }

--- a/src/Directory/Services/Contracts/IOntologyTermService.cs
+++ b/src/Directory/Services/Contracts/IOntologyTermService.cs
@@ -84,6 +84,7 @@ namespace Biobanks.Directory.Services.Contracts
         /// </summary>
         /// <param name="id">The alphanumeric Id of the OntologyTerm</param>
         Task<bool> IsInUse(string id);
+        Task<List<OntologyTerm>> GetOntologyTermsFromList(List<string> list);
 
         /// <summary>
         /// Counts the number of OntologyTerms which match the given parameter filters
@@ -103,5 +104,6 @@ namespace Biobanks.Directory.Services.Contracts
         /// <returns>The integer number of occurances of the OntologyTerm in both Collections and Capabilities </returns>
         Task<int> CountCollectionCapabilityUsage(string ontologyTermId);
         Task<List<OntologyTerm>> GetByAssociatedDataType(int id);
+        Task<List<AssociatedDataType>> GetAssociatedDataFromList(List<int> list);
     }
 }

--- a/src/Directory/Services/OntologyTermService.cs
+++ b/src/Directory/Services/OntologyTermService.cs
@@ -32,6 +32,7 @@ namespace Biobanks.Directory.Services
            .AsNoTracking()
            .Include(x => x.SnomedTag)
            .Include(x => x.MaterialTypes)
+           .Include(x => x.AssociatedDataTypes)
            .Where(x => x.DisplayOnDirectory || !onlyDisplayable);
 
             // Filter By ID
@@ -127,12 +128,14 @@ namespace Biobanks.Directory.Services
             // Update Current Term
             var currentTerm = await _db.OntologyTerms
                 .Include(x => x.MaterialTypes)
+                .Include(x => x.AssociatedDataTypes)
                 .FirstAsync(x => x.Id == ontologyTerm.Id);
 
             currentTerm.Value = ontologyTerm.Value;
             currentTerm.OtherTerms = ontologyTerm.OtherTerms;
             currentTerm.DisplayOnDirectory = ontologyTerm.DisplayOnDirectory;
             currentTerm.SnomedTag = ontologyTerm.SnomedTag;
+            currentTerm.AssociatedDataTypes = ontologyTerm.AssociatedDataTypes;
 
             // Link To Existing Material Types
             currentTerm.MaterialTypes = await _db.MaterialTypes.Where(x => materialIds.Contains(x.Id)).ToListAsync();
@@ -157,7 +160,7 @@ namespace Biobanks.Directory.Services
 
         public async Task<List<OntologyTerm>> GetByAssociatedDataType(int id)
         {
-            var list = await _db.AssociatedDataTypes 
+            var list = await _db.AssociatedDataTypes
                     .Where(p => p.Id == id)
                     .SelectMany(p => p.OntologyTerms)
                     .OrderByDescending(p => p.Id)
@@ -173,6 +176,22 @@ namespace Biobanks.Directory.Services
                     .OrderByDescending(p => p.Id)
                     .ToListAsync();
 
+            return list;
+        }
+
+        public async Task<List<OntologyTerm>> GetOntologyTermsFromList(List<string> input)
+        {
+            var list = await _db.OntologyTerms
+                    .Where(r => input.Contains(r.Id))
+                    .ToListAsync();
+            return list;
+        }
+
+        public async Task<List<AssociatedDataType>> GetAssociatedDataFromList(List<int> input)
+        {
+            var list = await _db.AssociatedDataTypes
+                    .Where(r => input.Contains(r.Id))
+                    .ToListAsync();
             return list;
         }
     }

--- a/src/Directory/Services/ReferenceDataService.cs
+++ b/src/Directory/Services/ReferenceDataService.cs
@@ -84,7 +84,7 @@ namespace Biobanks.Directory.Services
                 .FirstOrDefaultAsync(x => x.Value == value);
 
         /// <inheritdoc/>
-        public async Task<ICollection<T>> List(string wildcard)
+        public virtual async Task<ICollection<T>> List(string wildcard)
             => await Query()
                 .AsNoTracking()
                 .Where(x => x.Value.Contains(wildcard))


### PR DESCRIPTION
## Overview

Fixed bugs to do with associated data and ontology terms relationship

## Azure Boards

- AB#47374

## Notes

Everything to my knowledge seems to work except updating an existing associated data or ontology term to have more or less many to many relationships as it throws this error. 
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/38753056/173109823-80d70d74-2bfd-4db4-a208-26673689e4a5.png">
Full message:
ExceptionMessage: "The operation failed: The relationship could not be changed because one or more of the foreign-key properties is non-nullable. When a change is made to a relationship, the related foreign-key property is set to a null value. If the foreign-key does not support null values, a new relationship must be defined, the foreign-key property must be assigned another non-null value, or the unrelated object must be deleted."

Will look further into how to fix on monday