### PR TITLE
AB#47342 - Added Many to Many table for Age Range and Sample set

### DIFF
--- a/src/Data/Migrations/20220706135059_MultipleAgeRanges.Designer.cs
+++ b/src/Data/Migrations/20220706135059_MultipleAgeRanges.Designer.cs
@@ -4,14 +4,16 @@ using Biobanks.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Biobanks.Data.Migrations
 {
     [DbContext(typeof(BiobanksDbContext))]
-    partial class BiobanksDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220706135059_MultipleAgeRanges")]
+    partial class MultipleAgeRanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Data/Migrations/20220706135059_MultipleAgeRanges.cs
+++ b/src/Data/Migrations/20220706135059_MultipleAgeRanges.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Biobanks.Data.Migrations
+{
+    public partial class MultipleAgeRanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CollectionSampleSets_AgeRanges_AgeRangeId",
+                table: "SampleSets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CollectionSampleSets_AgeRangeId",
+                table: "SampleSets");
+
+            migrationBuilder.CreateTable(
+                name: "AgeRangeSampleSet",
+                columns: table => new
+                {
+                    AgeRangesId = table.Column<int>(type: "int", nullable: false),
+                    SampleSetsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AgeRangeSampleSet", x => new { x.AgeRangesId, x.SampleSetsId });
+                    table.ForeignKey(
+                        name: "FK_AgeRangeSampleSet_AgeRanges_AgeRangesId",
+                        column: x => x.AgeRangesId,
+                        principalTable: "AgeRanges",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AgeRangeSampleSet_SampleSets_SampleSetsId",
+                        column: x => x.SampleSetsId,
+                        principalTable: "SampleSets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AgeRangeSampleSet_SampleSetsId",
+                table: "AgeRangeSampleSet",
+                column: "SampleSetsId");
+
+            //manually move over data to new many to many tables
+            migrationBuilder.Sql("INSERT INTO AgeRangeSampleSet(AgeRangesId, SampleSetsId) SELECT SampleSets.AgeRangeId, SampleSets.Id FROM SampleSets");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AgeRangeSampleSet");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CollectionSampleSets_AgeRangeId",
+                table: "SampleSets",
+                column: "AgeRangeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CollectionSampleSets_AgeRanges_AgeRangeId",
+                table: "SampleSets",
+                column: "AgeRangeId",
+                principalTable: "AgeRanges",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Directory/Data/BiobanksDbContext.cs
+++ b/src/Directory/Data/BiobanksDbContext.cs
@@ -200,6 +200,17 @@ namespace Biobanks.Directory.Data
             modelBuilder.Entity<Status>()
                 .ToTable("Statuses");
 
+            modelBuilder.Entity<AgeRange>()
+                .HasMany(a => a.SampleSets)
+                .WithMany(s => s.AgeRanges)
+                .Map(asa =>
+                {
+                    asa.MapLeftKey("AgeRangesId");
+                    asa.MapRightKey("SampleSetsId");
+                    asa.ToTable("AgeRangeSampleSet");
+                });
+
+
             modelBuilder.Entity<OntologyTerm>()
                 .HasMany(c => c.AssociatedDataTypes)
                 .WithMany(o => o.OntologyTerms)

--- a/src/Entities/Data/ReferenceData/AgeRange.cs
+++ b/src/Entities/Data/ReferenceData/AgeRange.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Biobanks.Entities.Data.ReferenceData
 {
     public class AgeRange : BaseReferenceData
@@ -5,5 +7,7 @@ namespace Biobanks.Entities.Data.ReferenceData
         public string LowerBound { get; set; }
 
         public string UpperBound { get; set; }
+
+        public virtual ICollection<SampleSet> SampleSets { get; set; }
     }
 }

--- a/src/Entities/Data/SampleSet.cs
+++ b/src/Entities/Data/SampleSet.cs
@@ -2,6 +2,7 @@ using Biobanks.Entities.Shared.ReferenceData;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Biobanks.Entities.Data.ReferenceData;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Biobanks.Entities.Data
 {
@@ -16,7 +17,12 @@ namespace Biobanks.Entities.Data
         public int SexId { get; set; }
         public virtual Sex Sex { get; set; }
 
+        public virtual ICollection<AgeRange> AgeRanges { get; set; }
+
+        //TODO migrate data and then delete this column
         public int AgeRangeId { get; set; }
+
+        [NotMapped]
         public virtual AgeRange AgeRange { get; set; }
 
         public int DonorCountId { get; set; }


### PR DESCRIPTION
This is a preparation PR for moving the Biobanks underlying logic to look up multiple age ranges for a sample set. 

In this PR, a new shadow entity, AgeRangesSampleSets has been added. The data from the SampleSets table has also been copied to the new table. No business logic in the app has changed.

This should not be deployed without the corresponding following PR which links up the web app to the new many to many table, otherwise we risk losing any newly added sample set data.