### PR TITLE
AB#76128: Ref data port - access, ageranges, annualstatistic

### DIFF
--- a/src/Directory/Services/AccessConditionService.cs
+++ b/src/Directory/Services/AccessConditionService.cs
@@ -1,11 +1,15 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+        " Any changes made here will need to be made in the corresponding core version"
+        , false)]
     public class AccessConditionService : ReferenceDataService<AccessCondition>
     {
         public AccessConditionService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/AgeRangeService.cs
+++ b/src/Directory/Services/AgeRangeService.cs
@@ -1,10 +1,14 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+        " Any changes made here will need to be made in the corresponding core version"
+        , false)]
     public class AgeRangeService : ReferenceDataService<AgeRange>
     {
         public AgeRangeService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/AnnualStatisticGroupService.cs
+++ b/src/Directory/Services/AnnualStatisticGroupService.cs
@@ -1,11 +1,15 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+    " Any changes made here will need to be made in the corresponding core version"
+    , false)]
     public class AnnualStatisticGroupService : ReferenceDataService<AnnualStatisticGroup>
     {
         public AnnualStatisticGroupService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/AnnualStatisticService.cs
+++ b/src/Directory/Services/AnnualStatisticService.cs
@@ -1,11 +1,15 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+        " Any changes made here will need to be made in the corresponding core version"
+        , false)]
     public class AnnualStatisticService : ReferenceDataService<AnnualStatistic>
     {
         public AnnualStatisticService(BiobanksDbContext db) : base(db) { }

--- a/src/Submissions/Api/Services/Directory/AccessConditionService.cs
+++ b/src/Submissions/Api/Services/Directory/AccessConditionService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Biobanks.Data;
+using Biobanks.Entities.Data.ReferenceData;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class AccessConditionService : ReferenceDataService<AccessCondition>
+    {
+        public AccessConditionService(BiobanksDbContext db) : base(db) { }
+
+        protected override IQueryable<AccessCondition> Query()
+            => base.Query().Include(x => x.Organisations);
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.Collections.CountAsync(x => x.AccessConditionId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.Collections.AnyAsync(x => x.AccessConditionId == id);
+    }
+}
+

--- a/src/Submissions/Api/Services/Directory/AgeRangeService.cs
+++ b/src/Submissions/Api/Services/Directory/AgeRangeService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Biobanks.Data;
+using Biobanks.Entities.Data.ReferenceData;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class AgeRangeService : ReferenceDataService<AgeRange>
+    {
+        public AgeRangeService(BiobanksDbContext db) : base(db) { }
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.SampleSets.CountAsync(x => x.AgeRangeId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.SampleSets.AnyAsync(x => x.AgeRangeId == id);
+
+        public override async Task<AgeRange> Update(AgeRange entity)
+        {
+            var existing = await base.Update(entity);
+            existing.UpperBound = entity.UpperBound;
+            existing.LowerBound = entity.LowerBound;
+            await _db.SaveChangesAsync();
+
+            return existing;
+        }
+    }
+}
+

--- a/src/Submissions/Api/Services/Directory/AnnualStatisticGroupService.cs
+++ b/src/Submissions/Api/Services/Directory/AnnualStatisticGroupService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Biobanks.Data;
+using Biobanks.Entities.Data.ReferenceData;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class AnnualStatisticGroupService : ReferenceDataService<AnnualStatisticGroup>
+    {
+        public AnnualStatisticGroupService(BiobanksDbContext db) : base(db) { }
+
+        protected override IQueryable<AnnualStatisticGroup> Query()
+            => base.Query()
+                .Include(x => x.AnnualStatistics);
+
+        public override async Task<int> GetUsageCount(int id)
+            => await Query()
+                .Where(x => x.Id == id)
+                .Select(x => x.AnnualStatistics.Count)
+                .FirstAsync();
+
+        public override async Task<bool> IsInUse(int id)
+            => await Query()
+                .Where(x => x.Id == id)
+                .SelectMany(x => x.AnnualStatistics)
+                .AnyAsync();
+    }
+}
+

--- a/src/Submissions/Api/Services/Directory/AnnualStatisticService.cs
+++ b/src/Submissions/Api/Services/Directory/AnnualStatisticService.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Biobanks.Data;
+using Biobanks.Entities.Data.ReferenceData;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class AnnualStatisticService : ReferenceDataService<AnnualStatistic>
+    {
+        public AnnualStatisticService(BiobanksDbContext db) : base(db) { }
+
+        protected override IQueryable<AnnualStatistic> Query()
+            => base.Query()
+                .Include(x => x.AnnualStatisticGroup)
+                .Include(x => x.OrganisationAnnualStatistics);
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.OrganisationAnnualStatistics.CountAsync(x => x.AnnualStatisticId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.OrganisationAnnualStatistics.AnyAsync(x => x.AnnualStatisticId == id);
+
+        public override async Task<AnnualStatistic> Update(AnnualStatistic entity)
+        {
+            var existing = await base.Update(entity);
+            existing.AnnualStatisticGroupId = entity.AnnualStatisticGroupId;
+            existing.AnnualStatisticGroup = entity.AnnualStatisticGroup;
+            await _db.SaveChangesAsync();
+
+            return existing;
+        }
+    }
+}
+

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -254,7 +254,11 @@ namespace Biobanks.Submissions.Api
                     .AddTransient<IBiobankReadService, BiobankReadService>()
                     .AddTransient<IBiobankIndexService, BiobankIndexService>()
                     .AddTransient<ILogoStorageProvider, SqlServerLogoStorageProvider>();
-             //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
+                //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
+
+                // Reference Data
+                services
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AccessCondition>, AccessConditionService>();
 
             }
 

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -260,7 +260,8 @@ namespace Biobanks.Submissions.Api
                 services
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<AccessCondition>, AccessConditionService>()
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<AgeRange>, AgeRangeService>()
-                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AnnualStatistic>, AnnualStatisticService>();
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AnnualStatistic>, AnnualStatisticService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AnnualStatisticGroup>, AnnualStatisticGroupService>();
             }
 
 

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -258,8 +258,8 @@ namespace Biobanks.Submissions.Api
 
                 // Reference Data
                 services
-                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AccessCondition>, AccessConditionService>();
-
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AccessCondition>, AccessConditionService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AgeRange>, AgeRangeService>();
             }
 
 

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -259,7 +259,8 @@ namespace Biobanks.Submissions.Api
                 // Reference Data
                 services
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<AccessCondition>, AccessConditionService>()
-                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AgeRange>, AgeRangeService>();
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AgeRange>, AgeRangeService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<AnnualStatistic>, AnnualStatisticService>();
             }
 
 


### PR DESCRIPTION
## Overview

Port some ref data services to core:
- `AccessConditionService`
- `AgeRangeService`
- `AnnualStatisticService`
- `AnnualStatisticGroupService`

## Azure Boards

- [AB#76128](https://dev.azure.com/UniversityOfNottingham/DRS/_backlogs/backlog/ADAC0001%20-%20Biobanks/Epics/?workitem=76128)
- [AB#76149](https://dev.azure.com/UniversityOfNottingham/DRS/_backlogs/backlog/ADAC0001%20-%20Biobanks/Epics/?workitem=76149)
- [AB#76153](https://dev.azure.com/UniversityOfNottingham/DRS/_backlogs/backlog/ADAC0001%20-%20Biobanks/Epics/?workitem=76153)
- [AB#76152](https://dev.azure.com/UniversityOfNottingham/DRS/_backlogs/backlog/ADAC0001%20-%20Biobanks/Epics/?workitem=76152)
