### PR TITLE
AB#76189: Port more ref data services

### DIFF
--- a/src/Directory/Services/SampleCollectionModeService.cs
+++ b/src/Directory/Services/SampleCollectionModeService.cs
@@ -1,10 +1,14 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+        " Any changes made here will need to be made in the corresponding core version"
+        , false)]
     public class SampleCollectionModeService : ReferenceDataService<SampleCollectionMode>
     {
         public SampleCollectionModeService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/ServiceOfferingService.cs
+++ b/src/Directory/Services/ServiceOfferingService.cs
@@ -1,11 +1,15 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+        " Any changes made here will need to be made in the corresponding core version"
+        , false)]
     public class ServiceOfferingService : ReferenceDataService<ServiceOffering>
     {
         public ServiceOfferingService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/SexService.cs
+++ b/src/Directory/Services/SexService.cs
@@ -1,10 +1,14 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Shared.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+    " Any changes made here will need to be made in the corresponding core version"
+    , false)]
     public class SexService : ReferenceDataService<Sex>
     {
         public SexService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/SopStatusService.cs
+++ b/src/Directory/Services/SopStatusService.cs
@@ -1,10 +1,14 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Data.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+    " Any changes made here will need to be made in the corresponding core version"
+    , false)]
     public class SopStatusService : ReferenceDataService<SopStatus>
     {
         public SopStatusService(BiobanksDbContext db) : base(db) { }

--- a/src/Directory/Services/StorageTemperatureService.cs
+++ b/src/Directory/Services/StorageTemperatureService.cs
@@ -1,11 +1,15 @@
 ﻿using Biobanks.Directory.Data;
 using Biobanks.Entities.Shared.ReferenceData;
+using System;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Biobanks.Directory.Services
 {
+    [Obsolete("To be deleted when the Directory core version goes live." +
+    " Any changes made here will need to be made in the corresponding core version"
+    , false)]
     public class StorageTemperatureService : ReferenceDataService<StorageTemperature>
     {
         public StorageTemperatureService(BiobanksDbContext db) : base(db) { }

--- a/src/Submissions/Api/Services/Directory/SampleCollectionModeService.cs
+++ b/src/Submissions/Api/Services/Directory/SampleCollectionModeService.cs
@@ -1,0 +1,19 @@
+﻿using Biobanks.Data;
+using System.Threading.Tasks;
+using Biobanks.Entities.Data.ReferenceData;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class SampleCollectionModeService : ReferenceDataService<SampleCollectionMode>
+    {
+        public SampleCollectionModeService(BiobanksDbContext db) : base(db) { }
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.DiagnosisCapabilities.CountAsync(x => x.SampleCollectionModeId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.DiagnosisCapabilities.AnyAsync(x => x.SampleCollectionModeId == id);
+    }
+}
+

--- a/src/Submissions/Api/Services/Directory/ServiceOfferingService.cs
+++ b/src/Submissions/Api/Services/Directory/ServiceOfferingService.cs
@@ -1,0 +1,23 @@
+﻿using Biobanks.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Biobanks.Entities.Data.ReferenceData;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class ServiceOfferingService : ReferenceDataService<ServiceOffering>
+    {
+        public ServiceOfferingService(BiobanksDbContext db) : base(db) { }
+
+        protected override IQueryable<ServiceOffering> Query()
+            => base.Query().Include(x => x.OrganisationServiceOfferings);
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.OrganisationServiceOfferings.CountAsync(x => x.ServiceOfferingId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.OrganisationServiceOfferings.AnyAsync(x => x.ServiceOfferingId == id);
+    }
+}
+

--- a/src/Submissions/Api/Services/Directory/SexService.cs
+++ b/src/Submissions/Api/Services/Directory/SexService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Biobanks.Data;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Biobanks.Entities.Shared.ReferenceData;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class SexService : ReferenceDataService<Sex>
+    {
+        public SexService(BiobanksDbContext db) : base(db) { }
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.SampleSets.CountAsync(x => x.SexId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.SampleSets.AnyAsync(x => x.SexId == id);
+    }
+}
+

--- a/src/Submissions/Api/Services/Directory/SopStatusService.cs
+++ b/src/Submissions/Api/Services/Directory/SopStatusService.cs
@@ -1,0 +1,18 @@
+﻿using Biobanks.Data;
+using System.Threading.Tasks;
+using Biobanks.Entities.Data.ReferenceData;
+using Microsoft.EntityFrameworkCore;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class SopStatusService : ReferenceDataService<SopStatus>
+    {
+        public SopStatusService(BiobanksDbContext db) : base(db) { }
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.Networks.CountAsync(x => x.SopStatusId == id);
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.Networks.AnyAsync(x => x.SopStatusId == id);
+    }
+}

--- a/src/Submissions/Api/Services/Directory/StorageTemperatureService.cs
+++ b/src/Submissions/Api/Services/Directory/StorageTemperatureService.cs
@@ -1,8 +1,8 @@
-﻿using Biobanks.Data;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using System.Linq;
+using Biobanks.Data;
 using Biobanks.Entities.Shared.ReferenceData;
 using Microsoft.EntityFrameworkCore;
-using System.Linq;
 
 namespace Biobanks.Submissions.Api.Services.Directory
 {

--- a/src/Submissions/Api/Services/Directory/StorageTemperatureService.cs
+++ b/src/Submissions/Api/Services/Directory/StorageTemperatureService.cs
@@ -1,0 +1,22 @@
+﻿using Biobanks.Data;
+using System.Threading.Tasks;
+using Biobanks.Entities.Shared.ReferenceData;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace Biobanks.Submissions.Api.Services.Directory
+{
+    public class StorageTemperatureService : ReferenceDataService<StorageTemperature>
+    {
+        public StorageTemperatureService(BiobanksDbContext db) : base(db) { }
+
+        public override async Task<int> GetUsageCount(int id)
+            => await _db.SampleSets
+                .Include(x => x.MaterialDetails)
+                .CountAsync(x => x.MaterialDetails.Any(y => y.StorageTemperatureId == id));
+
+        public override async Task<bool> IsInUse(int id)
+            => await _db.MaterialDetails.AnyAsync(x => x.StorageTemperatureId == id);
+    }
+}
+

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -263,7 +263,7 @@ namespace Biobanks.Submissions.Api
                     .AddTransient<IIndexProvider, LegacyIndexProvider>()
                     .AddTransient<INetworkService, NetworkService>()
                     .AddTransient<IBiobankWriteService, BiobankWriteService>();
-              //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
+             //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
 
                 // Reference Data
                 services

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -263,7 +263,7 @@ namespace Biobanks.Submissions.Api
                     .AddTransient<IIndexProvider, LegacyIndexProvider>()
                     .AddTransient<INetworkService, NetworkService>()
                     .AddTransient<IBiobankWriteService, BiobankWriteService>();
-                //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
+              //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
 
                 // Reference Data
                 services
@@ -288,7 +288,6 @@ namespace Biobanks.Submissions.Api
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<Sex>, SexService>()
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<SopStatus>, SopStatusService>()
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<Entities.Shared.ReferenceData.StorageTemperature>, StorageTemperatureService>();
-                
 
             }
 

--- a/src/Submissions/Api/Startup.cs
+++ b/src/Submissions/Api/Startup.cs
@@ -46,6 +46,7 @@ using Biobanks.Submissions.Api.JsonConverters;
 using Core.Submissions.Models.OptionsModels;
 using Biobanks.Aggregator;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Submissions.Api.Services.Submissions.Contracts;
 using Biobanks.Submissions.Api.Services.Submissions;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
@@ -262,7 +263,7 @@ namespace Biobanks.Submissions.Api
                     .AddTransient<IIndexProvider, LegacyIndexProvider>()
                     .AddTransient<INetworkService, NetworkService>()
                     .AddTransient<IBiobankWriteService, BiobankWriteService>();
-             //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
+                //   .AddTransient<ElasticCapabilityIndexProvider, ICapabilityIndexProvider>();
 
                 // Reference Data
                 services
@@ -281,7 +282,13 @@ namespace Biobanks.Submissions.Api
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<County>, CountyService>()
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<DonorCount>, DonorCountService>()
                     .AddTransient<Services.Directory.Contracts.IReferenceDataService<Funder>, FunderService>()
-                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<MacroscopicAssessment>, MacroscopicAssessmentService>();
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<MacroscopicAssessment>, MacroscopicAssessmentService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<SampleCollectionMode>, SampleCollectionModeService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<ServiceOffering>, ServiceOfferingService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<Sex>, SexService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<SopStatus>, SopStatusService>()
+                    .AddTransient<Services.Directory.Contracts.IReferenceDataService<Entities.Shared.ReferenceData.StorageTemperature>, StorageTemperatureService>();
+                
 
             }
 


### PR DESCRIPTION
## Overview

Port further reference data services:

- `SampleCollectionModeService`
- `ServiceOfferingService`
- `SexService`
- `SopStatusService`
- `StorageTemperatureService`

## Azure Boards

- [AB#76189](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/76189)
- [AB#76192](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/76192)
- [AB#76193](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/76193)
- [AB#76194](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/76194)
- [AB#76196](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/76196)
