### PR TITLE
AB#79908: Fix build warnings

### DIFF
--- a/src/Entities/Data/Collection.cs
+++ b/src/Entities/Data/Collection.cs
@@ -28,6 +28,7 @@ namespace Biobanks.Entities.Data
 
         public bool FromApi { get; set; }
 
+        // TODO: Remove the nullable context when the whole project supports .net 5+.
         #nullable enable
         public string? Notes { get; set; }
         #nullable disable

--- a/src/Entities/Data/Collection.cs
+++ b/src/Entities/Data/Collection.cs
@@ -28,7 +28,9 @@ namespace Biobanks.Entities.Data
 
         public bool FromApi { get; set; }
 
+        #nullable enable
         public string? Notes { get; set; }
+        #nullable disable
 
         public int AccessConditionId { get; set; }
         public virtual AccessCondition AccessCondition { get; set; }

--- a/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
@@ -7,6 +7,7 @@ using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Services.Directory.Extensions;
 using Hangfire;
 using Microsoft.ApplicationInsights;
+// using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using System;
@@ -31,18 +32,22 @@ namespace Biobanks.Submissions.Api.Services.Directory
 
         private readonly IHostEnvironment _hostEnvironment;
 
+        private readonly TelemetryClient _telemetryClient;
+
         public BiobankIndexService(
             IReferenceDataService<DonorCount> donorCountService,
             IBiobankReadService biobankReadService,
             IIndexProvider indexProvider,
             ISearchProvider searchProvider,
-            IHostEnvironment hostEnvironment)
+            IHostEnvironment hostEnvironment,
+            TelemetryClient telemetryClient)
         {
             _donorCountService = donorCountService;
             _biobankReadService = biobankReadService;
             _indexProvider = indexProvider;
             _searchProvider = searchProvider;
             _hostEnvironment = hostEnvironment;
+            _telemetryClient = telemetryClient;
         }
 
         public async Task BuildIndex()
@@ -87,8 +92,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
                 }
                 catch (Exception e) when (e is IOException || e is HttpRequestException)
                 {
-                    var ai = new TelemetryClient();
-                    ai.TrackException(e);
+                    _telemetryClient.TrackException(e);
                     throw;
                 }
             }
@@ -115,8 +119,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
             catch (Exception e)
             {
                 // Log Error via Application Insights
-                var ai = new TelemetryClient();
-                ai.TrackException(e);
+                _telemetryClient.TrackException(e);
             }
 
             return null;

--- a/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
@@ -7,7 +7,6 @@ using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Services.Directory.Extensions;
 using Hangfire;
 using Microsoft.ApplicationInsights;
-// using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using System;

--- a/src/Submissions/Api/Services/Directory/Contracts/INetworkService.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/INetworkService.cs
@@ -71,7 +71,7 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// <param name="organisationId">The Id of the applicable Organisations</param>
         /// <param name="networkId">The Id of the applicable Network</param>
         /// <returns>The untracked OrganisationNetwork relationships</returns>
-        Task<OrganisationNetwork> GetOrganisationNetwork(int biobankId, int networkId);
+        Task<OrganisationNetwork> GetOrganisationNetwork(int organisationId, int networkId);
 
         /// <summary>
         /// Update an exisiting OrganisationNetwork relationship
@@ -147,6 +147,9 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// <summary>
         /// Add an Organisation to a Network
         /// </summary>
+        /// <param name="organisationId">The Id of the Organisation</param>
+        /// <param name="networkId">The Id of the Network</param>
+        /// <param name="organisationExternalId">The external Id of the Organisation</param>
         /// <param name="approve">Whether the request should be automatically be approved</param>
         /// <returns>true - Successfully added the Organisation to the Network</returns>
         Task<bool> AddOrganisationToNetwork(int organisationId, int networkId, string organisationExternalId, bool approve);

--- a/src/Submissions/Api/Services/Directory/Contracts/IOntologyTermService.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/IOntologyTermService.cs
@@ -77,6 +77,8 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// The tags to filter by. A null value will not filter by tag, where an empty list will only return
         /// untagged OntologyTerms. By default the value is null, hence tags as a filter will be ignored.
         /// </param>
+        /// <param name="onlyDisplayable">Whether to return only OntologyTerms that are displayable in the Directory</param>
+        /// <param name="filterById">Whether to filter by Id.</param>
         /// <returns>true - If at least one OntologyTerm exists that matches the given parameter filters</returns>
         Task<bool> Exists(string id = null, string value = null, List<string> tags = null, bool onlyDisplayable = false, bool filterById = true);
 

--- a/src/Submissions/Api/Services/Directory/Contracts/IOrganisationDirectoryService.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/IOrganisationDirectoryService.cs
@@ -47,7 +47,8 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         Task<IEnumerable<Organisation>> ListByExternalIds(IList<string> organisationExternalId);
 
         /// <summary>
-        /// Get all untracked Organisation which match are part of the given Netowrk
+        /// Get all untracked Organisation which match are part of the given Network
+        /// </summary>
         /// <param name="networkId">The Id of the Network to match against</param>
         /// <returns>An Enumerable of all applicable untracked Organisations</returns>
         Task<IEnumerable<Organisation>> ListByNetworkId(int networkId);
@@ -55,6 +56,7 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// <summary>
         /// Get all untracked Organisation which are under the control by the given User
         /// <param name="userId">The Id of the User to match against</param>
+        /// </summary>
         /// <returns>An Enumerable of all applicable untracked Organisations</returns>
         Task<IEnumerable<Organisation>> ListByUserId(string userId);
 
@@ -212,7 +214,7 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// </summary>
         /// <param name="funderId">The Id of the Funder being added</param>
         /// <param name="organisationId">The Id of the Organisation</param>
-        Task RemoveFunder(int funderId, int biobankId);
+        Task RemoveFunder(int funderId, int organisationId);
 
         /// <summary>
         /// Get the last active user for a given Organisation

--- a/src/Submissions/Api/Services/Directory/Contracts/IReferenceDataService.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/IReferenceDataService.cs
@@ -42,6 +42,7 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// <summary>
         /// Checks if an entity with given value exists
         /// </summary>
+        /// <param name="id">The Id of the Entity <typeparamref name="T"/></param>
         /// <param name="value">The descriptive value of the Entity <typeparamref name="T"/></param>
         /// <returns>true - If at least one entity exists with given descriptive value not equal to the Id</returns>
         Task<bool> ExistsExcludingId(int id, string value);


### PR DESCRIPTION
## Overview

Fixes misc build warnings across the new submissions api. These are mostly xml warnings and qol improvements.

The main change is moving the application insights telemtry to a singleton pattern, as the framework approach has been [deprecated](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152), and would cause memory leaks.

This also means using telemetry is consistent with other services, and can be injected when necesssary inside services.