### PR TITLE
AB#85160: Biobank Profile controller

### DIFF
--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -696,7 +696,7 @@ public class ProfileController : Controller
             try
             {
                 using var client = new HttpClient();
-                var buildUrl = new UriBuilder(await _configService.GetSiteConfigValue(ConfigKey.EpmcApiUrl))
+                var buildUrl = new UriBuilder(await _configService.GetSiteConfigValue(_siteConfig.EpmcApiUrl))
                
                 {
                     Query = $"query=ext_id:{publicationId} AND SRC:MED" +

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -46,6 +46,7 @@ public class ProfileController : Controller
     private readonly PublicationService _publicationService;
     private readonly RegistrationReasonService _registrationReasonService;
     private readonly ServiceOfferingService _serviceOfferingService;
+    private readonly SitePropertiesOptions _siteConfig;
     private readonly UserManager<ApplicationUser> _userManager;
 
     public ProfileController(
@@ -62,6 +63,7 @@ public class ProfileController : Controller
         PublicationService publicationService,
         RegistrationReasonService registrationReasonService,
         ServiceOfferingService serviceOfferingService,
+        SitePropertiesOptions siteConfig,
         UserManager<ApplicationUser> userManager)
     {
         _annualStatisticGroupService = annualStatisticGroupService;
@@ -77,6 +79,7 @@ public class ProfileController : Controller
         _publicationService = publicationService;
         _registrationReasonService = registrationReasonService;
         _serviceOfferingService = serviceOfferingService;
+        _siteConfig = siteConfig;
         _userManager = userManager;
     }
     
@@ -808,12 +811,12 @@ public class ProfileController : Controller
         });
 
     [HttpPost]
-    public async Task<JsonResult> UpdateAnnualStatAjax(AnnualStatModel model)
+    public async Task<JsonResult> UpdateAnnualStatAjax(AnnualStatModel model, int biobankId)
     {
         if (model.Year > DateTime.Now.Year)
             ModelState.AddModelError("", $"Year value for annual stat cannot be in the future.");
 
-        var annualStatsStartYear = int.Parse(ConfigurationManager.AppSettings["AnnualStatsStartYear"]);
+        var annualStatsStartYear = int.Parse(_siteConfig.AnnualStatsStartYear);
         if (model.Year < annualStatsStartYear)
             ModelState.AddModelError("", $"Year value for annual stat cannot be earlier than {annualStatsStartYear}");
 
@@ -833,7 +836,7 @@ public class ProfileController : Controller
 
         // no validation errors at this point, so proceed
         await _biobankWriteService.UpdateOrganisationAnnualStatisticAsync(
-            SessionHelper.GetBiobankId(Session),
+            biobankId,
             model.AnnualStatisticId,
             model.Value,
             model.Year);

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -715,10 +715,7 @@ public class ProfileController : Controller
                 e is JsonReaderException ||
                 e is UriFormatException)
             {
-                // Log Error via Application Insights
-                var ai = new TelemetryClient();
-                ai.TrackException(e);
-
+                
                 return null;
             }
 

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -462,19 +462,19 @@ public class ProfileController : Controller
         if (!HttpContext.Request.Form.Files.Any())
             return Json(new KeyValuePair<bool, string>(false, "No files found. Please select a new file and try again."));
 
-        var fileBase = HttpContext.Request.Form.Files["TempLogo"];
+        var formFile = HttpContext.Request.Form.Files["TempLogo"];
 
-        if (fileBase == null)
+        if (formFile == null)
             return Json(new KeyValuePair<bool, string>(false, "No files found. Please select a new file and try again."));
 
-        if (fileBase.Length > 1000000)
+        if (formFile.Length > 1000000)
             return Json(new KeyValuePair<bool, string>(false, "The file you supplied is too large. Logo image files must be 1Mb or less."));
         
          try
         {
-            if (fileBase.ValidateAsLogo())
+            if (formFile.ValidateAsLogo())
             {
-                var logoStream = fileBase.ToProcessableStream();
+                var logoStream = formFile.ToProcessableStream();
                 Session[TempBiobankLogoSessionId] =
                     ImageService.ResizeImageStream(logoStream, maxX: 300, maxY: 300)
                     .ToArray();
@@ -499,13 +499,14 @@ public class ProfileController : Controller
         return File((byte[])Session[TempBiobankLogoSessionId], Session[TempBiobankLogoContentTypeSessionId].ToString());
     }
 
-    [HttpPost]
-    [Authorize(Roles = "BiobankAdmin")]
-    public void RemoveTempLogo()
-    {
-        Session[TempBiobankLogoSessionId] = null;
-        Session[TempBiobankLogoContentTypeSessionId] = null;
-    }
+    // TODO: Replace session (this method is not used, so could alternatively be removed)
+    // [HttpPost]
+    // [Authorize(Roles = "BiobankAdmin")]
+    // public void RemoveTempLogo()
+    // {
+    //     Session[TempBiobankLogoSessionId] = null;
+    //     Session[TempBiobankLogoContentTypeSessionId] = null;
+    // }
     
     #endregion
 

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -689,7 +689,7 @@ public class ProfileController : Controller
             biobankPublications = _mapper.Map<List<BiobankPublicationModel>>(publications);
         }
 
-        return new Ok(biobankPublications);
+        return Ok(biobankPublications);
 
     }
 

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -6,6 +6,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using AutoMapper;
 using Biobanks.Entities.Data;
+using Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
 using Biobanks.Submissions.Api.Config;
 using Biobanks.Submissions.Api.Constants;
 using Biobanks.Submissions.Api.Models.Directory;
@@ -24,16 +25,29 @@ public class ProfileController : Controller
 {
     private readonly AnnualStatisticGroupService _annualStatisticGroupService;
     private readonly ConfigService _configService;
-    private readonly CountryService _countryService;
     private readonly CountyService _countyService;
+    private readonly CountryService _countryService;
     private readonly Mapper _mapper;
     private readonly NetworkService _networkService;
     private readonly OrganisationDirectoryService _organisationService;
     
-    
-    
-    public ProfileController()
+    public ProfileController(
+        AnnualStatisticGroupService annualStatisticGroupService,
+        ConfigService configService,
+        CountyService countyService,
+        CountryService countryService,
+        Mapper mapper,
+        NetworkService networkService,
+        OrganisationDirectoryService organisationService
+        )
     {
+        _annualStatisticGroupService = annualStatisticGroupService;
+        _configService = configService;
+        _countyService = countyService;
+        _countryService = countryService;
+        _mapper = mapper;
+        _networkService = networkService;
+        _organisationService = organisationService;
     }
 
     [Authorize(CustomClaimType.Biobank)]

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoMapper;
+using Biobanks.Entities.Data;
+using Biobanks.Submissions.Api.Config;
+using Biobanks.Submissions.Api.Constants;
+using Biobanks.Submissions.Api.Models.Directory;
+using Biobanks.Submissions.Api.Models.Shared;
+using Biobanks.Submissions.Api.Services.Directory;
+using Biobanks.Submissions.Api.Utilities;
+using Microsoft.ApplicationInsights;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace Biobanks.Submissions.Api.Areas.Biobank.Controllers;
+
+[Area("Biobank")]
+public class ProfileController : Controller
+{
+    private readonly AnnualStatisticGroupService _annualStatisticGroupService;
+    private readonly ConfigService _configService;
+    private readonly CountryService _countryService;
+    private readonly CountyService _countyService;
+    private readonly Mapper _mapper;
+    private readonly NetworkService _networkService;
+    private readonly OrganisationDirectoryService _organisationService;
+    
+    
+    
+    public ProfileController()
+    {
+    }
+
+    [Authorize(CustomClaimType.Biobank)]
+    public async Task<ActionResult> Index()
+    {
+        var model = await GetBiobankDetailsModelAsync();
+
+        var biobankId = SessionHelper.GetBiobankId(MetricDimensionNames.TelemetryContext.Session);
+
+        if (biobankId == 0)
+            return RedirectToAction("Index", "Home");
+
+        //for viewing details only, we include networks
+        var networks = await _networkService.ListByOrganisationId(biobankId);
+
+        model.AnnualStatisticGroups = await _annualStatisticGroupService.List();
+
+        model.NetworkModels = networks.Select(x => new NetworkMemberModel
+        {
+            Id = x.NetworkId,
+            Logo = x.Logo,
+            Name = x.Name
+        }).ToList();
+
+        return View(model);
+    }
+
+    private async Task<Organisation> EditBiobankDetails(BiobankDetailsModel model)
+    {
+        if (model.BiobankId == null) throw new ApplicationException();
+
+        var logoName = model.LogoName;
+
+        // if updating, try and upload a logo now (ensuring logoName is correct)
+        if (model.RemoveLogo)
+        {
+            logoName = null;
+            await _biobankWriteService.RemoveLogoAsync(model.BiobankId.Value);
+        }
+        else if (model.Logo != null)
+        {
+            try
+            {
+                var logoStream = model.Logo.ToProcessableStream();
+
+                logoName =
+                    await
+                        _biobankWriteService.StoreLogoAsync(
+                            logoStream,
+                            model.Logo.FileName,
+                            model.Logo.ContentType,
+                            model.BiobankExternalId);
+            }
+            catch (ArgumentNullException)
+            {
+            } //no problem, just means no logo uploaded in this form submission
+        }
+
+        var biobank = _mapper.Map<Organisation>(model);
+
+        //Update bits Automapper doesn't do
+        biobank.OrganisationRegistrationReasons = new List<OrganisationRegistrationReason>();
+        biobank.OrganisationServiceOfferings = new List<OrganisationServiceOffering>();
+
+        foreach (var rr in model.RegistrationReasons)
+        {
+            if (rr.Active)
+                biobank.OrganisationRegistrationReasons.Add(new OrganisationRegistrationReason
+                { OrganisationId = biobank.OrganisationId, RegistrationReasonId = rr.RegistrationReasonId });
+        }
+
+        foreach (var sm in model.ServiceModels)
+        {
+            if (sm.Active)
+                biobank.OrganisationServiceOfferings.Add(new OrganisationServiceOffering
+                { OrganisationId = biobank.OrganisationId, ServiceOfferingId = sm.ServiceOfferingId });
+        }
+
+        biobank.Logo = logoName;
+        return await _organisationService.Update(biobank);
+    }
+
+    private async Task<Organisation> CreateBiobank(BiobankDetailsModel model)
+    {
+        var biobank = await _organisationService.Create(_mapper.Map<OrganisationDTO>(model));
+        await _organisationService.AddUserToOrganisation(User.Identity.GetUserId(), biobank.OrganisationId);
+
+        //update the request to show org created
+        var request = await _organisationService.GetRegistrationRequestByEmail(User.Identity.Name);
+        request.OrganisationCreatedDate = DateTime.Now;
+        request.OrganisationExternalId = biobank.OrganisationExternalId;
+        await _organisationService.UpdateRegistrationRequest(request);
+
+        //add a claim now that they're associated with the biobank
+        _claimsManager.AddClaims(new List<Claim>
+                {
+                    new Claim(CustomClaimType.Biobank, JsonConvert.SerializeObject(new KeyValuePair<int, string>(biobank.OrganisationId, biobank.Name)))
+                });
+
+        Session[SessionKeys.ActiveOrganisationType] = ActiveOrganisationType.Biobank;
+        Session[SessionKeys.ActiveOrganisationId] = biobank.OrganisationId;
+        Session[SessionKeys.ActiveOrganisationName] = biobank.Name;
+
+        //Logo upload (now we have the id, we can form the filename)
+        if (model.Logo != null)
+        {
+            try
+            {
+                var logoStream = model.Logo.ToProcessableStream();
+
+                //use the DTO again to update
+                biobank.Logo = await
+                            _biobankWriteService.StoreLogoAsync(logoStream,
+                                model.Logo.FileName,
+                                model.Logo.ContentType,
+                                biobank.OrganisationExternalId);
+
+                biobank = await _organisationService.Update(biobank);
+            }
+            catch (ArgumentNullException)
+            {
+            } //no problem, just means no logo uploaded in this form submission
+
+        }
+
+
+        return biobank;
+    }
+
+    public async Task<ActionResult> Edit(bool detailsIncomplete = false)
+    {
+        var sampleResource = await _configService.GetSiteConfigValue(ConfigKey.SampleResourceName);
+
+        if (detailsIncomplete)
+            this.SetTemporaryFeedbackMessage("Please fill in the details below for your " + sampleResource + ". Once you have completed these, you'll be able to perform other administration tasks",
+                FeedbackMessageType.Info);
+
+        var activeOrganisationType = Convert.ToInt32(Session[SessionKeys.ActiveOrganisationType]);
+
+        return activeOrganisationType == (int)ActiveOrganisationType.NewBiobank
+            ? View(await NewBiobankDetailsModelAsync()) //no biobank id means we're dealing with a request
+            : View(await GetBiobankDetailsModelAsync()); //biobank id means we're dealing with an existing biobank
+    }
+
+    private async Task<BiobankDetailsModel> AddCountiesToModel(BiobankDetailsModel model)
+    {
+        model.Counties = await _countyService.List();
+        model.Countries = await _countryService.List();
+        return model;
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<ActionResult> Edit(BiobankDetailsModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            model = await AddCountiesToModel(model);
+            return View(model);
+        }
+
+        //Extra form validation that the model state can't do for us
+
+        //Logo, if any
+        try
+        {
+            model.Logo.ValidateAsLogo();
+        }
+        catch (BadImageFormatException ex)
+        {
+            model = await AddCountiesToModel(model);
+            ModelState.AddModelError("", ex.Message);
+            return View(model);
+        }
+
+        //URL, if any
+        try
+        {
+            model.Url = UrlTransformer.Transform(model.Url);
+        }
+        catch (InvalidUrlSchemeException e)
+        {
+            model = await AddCountiesToModel(model);
+            ModelState.AddModelError("", e.Message);
+            model = await AddCountiesToModel(model);
+            return View(model);
+        }
+        catch (UriFormatException)
+        {
+            model = await AddCountiesToModel(model);
+            ModelState.AddModelError("",
+                $"{model.Url} is not a valid URL.");
+            model = await AddCountiesToModel(model);
+            return View(model);
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.Url))
+        {
+            try
+            {
+                // Attempt to access the page and see if it returns 2xx code
+                // Automatically follows redirects (though the RFC says .NET Framework is being naughty by doing this!)
+                var response = await new HttpClient().GetAsync(model.Url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    ModelState.AddModelError(Empty, $"{model.Url} does not appear to be a valid URL.");
+                    model = await AddCountiesToModel(model);
+                    return View(model);
+                }
+            }
+            catch
+            {
+                ModelState.AddModelError(Empty, $"Could not access URL {model.Url}.");
+                model = await AddCountiesToModel(model);
+                return View(model);
+            }
+        }
+
+        //Create or Edit the biobank details
+        Organisation biobank;
+        if (model.BiobankId == null) biobank = await CreateBiobank(model);
+        else biobank = await EditBiobankDetails(model);
+
+
+        //stuff that happens regardless of create/update (but requires id to be populated, so has to be done after the above)
+
+        //Add/Delete Services
+        var activeServices =
+            model.ServiceModels.Where(x => x.Active).Select(x => new OrganisationServiceOffering
+            {
+                ServiceOfferingId = x.ServiceOfferingId,
+                OrganisationId = biobank.OrganisationId
+            }).ToList();
+
+        await _biobankWriteService.AddBiobankServicesAsync(activeServices);
+
+        foreach (var inactiveService in model.ServiceModels.Where(x => !x.Active))
+        {
+            await
+                _biobankWriteService.DeleteBiobankServiceAsync(biobank.OrganisationId,
+                    inactiveService.ServiceOfferingId);
+        }
+
+        //Add/Delete registration reasons
+        var activeRegistrationReasons =
+            model.RegistrationReasons.Where(x => x.Active).Select(x => new OrganisationRegistrationReason
+            {
+                RegistrationReasonId = x.RegistrationReasonId,
+                OrganisationId = biobank.OrganisationId
+            }).ToList();
+
+        await _biobankWriteService.AddBiobankRegistrationReasons(activeRegistrationReasons);
+
+        foreach (var inactiveRegistrationReason in model.RegistrationReasons.Where(x => !x.Active))
+        {
+            await
+                _biobankWriteService.DeleteBiobankRegistrationReasonAsync(biobank.OrganisationId,
+                    inactiveRegistrationReason.RegistrationReasonId);
+        }
+        var sampleResource = await _configService.GetSiteConfigValue(ConfigKey.SampleResourceName);
+        this.SetTemporaryFeedbackMessage(sampleResource + " details updated!", FeedbackMessageType.Success);
+
+        //Back to the profile to view your saved changes
+        return RedirectToAction("Index");
+    }
+
+    private async Task<List<OrganisationServiceModel>> GetAllServicesAsync()
+    {
+        var allServices = await _serviceOfferingService.List();
+
+        return allServices.Select(service => new OrganisationServiceModel
+        {
+            Active = false,
+            ServiceOfferingName = service.Value,
+            ServiceOfferingId = service.Id,
+            SortOrder = service.SortOrder
+        })
+        .OrderBy(x => x.SortOrder)
+        .ToList();
+    }
+
+    private async Task<List<OrganisationRegistrationReasonModel>> GetAllRegistrationReasonsAsync()
+    {
+        var allRegistrationReasons = await _registrationReasonService.List();
+
+        return allRegistrationReasons.Select(regReason => new OrganisationRegistrationReasonModel
+        {
+            Active = false,
+            RegistrationReasonName = regReason.Value,
+            RegistrationReasonId = regReason.Id
+        })
+        .ToList();
+    }
+
+    private async Task<BiobankDetailsModel> NewBiobankDetailsModelAsync()
+    {
+        //the biobank doesn't exist yet, but a request should, so we can get the name
+        var request = await _organisationService.GetRegistrationRequest(SessionHelper.GetBiobankId(MetricDimensionNames.TelemetryContext.Session));
+
+        //validate that the request is accepted
+        if (request.AcceptedDate == null) return null;
+
+        var model = new BiobankDetailsModel
+        {
+            OrganisationName = request.OrganisationName,
+            ServiceModels = await GetAllServicesAsync(),
+            RegistrationReasons = await GetAllRegistrationReasonsAsync(),
+            Counties = await _countyService.List(),
+            Countries = await _countryService.List()
+        };
+
+        model = await AddCountiesToModel(model);
+
+        return model;
+    }
+
+    private async Task<BiobankDetailsModel> GetBiobankDetailsModelAsync()
+    {
+        //having a biobankId claim means we can definitely get a biobank for that claim and return a model for that
+        var bb = await _organisationService.Get(SessionHelper.GetBiobankId(MetricDimensionNames.TelemetryContext.Session));
+
+        //Try and get any service offerings for this biobank
+        var bbServices =
+                await _biobankReadService.ListBiobankServiceOfferingsAsync(bb.OrganisationId);
+
+        //mark services as active in the full list
+        var services = (await GetAllServicesAsync()).Select(service =>
+        {
+            service.Active = bbServices.Any(x => x.ServiceOfferingId == service.ServiceOfferingId);
+            return service;
+        }).ToList();
+
+        //Try and get any registration reasons for this biobank
+        var bbRegistrationReasons =
+                await _organisationService.ListRegistrationReasons(bb.OrganisationId);
+
+        //mark services as active in the full list
+        var registrationReasons = (await GetAllRegistrationReasonsAsync()).Select(regReason =>
+        {
+            regReason.Active = bbRegistrationReasons.Any(x => x.RegistrationReasonId == regReason.RegistrationReasonId);
+            return regReason;
+        }).ToList();
+
+        var model = new BiobankDetailsModel
+        {
+            BiobankId = bb.OrganisationId,
+            BiobankExternalId = bb.OrganisationExternalId,
+            OrganisationTypeId = bb.OrganisationTypeId,
+            AccessConditionId = bb.AccessConditionId,
+            CollectionTypeId = bb.CollectionTypeId,
+            OrganisationName = bb.Name,
+            Description = bb.Description,
+            Url = bb.Url,
+            LogoName = bb.Logo,
+            ContactEmail = bb.ContactEmail,
+            ContactNumber = bb.ContactNumber,
+            AddressLine1 = bb.AddressLine1,
+            AddressLine2 = bb.AddressLine2,
+            AddressLine3 = bb.AddressLine3,
+            AddressLine4 = bb.AddressLine4,
+            City = bb.City,
+            CountyId = bb.County?.Id,
+            CountryId = bb.Country.Id,
+            CountyName = bb.County?.Value,
+            CountryName = bb.Country.Value,
+            Postcode = bb.PostCode,
+            GoverningInstitution = bb.GoverningInstitution,
+            GoverningDepartment = bb.GoverningDepartment,
+            ServiceModels = services,
+            RegistrationReasons = registrationReasons,
+            Counties = await _countyService.List(),
+            Countries = await _countryService.List(),
+            SharingOptOut = bb.SharingOptOut,
+            EthicsRegistration = bb.EthicsRegistration,
+            BiobankAnnualStatistics = bb.OrganisationAnnualStatistics,
+            OtherRegistrationReason = bb.OtherRegistrationReason
+        };
+
+        model = await AddCountiesToModel(model);
+
+        return model;
+    }
+    
+}

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -175,10 +175,10 @@ public class ProfileController : Controller
         await _organisationService.UpdateRegistrationRequest(request);
 
         //add a claim now that they're associated with the biobank
-        _userManager.AddClaimsAsync(await _userManager.GetUserAsync(User),new List<Claim>
-                {
-                    new Claim(CustomClaimType.Biobank, JsonConvert.SerializeObject(new KeyValuePair<int, string>(biobank.OrganisationId, biobank.Name)))
-                });
+        await _userManager.AddClaimsAsync(await _userManager.GetUserAsync(User),new List<Claim>
+        {
+            new Claim(CustomClaimType.Biobank, JsonConvert.SerializeObject(new KeyValuePair<int, string>(biobank.OrganisationId, biobank.Name)))
+        });
 
         //Logo upload (now we have the id, we can form the filename)
         if (model.Logo != null)

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -457,7 +457,7 @@ public class ProfileController : Controller
     #region Temp Logo Management
     
     [HttpPost]
-    public JsonResult AddTempLogo()
+    public ActionResult AddTempLogo()
     {
         if (!HttpContext.Request.Form.Files.Any())
             return Json(new KeyValuePair<bool, string>(false, "No files found. Please select a new file and try again."));
@@ -475,29 +475,31 @@ public class ProfileController : Controller
             if (formFile.ValidateAsLogo())
             {
                 var logoStream = formFile.ToProcessableStream();
-                Session[TempBiobankLogoSessionId] =
-                    ImageService.ResizeImageStream(logoStream, maxX: 300, maxY: 300)
-                    .ToArray();
-                Session[TempBiobankLogoContentTypeSessionId] = fileBaseWrapper.ContentType;
+                // TODO: Replace Session
+                // Session[TempBiobankLogoSessionId] =
+                //     ImageService.ResizeImageStream(logoStream, maxX: 300, maxY: 300)
+                //     .ToArray();
+                // Session[TempBiobankLogoContentTypeSessionId] = fileBaseWrapper.ContentType;
 
                 return
-                    Json(new KeyValuePair<bool, string>(true,
+                    Ok(new KeyValuePair<bool, string>(true,
                         Url.Action("TempLogo", "Profile")));
             }
         }
         catch (BadImageFormatException e)
         {
-            return Json(new KeyValuePair<bool, string>(false, e.Message));
+            return Ok(new KeyValuePair<bool, string>(false, e.Message));
         }
 
-        return Json(new KeyValuePair<bool, string>(false, "No files found. Please select a new file and try again."));
+        return Ok(new KeyValuePair<bool, string>(false, "No files found. Please select a new file and try again."));
     }
 
-    [HttpGet]
-    public ActionResult TempLogo(string id)
-    {
-        return File((byte[])Session[TempBiobankLogoSessionId], Session[TempBiobankLogoContentTypeSessionId].ToString());
-    }
+    // TODO: Replace Session
+    // [HttpGet]
+    // public ActionResult TempLogo(string id)
+    // {
+    //     return File((byte[])Session[TempBiobankLogoSessionId], Session[TempBiobankLogoContentTypeSessionId].ToString());
+    // }
 
     // TODO: Replace session (this method is not used, so could alternatively be removed)
     // [HttpPost]

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/AddFunderModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/AddFunderModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class AddFunderModel
+{
+    [DisplayName("Funder Name")]
+    [Required]
+    public string FunderName { get; set; }
+
+    public string BiobankName { get; set; }
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/AnnualStatModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/AnnualStatModel.cs
@@ -1,0 +1,8 @@
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class AnnualStatModel
+{
+    public int AnnualStatisticId { get; set; }
+    public int Year { get; set; }
+    public int? Value { get; set; }
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/BiobankAnnualStatsModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/BiobankAnnualStatsModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Biobanks.Entities.Data;
+using Biobanks.Entities.Data.ReferenceData;
+
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class BiobankAnnualStatsModel
+{
+    public IEnumerable<AnnualStatisticGroup> AnnualStatisticGroups { get; set; }
+    public ICollection<OrganisationAnnualStatistic> BiobankAnnualStatistics { get; set; }
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/BiobankDetailsModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/BiobankDetailsModel.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Biobanks.Entities.Data;
+using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Submissions.Api.Models;
+using Biobanks.Submissions.Api.Models.Shared;
+using Microsoft.AspNetCore.Http;
+
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class BiobankDetailsModel
+{
+    //non editable stuff that stays the same for edit / empty for create
+        public int? BiobankId { get; set; } //nullable to allow for creation of new?
+        public string BiobankExternalId { get; set; }
+        public int? OrganisationTypeId { get; set; }
+
+        public int? AccessConditionId { get; set; }
+
+        public int? CollectionTypeId { get; set; }
+
+        [Required(ErrorMessage = "Please enter the name of the resource.")]
+        [MaxLength(100, ErrorMessage = ModelErrors.MaxLength)]
+        [Display(Name = "Name")]
+        public string OrganisationName { get; set; }
+
+        [Required(ErrorMessage = "Please enter a description of the resource.")]
+        [DataType(DataType.MultilineText)]
+        public string Description { get; set; }
+
+        [DataType(DataType.Url)]
+        [Display(Name = "URL")]
+        public string Url { get; set; }
+
+        [Required(ErrorMessage = "Please enter a contact email address.")]
+        [DataType(DataType.EmailAddress)]
+        [EmailAddress]
+        [Display(Name = "Contact email")]
+        public string ContactEmail { get; set; }
+
+        [DataType(DataType.PhoneNumber)]
+        [Phone]
+        [Display(Name = "Contact phone number")]
+        public string ContactNumber { get; set; }
+
+        [DataType(DataType.Upload)]
+        public IFormFile Logo { get; set; } //how do file uploads work? http://cpratt.co/file-uploads-in-asp-net-mvc-with-view-models/
+        public string LogoName { get; set; } //used to display an already stored logo
+        public bool RemoveLogo { get; set; }
+
+        //Address
+        [Required(ErrorMessage = "Please enter the first line of the resource's address.")]
+        [Display(Name = "Address")] //Only provide a display name for the first line which is mandatory
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; } //don't bother labelling the optional lines
+        public string AddressLine3 { get; set; }
+        public string AddressLine4 { get; set; }
+
+        [Required(ErrorMessage = "Please enter the name of a city.")]
+        public string City { get; set; }
+
+        [Display(Name = "County")]
+        public int? CountyId { get; set; }
+
+        [Display(Name = "County")]
+        public string CountyName { get; set; }
+
+
+        [Required(ErrorMessage = "Please enter a postcode.")]
+        [DataType(DataType.PostalCode)]
+        public string Postcode { get; set; }
+
+        [Required(ErrorMessage = "Please select a country.")]
+        [Display(Name = "Country")]
+        public int? CountryId { get; set; }
+
+        [Display(Name = "Country")]
+        public string CountryName { get; set; }
+
+
+        //Governing Body
+        [Required(ErrorMessage = "Please enter the name of the resource's governing institution.")]
+        [MaxLength(100, ErrorMessage = ModelErrors.MaxLength)]
+        [Display(Name = "Institution")]
+        public string GoverningInstitution { get; set; }
+        [MaxLength(100, ErrorMessage = ModelErrors.MaxLength)]
+        [Display(Name = "School / Department")]
+        public string GoverningDepartment { get; set; }
+
+        [Display(Name = "Ethics Registration")]
+        [MaxLength(100, ErrorMessage = ModelErrors.MaxLength)] //consider more accurate validation?
+        public string EthicsRegistration { get; set; }
+
+        [Display(Name = "Opt out of sharing data with other directories")]
+        public bool SharingOptOut { get; set; }
+
+        [Display(Name = "Other")]
+        public string OtherRegistrationReason { get; set; }
+
+        public ICollection<OrganisationServiceModel> ServiceModels { get; set; }
+
+        public ICollection<OrganisationRegistrationReasonModel> RegistrationReasons { get; set; }
+
+        public ICollection<NetworkMemberModel> NetworkModels { get; set; }
+
+        public ICollection<County> Counties { get; set; }
+        public ICollection<Country> Countries { get; set; }
+
+        public IEnumerable<AnnualStatisticGroup> AnnualStatisticGroups { get; set; }
+        public ICollection<OrganisationAnnualStatistic> BiobankAnnualStatistics { get; set; }
+    
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/BiobankFundersModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/BiobankFundersModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Biobanks.Submissions.Api.Areas.Admin.Models;
+
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class BiobankFundersModel
+{
+    public int BiobankId { get; set; }
+    public ICollection<FunderModel> Funders { get; set; }
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/OrganisationRegistrationReasonModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/OrganisationRegistrationReasonModel.cs
@@ -1,0 +1,11 @@
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class OrganisationRegistrationReasonModel
+{
+    public int RegistrationReasonId { get; set; }
+
+    public string RegistrationReasonName { get; set; }
+
+    public bool Active { get; set; }
+    
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/OrganisationServiceModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/OrganisationServiceModel.cs
@@ -1,0 +1,12 @@
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class OrganisationServiceModel
+{
+    public int ServiceOfferingId { get; set; }
+
+    public string ServiceOfferingName { get; set; }
+
+    public bool Active { get; set; }
+
+    public int SortOrder { get; set; }
+}

--- a/src/Submissions/Api/Areas/Biobank/Models/Profile/PublicationSearchModel.cs
+++ b/src/Submissions/Api/Areas/Biobank/Models/Profile/PublicationSearchModel.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace Biobanks.Submissions.Api.Areas.Biobank.Models.Profile;
+
+public class PublicationSearchModel
+{
+    [JsonProperty("id")]
+    public string PublicationId { get; set; }
+
+    public string Title { get; set; }
+
+    [JsonProperty("authorString")]
+    public string Authors { get; set; }
+
+    [JsonProperty("journalTitle")]
+    public string Journal { get; set; }
+
+    [JsonProperty("pubYear")]
+    public int Year { get; set; }
+
+    public string DOI { get; set; }
+
+    public string Source { get; set; }
+    
+}

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/AnnualStats.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/AnnualStats.cshtml
@@ -1,0 +1,75 @@
+@inject IOptions<SitePropertiesOptions> _options;
+
+@using Biobanks.Submissions.Api.Config
+@using Microsoft.Extensions.Options
+@model Biobanks.Submissions.Api.Areas.Biobank.Models.Profile.BiobankAnnualStatsModel
+@{
+    ViewBag.Title = "Annual Stats";
+}
+
+<partial name = "_BiobankTabs" model ="Annual Stats" />
+
+<h3>
+    @ViewBag.Title
+</h3>
+
+<div class="row">
+    <div class="alert alert-info feedback-message annualstats-feedback" role="alert">
+        Changes are saved automatically.
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th rowspan="2">Year</th>
+                    @foreach (var annualStatsGroup in Model.AnnualStatisticGroups)
+                    {
+                        <th colspan="@(annualStatsGroup.AnnualStatistics.Count)" class="text-center">@annualStatsGroup.Value</th>
+                    }
+                </tr>
+
+                <tr>
+                    @foreach (var annualStatsGroup in Model.AnnualStatisticGroups)
+                    {
+                        foreach (var annualStat in annualStatsGroup.AnnualStatistics)
+                        {
+                            <th class="text-center">@annualStat.Value</th>
+                        }
+                    }
+                </tr>
+            </thead>
+
+            <tbody>
+                @for (var year = int.Parse(_options.Value.AnnualStatsStartYear); year <= DateTime.Now.Year; year++)
+                {
+                    <tr>
+                        <td>@year</td>
+                        @foreach (var annualStatsGroup in Model.AnnualStatisticGroups)
+                        {
+                            foreach (var annualStat in annualStatsGroup.AnnualStatistics)
+                            {
+                                var statValue = Model.BiobankAnnualStatistics.FirstOrDefault(bas => bas.AnnualStatisticId == annualStat.Id && bas.Year == year)?.Value;
+                                <td class="text-center">
+                                    <input type="number" min="0" class="form-control annualstats-input" data-year="@year" data-statistic="@annualStat.Id" value="@statValue" />
+                                </td>
+                            }
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@section FooterScripts
+{
+    <script type="text/javascript">
+        var annualStatUpdateUrl = "@Url.Action("UpdateAnnualStatAjax")";
+    </script>
+    
+    <script src="~/dist/js/Biobank/annualstats.min.js" asp-append-version="true"></script>
+    
+}

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Edit.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Edit.cshtml
@@ -1,0 +1,286 @@
+@inject Biobanks.Submissions.Api.Services.Directory.IConfigService _config
+
+@using Biobanks.Submissions.Api.Config
+@model Biobanks.Submissions.Api.Areas.Biobank.Models.Profile.BiobankDetailsModel;
+
+@{
+    ViewBag.Title = "Edit " + await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " details";
+}
+
+<h2>Edit @await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) details</h2>
+
+@using (Html.BeginForm("Edit", "Profile",
+    FormMethod.Post,
+    new { @class = "form-horizontal", enctype = "multipart/form-data" }))
+{
+    @Html.AntiForgeryToken()
+
+    @Html.HiddenFor(x => x.BiobankId)
+    @Html.HiddenFor(x => x.BiobankExternalId)
+    @Html.HiddenFor(x => x.OrganisationTypeId)
+    @Html.HiddenFor(x => x.LogoName)
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.OrganisationName, new { @class = "required" })
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-name"></span>
+        </div>
+
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.OrganisationName, new { @class = "form-control" })
+            @Html.ValidationMessageFor(x => x.OrganisationName)
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.Description, new { @class = "required" })
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-description"></span>
+        </div>
+
+        <div class="col-sm-6">
+            @Html.TextAreaFor(x => x.Description, new { @class = "form-control", rows = 5 })
+            @Html.ValidationMessageFor(x => x.Description)
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.Url)
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-url"></span>
+        </div>
+
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.Url, new { @class = "form-control" })
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.ContactEmail, new { @class = "required" })
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-contactemail"></span>
+        </div>
+
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.ContactEmail, new { @class = "form-control", type = "email" })
+            @Html.ValidationMessageFor(x => x.ContactEmail)
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.ContactNumber)
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-contactnumber"></span>
+        </div>
+
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.ContactNumber, new { @class = "form-control", type = "tel" })
+            @Html.ValidationMessageFor(x => x.ContactNumber)
+        </div>
+    </div>
+
+    <div class="form-group">
+        @Html.LabelFor(x => x.Logo, new { @class = "col-sm-3 control-label" })
+
+        <div class="col-sm-6">
+            <div class="padded-logo">
+                @if (string.IsNullOrEmpty(Model.LogoName))
+                {
+                    <img class="logo-img bordered-logo" id="TempBiobankLogo" src="@Url.Content("~/Content/images/NoLogo.png")" alt="Biobank Logo" />
+                }
+                else
+                {
+                    <img class="logo-img bordered-logo" id="TempBiobankLogo" src="@Url.Action("Index", "Logo", new {logoName = Model.LogoName})" alt="Biobank Logo" />
+                }
+            </div>
+
+            <div id="BiobankLogoUploadError" class="alert alert-danger" role="alert" style="margin-bottom: 20px; display: none;">Error Message Will Go Here!</div>
+
+            @Html.EditorFor(x => x.Logo, new { @class = "form-control" })
+            <button type="button" id="BiobankLogoFileDialogueTrigger" class="btn btn-success">Select New Logo</button>
+            <button type="button" id="RemoveBiobankLogoTrigger" class="btn btn-default">Remove Logo</button>
+            @Html.HiddenFor(x => x.RemoveLogo)
+        </div>
+    </div>
+
+    <h4>Address Details <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-address"></span></h4>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.AddressLine1, new { @class = "required" })
+
+        </div>
+
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.AddressLine1, new { @class = "form-control" })
+            @Html.ValidationMessageFor(x => x.AddressLine1)
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-6">
+            @Html.TextBoxFor(x => x.AddressLine2, new { @class = "form-control" })
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-6">
+            @Html.TextBoxFor(x => x.AddressLine3, new { @class = "form-control" })
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-6">
+            @Html.TextBoxFor(x => x.AddressLine4, new { @class = "form-control" })
+        </div>
+    </div>
+
+    <div class="form-group">
+        @Html.LabelFor(x => x.City, new { @class = "col-sm-3 control-label required" })
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.City, new { @class = "form-control" })
+            @Html.ValidationMessageFor(x => x.City)
+        </div>
+    </div>
+
+    if (await _config.GetSiteConfigValue(ConfigKey.ShowCounties) == "true")
+    {
+        <div class="form-group">
+            @Html.LabelFor(x => x.CountyId, new { @class = "col-sm-3 control-label required" })
+            <div class="col-sm-6">
+                @Html.DropDownListFor(x => x.CountyId, new SelectList(items: Model.Counties.OrderBy(x => x.Country.Value).ThenBy(x => x.Value), dataValueField: "Id", dataTextField: "Value", dataGroupField: "Country.Value", selectedValue: null), "Select County", new { @class = "form-control" })
+                @Html.ValidationMessageFor(x => x.CountyId)
+            </div>
+        </div>
+
+        <div class="form-group">
+            @Html.LabelFor(x => x.CountryId, new { @class = "col-sm-3 control-label required" })
+            <div class="col-sm-6">
+                @Html.DropDownListFor(x => x.CountryId, new SelectList(Model.Countries, "Id", "Value"), "Select Country", new { @class = "form-control" })
+                @Html.ValidationMessageFor(x => x.CountryId)
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="form-group">
+            @Html.LabelFor(x => x.CountryId, new { @class = "col-sm-3 control-label required" })
+            <div class="col-sm-6">
+                @Html.DropDownListFor(x => x.CountryId, new SelectList(Model.Countries, "Id", "Value"), "Select Country", new { @class = "form-control" })
+                @Html.ValidationMessageFor(x => x.CountryId)
+            </div>
+        </div>
+    }
+
+
+    <div class="form-group">
+        @Html.LabelFor(x => x.Postcode, new { @class = "col-sm-3 control-label required" })
+        <div class="col-sm-2">
+            @Html.TextBoxFor(x => x.Postcode, new { @class = "form-control" })
+            @Html.ValidationMessageFor(x => x.Postcode)
+        </div>
+    </div>
+
+    <h4>Governance Compliance</h4>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.GoverningInstitution, new { @class = "required" })
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-institution"></span>
+        </div>
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.GoverningInstitution, new { @class = "form-control" })
+            @Html.ValidationMessageFor(x => x.GoverningInstitution)
+        </div>
+    </div>
+
+    <div class="form-group">
+        @Html.LabelFor(x => x.GoverningDepartment, new { @class = "col-sm-3 control-label" })
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.GoverningDepartment, new { @class = "form-control" })
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @*@Html.LabelFor(x => x.EthicsRegistration)*@
+            <label id="EthicsRegistration">@await _config.GetSiteConfigValue(ConfigKey.EthicsFieldName)</label>
+            <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-ethicsregistration"></span>
+        </div>
+
+        <div class="col-sm-6">
+
+            @if (await _config.GetSiteConfigValue(ConfigKey.EthicsFieldIsCheckbox) == "true")
+            {
+                @*uncheck is simply a null value, otherwise checked is given text TRUE*@
+                <input checked="@(!String.IsNullOrEmpty(Model.EthicsRegistration)? "checked" : null)"
+                       id="EthicsRegistration"
+                       name="EthicsRegistration"
+                       type="checkbox"
+                       value="TRUE" />
+            }
+            else //free text
+            {
+                @Html.TextBoxFor(x => x.EthicsRegistration, new { @class = "form-control" })
+            }
+
+        </div>
+    </div>
+
+    <h4>Services <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-services"></span></h4>
+
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-4">
+            @Html.EditorFor(x => x.ServiceModels)
+        </div>
+    </div>
+
+    if (await _config.GetSiteConfigValue(ConfigKey.EnableDataSharing) == "true")
+    {
+        <h4>Data sharing settings <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-datasharingsettings"></span></h4>
+
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-4">
+                <div class="checkbox">
+                    <label>
+                        @Html.CheckBoxFor(x => x.SharingOptOut)
+                        @Html.DisplayNameFor(x => x.SharingOptOut)
+                    </label>
+                </div>
+            </div>
+        </div>
+    }
+
+    <h4>Reasons for Registering <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-resource-reasonsforregistering"></span></h4>
+
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-6">
+            @Html.EditorFor(x => x.RegistrationReasons)
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-3 control-label">
+            @Html.LabelFor(x => x.OtherRegistrationReason)
+        </div>
+        <div class="col-sm-6">
+            @Html.TextBoxFor(x => x.OtherRegistrationReason, new { @class = "form-control" })
+            @Html.ValidationMessageFor(x => x.OtherRegistrationReason)
+        </div>
+    </div>
+
+    @Html.HiddenFor(x => x.AccessConditionId)
+    @Html.HiddenFor(x => x.CollectionTypeId)
+
+    @* TODO: 'other' registration reason *@
+
+    <div class="form-group">
+        <div class="col-sm-12 text-center">
+            @Html.ActionLink("Cancel", "Index", null, new { @class = "btn btn-default" })
+            <button type="submit" class="btn btn-primary">Update details</button>
+        </div>
+    </div>
+}
+
+@section FooterScripts
+{
+    <script src="~/dist/js/Biobank/edit-details.min.js" asp-append-version="true"></script>
+    <script src="~/dist/js/Biobank/help-buttons.min.js" asp-append-version="true"></script>
+}

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Funders.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Funders.cshtml
@@ -1,0 +1,65 @@
+
+@model Biobanks.Submissions.Api.Areas.Biobank.Models.Profile.BiobankFundersModel;
+
+@{
+    ViewBag.Title = "Funders";
+}
+
+<partial name = "_BiobankTabs" model ="Funders" />
+
+<h3>Funders <a href="#" class="btn btn-success pull-right" data-toggle="modal" data-target="#modalAddBiobankFunder" data-bind="click: openAddFunderDialog">Add new funder</a></h3>
+
+<span id="BiobankId" data-biobank-id="@Model.BiobankId"></span>
+
+<div class="row">
+    <div class="col-sm-12">
+        <br />
+        @if (Model.Funders.Any())
+        {
+            <table id="biobank-funders" class="table table-striped">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th></th>
+                </tr>
+                </thead>
+
+                <tbody>
+                @foreach (var funder in Model.Funders)
+                {
+                    <tr>
+                        <td>
+                            <span class="fa fa-user labelled-icon"></span>
+                            @funder.Name
+                        </td>
+                        <td>
+                            <div class="pull-right">
+                                <a href="@Url.Action("DeleteFunder", new {funderId = funder.FunderId, funderName = funder.Name})"
+                                   class="confirm-delete"
+                                   data-funder-name="@funder.Name">
+                                    <span class="fa fa-trash labelled-icon"></span>Delete
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+                }
+
+                </tbody>
+            </table>
+        }
+        else
+        {
+            <div class="alert alert-info">
+                There are no funders here yet.
+                <a href="#" data-toggle="modal" data-target="#modalAddBiobankFunder" data-bind="click: openAddFunderDialog">Add a funder now</a>
+            </div>
+        }
+    </div>
+</div>
+
+<div id="modalAddBiobankFunder" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modalAddBiobankFunder_Label"></div>
+
+@section FooterScripts
+{
+    <script src="~/dist/js/Biobank/funders.min.js" asp-append-version="true"></script>
+}

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Index.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Index.cshtml
@@ -8,7 +8,7 @@
     ViewBag.Title = await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " details";
 }
 
-@Html.Partial("_BiobankTabs", await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " Details")
+<partial name = "_BiobankTabs" model = @ViewBag.Title />
 
 <h3>@await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) details @Html.ActionLink("Edit " + await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " details", "Edit", null, new { @class = "btn btn-primary pull-right" })</h3>
 

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Index.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Index.cshtml
@@ -1,0 +1,131 @@
+
+@inject Biobanks.Submissions.Api.Services.Directory.IConfigService _config
+
+@using Biobanks.Submissions.Api.Config
+@model Biobanks.Submissions.Api.Areas.Biobank.Models.Profile.BiobankDetailsModel;
+
+@{
+    ViewBag.Title = await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " details";
+}
+
+@Html.Partial("_BiobankTabs", await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " Details")
+
+<h3>@await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) details @Html.ActionLink("Edit " + await _config.GetSiteConfigValue(ConfigKey.SampleResourceName) + " details", "Edit", null, new { @class = "btn btn-primary pull-right" })</h3>
+
+<div class="row">
+    <div class="col-sm-12">
+        <br />
+
+        <dl class="dl-horizontal">
+            <dt class="form-group">@Html.DisplayNameFor(x => x.OrganisationName)</dt>
+            <dd>@Html.DisplayFor(x => x.OrganisationName)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.Description)</dt>
+            <dd class="description">@Html.DisplayFor(x => x.Description)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.Url)</dt>
+            <dd>@Html.DisplayFor(x => x.Url)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.ContactEmail)</dt>
+            <dd>@Html.DisplayFor(x => x.ContactEmail)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.ContactNumber)</dt>
+            <dd>@Html.DisplayFor(x => x.ContactNumber)</dd>
+
+            @if (!string.IsNullOrEmpty(Model.LogoName))
+            {
+                <dt class="form-group">@Html.DisplayNameFor(x => x.Logo)</dt>
+                <dd class="padded-logo">
+                    <img class="logo-img bordered-logo" src="@Url.Action("Index", "Logo", new {logoName = Model.LogoName})" />
+                </dd>
+            }
+
+            <dt>@Html.DisplayNameFor(x => x.AddressLine1)</dt>
+            <dd>@Html.DisplayFor(x => x.AddressLine1)</dd>
+            <dd>@Html.DisplayFor(x => x.AddressLine2)</dd>
+            <dd>@Html.DisplayFor(x => x.AddressLine3)</dd>
+            <dd class="form-group">@Html.DisplayFor(x => x.AddressLine4)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.City)</dt>
+            <dd>@Html.DisplayFor(x => x.City)</dd>
+
+            @if (await _config.GetSiteConfigValue(ConfigKey.ShowCounties) == "true")
+            {
+                <dt class="form-group">@Html.DisplayNameFor(x => x.CountyName)</dt>
+                <dd>@Html.DisplayFor(x => x.CountyName)</dd>
+            }
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.CountryName)</dt>
+            <dd>@Html.DisplayFor(x => x.CountryName)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.Postcode)</dt>
+            <dd>@Html.DisplayFor(x => x.Postcode)</dd>
+        </dl>
+
+        <h4>Governance Compliance</h4>
+        <dl class="dl-horizontal">
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.GoverningInstitution)</dt>
+            <dd>@Html.DisplayFor(x => x.GoverningInstitution)</dd>
+
+            <dt class="form-group">@Html.DisplayNameFor(x => x.GoverningDepartment)</dt>
+            <dd>@Html.DisplayFor(x => x.GoverningDepartment)</dd>
+
+            @if (String.IsNullOrWhiteSpace(Model.EthicsRegistration)) 
+            {    
+                <dt class="form-group">@Html.DisplayNameFor(x => x.EthicsRegistration)</dt>
+                <dd>@Html.DisplayFor(x => x.EthicsRegistration)</dd>
+            }
+        </dl>
+
+        @if (Model.ServiceModels.Any(x => x.Active))
+        {
+            <h4>Services</h4>
+
+            <div class="row">
+                <ul class="col-sm-offset-1 col-sm-11 list-inside">
+                    @foreach (var serviceModel in Model.ServiceModels.Where(x => x.Active))
+                    {
+                        <li>
+                            @Html.DisplayFor(x => serviceModel.ServiceOfferingName)
+                        </li>
+                    }
+                </ul>
+            </div>
+        }
+
+        @if (Model.NetworkModels.Any())
+        {
+            <h4>Networks</h4>
+
+            <div class="row">
+                <ul class="col-sm-offset-1 col-sm-11 list-inside">
+                    @foreach (var networkModel in Model.NetworkModels)
+                    {
+                        <li>
+                            @Html.DisplayFor(x => networkModel.Name)
+                        </li>
+                    }
+                </ul>
+            </div>
+        }
+
+        @if (await _config.GetSiteConfigValue(ConfigKey.EnableDataSharing) == "true")
+        {
+            <h4>Data sharing settings</h4>
+            <div class="row">
+                <ul class="col-sm-offset-1 col-sm-11 list-inside">
+
+                    @if (Model.SharingOptOut)
+                    {
+                        <li>Data will not be shared with other directories.</li>
+                    }
+                    else
+                    {
+                        <li>Data may be shared with other directories.</li>
+                    }
+                </ul>
+            </div>
+        }
+    </div>
+</div>

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Publications.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Publications.cshtml
@@ -1,0 +1,113 @@
+@model int
+@{
+    ViewBag.Title = "Publications";
+}
+
+@Html.Partial("_BiobankTabs", "Publications")
+
+<h3>
+    @ViewBag.Title
+</h3>
+
+<span id="BiobankId" data-biobank-id="@Model"></span>
+
+<div class="row">
+    <div class="col-md-12">
+        @*Enable/Disable Publications*@
+        <label class="pull-right" title="Enable/Disable Publications">
+            On/Off
+            <input id="IncludePublications" type="checkbox">
+        </label>
+        <br />
+
+        <div class="alert alert-info feedback-message annualstats-feedback" role="alert">
+            Approving publications will help people find you by your research.
+        </div>
+
+        <table id="biobank-publications" class="table table-striped table-hover" style="width:100%"></table>
+    </div>
+</div>
+
+<!-- Author Modal -->
+<div class="modal fade" id="authorModal" tabindex="-1" role="dialog" aria-labelledby="authorModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title" id="authorModalLabel">Authors</h4>
+            </div>
+            <div class="modal-body">
+                <span id="authors-full"></span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Add Publication Modal -->
+<div class="modal fade" id="publications-modal" tabindex="-1" role="dialog" aria-labelledby="publications-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="publications-modal-label">Add Publication</h4>
+            </div>
+
+            <!-- Error List -->
+            <div class="row">
+                <div class="col-sm-12" data-bind="visible: dialogErrors().length > 0">
+                    <div class="alert alert-danger"
+                         data-valmsg-summary="true"
+                         data-bind="foreach: dialogErrors">
+                        <p>
+                            <span class="fa fa-exclamation-triangle"></span>
+                            <span data-bind="text: $data"></span>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Modal Form -->
+            <form id="modal-publications-form"
+                  data-success-redirect="@Url.Action("AddPublicationSuccessFeedback")"
+                  class="form-horizontal">
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="form-group">
+                                <div class="col-sm-3">
+                                    <label class="control-label">
+                                        PubMed ID
+                                        <span class="fa fa-info-circle labelled-icon" data-toggle="tooltip" data-placement="right" 
+                                              title="PMID of the publication from PubMed (https://pubmed.ncbi.nlm.nih.gov/)"></span>
+                                    </label>          
+                                </div>
+                                <div class="col-sm-9">
+                                    <input type="number" id="publicationId" name="Id" class="form-control" data-bind="value: modal.publicationId" required>
+                                </div>
+                            </div>
+                            <div class="form-group" data-bind="visible: searchResult().length > 0">
+                                <div class="col-sm-offset-3 col-sm-9">
+                                    <div class="alert alert-info">
+                                        <span id="Id" name="Id" data-bind="html: searchResult"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary" data-bind="text: modal.mode"></button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section FooterScripts
+{
+    <script src="~/dist/js/Biobank/publications.min.js" asp-append-version="true"></script>
+}

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Publications.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Publications.cshtml
@@ -3,7 +3,7 @@
     ViewBag.Title = "Publications";
 }
 
-@Html.Partial("_BiobankTabs", "Publications")
+<partial name = "_BiobankTabs" model = "Publications" />
 
 <h3>
     @ViewBag.Title

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/_ModalAddFunder.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/_ModalAddFunder.cshtml
@@ -1,19 +1,46 @@
-@model TModel
+@model Biobanks.Submissions.Api.Areas.Biobank.Models.Profile.AddFunderModel;
 
-@{
-    Layout = null;
-}
+<div class="modal-dialog" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="modalAddBiobankFunder_Label">Add new biobank funder</h4>
+        </div>
 
-<!DOCTYPE html>
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="alert alert-info">
+                    <p>Search for a funder to add.</p>
+                </div>
+            </div>
+        </div>
 
-<html>
-<head>
-    <title>title</title>
-</head>
-<body>
-<div>
-      
+        <div class="row">
+            <div class="col-sm-12" data-bind="visible: dialogErrors().length > 0">
+                <div class="alert alert-danger"
+                     data-valmsg-summary="true"
+                     data-bind="foreach: dialogErrors">
+                    <p>
+                        <span class="fa fa-exclamation-triangle"></span>
+                        <span data-bind="text: $data"></span>
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <form id="modalAddBiobankFunderForm"
+              data-action="@Url.Action("AddFunderAjax")"
+              data-success-redirect="@Url.Action("AddFunderSuccess")"
+              class="form-horizontal">
+            
+            <div class="modal-body">
+                @Html.EditorForModel(new { modal = true })
+            </div>
+
+            <div class="modal-footer">
+                <a class="btn btn-default" href="#" data-dismiss="modal">Cancel</a>
+                <button type="submit" class="btn btn-primary">Add funder</button>
+            </div>
+        </form>
+    </div>
 </div>
-</body>
-</html>
-

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/_ModalAddFunder.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/_ModalAddFunder.cshtml
@@ -1,0 +1,19 @@
+@model TModel
+
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>title</title>
+</head>
+<body>
+<div>
+      
+</div>
+</body>
+</html>
+

--- a/src/Submissions/Api/Config/ConfigKey.cs
+++ b/src/Submissions/Api/Config/ConfigKey.cs
@@ -54,7 +54,6 @@ namespace Biobanks.Submissions.Api.Config
 
     // Sample Resource Configuration Options
     public const string ContactThirdParty = "site.display.thirdparty";
-    
   }
 }
 

--- a/src/Submissions/Api/Config/ConfigKey.cs
+++ b/src/Submissions/Api/Config/ConfigKey.cs
@@ -55,8 +55,6 @@ namespace Biobanks.Submissions.Api.Config
     // Sample Resource Configuration Options
     public const string ContactThirdParty = "site.display.thirdparty";
     
-    // EPMC Api Config
-    public const string EpmcApiUrl = "";
   }
 }
 

--- a/src/Submissions/Api/Config/ConfigKey.cs
+++ b/src/Submissions/Api/Config/ConfigKey.cs
@@ -54,6 +54,9 @@ namespace Biobanks.Submissions.Api.Config
 
     // Sample Resource Configuration Options
     public const string ContactThirdParty = "site.display.thirdparty";
+    
+    // EPMC Api Config
+    public const string EpmcApiUrl = "";
   }
 }
 

--- a/src/Submissions/Api/Config/SitePropertiesOptions.cs
+++ b/src/Submissions/Api/Config/SitePropertiesOptions.cs
@@ -35,5 +35,7 @@ namespace Biobanks.Submissions.Api.Config
     /// How long in milliseconds authenticated user sessions should last on the client side
     /// </summary>
     public int ClientSessionTimeout { get; set; } = 1200000; //20 mins in milliseconds
+    
+    public string EpmcApiUrl = string.Empty;
   }
 }

--- a/src/Submissions/Api/Extensions/IFormFileExtensions.cs
+++ b/src/Submissions/Api/Extensions/IFormFileExtensions.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace Biobanks.Submissions.Api.Extensions;
+
+public static class IFormFileExtensions
+{
+    public static Stream ToProcessableStream(this IFormFile file)
+    {
+        if (file.Length > 0)
+            return file.OpenReadStream();
+
+        throw new FileLoadException("The supplied posted file does not have any content.");
+    }
+    
+    /// <summary>
+    /// Returns true if a logo suitable for uploading, false if not, throws exceptions in the case of validation errors.
+    /// </summary>
+    /// <param name="file">The uploaded logo file</param>
+    /// <returns>True if there is a valid logo to upload, False if not</returns>
+    public static bool ValidateAsLogo(this IFormFile file)
+    {
+        if (file == null || file.Length <= 0) return false; //nothing to validate or upload
+
+        if (file.Length > 1000000)
+        {
+            throw new BadImageFormatException("Images must be less than 1Mb in size.");
+        }
+
+        //validate format (ContentType)
+        if (!new[]
+            {
+                "image/gif", "image/jpeg", "image/pjpeg", "image/png"
+            }.Contains(file.ContentType))
+        {
+            throw new BadImageFormatException("Logo must be a valid GIF, JPEG or PNG file.");
+        }
+
+        return true;
+    }
+    
+}

--- a/src/Submissions/Api/Program.cs
+++ b/src/Submissions/Api/Program.cs
@@ -200,6 +200,7 @@ builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies())
     .AddTransient<IAnnotationService, AnnotationService>()
     .AddTransient<IBiobankService, BiobankService>()
     .AddTransient<IBiobankIndexService, BiobankIndexService>()
+    .AddTransient<IBiobankWriteService, BiobankWriteService>()
     .AddTransient<ICapabilityService, CapabilityService>()
     .AddTransient<ICollectionAggregatorService, CollectionAggregatorService>()
     .AddTransient<ICollectionService, CollectionService>()
@@ -303,6 +304,7 @@ builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies())
         CountryService>()
     .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<DonorCount>,
         DonorCountService>()
+    .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<Funder>, FunderService>()
     .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<MacroscopicAssessment>,
         MacroscopicAssessmentService>()
     .AddTransient<IMaterialTypeService, MaterialTypeService>()
@@ -327,19 +329,8 @@ builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies())
 if (bool.Parse(builder.Configuration["DirectoryEnabled:Enabled"]) == true)
 {
     builder.Services
-        .AddTransient<IBiobankIndexService, BiobankIndexService>()
-        .AddTransient<IAnalyticsReportGenerator, AnalyticsReportGenerator>()
         .AddTransient<IBiobankReadService, BiobankReadService>()
-        .AddTransient<IBiobankWriteService, BiobankWriteService>()
-        .AddTransient<IIndexProvider, LegacyIndexProvider>()
-        .AddTransient(typeof(IGenericEFRepository<>), typeof(IGenericEFRepository<>))
-        .AddTransient<ITokenLoggingService, TokenLoggingService>()
-        .AddTransient<IDiseaseStatusService, DiseaseStatusService>()
-
-        // Reference Data
-        .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<AssociatedDataType>, AssociatedDataTypeService>()
-        .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<Funder>, FunderService>();
-
+        .AddTransient<IDiseaseStatusService, DiseaseStatusService>();
 }
 
 // Conditional services

--- a/src/Submissions/Api/Program.cs
+++ b/src/Submissions/Api/Program.cs
@@ -302,6 +302,7 @@ builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies())
     .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<County>, CountyService>()
     .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<Country>,
         CountryService>()
+    .AddTransient<IDiseaseStatusService, DiseaseStatusService>()
     .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<DonorCount>,
         DonorCountService>()
     .AddTransient<Biobanks.Submissions.Api.Services.Directory.Contracts.IReferenceDataService<Funder>, FunderService>()
@@ -329,8 +330,7 @@ builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies())
 if (bool.Parse(builder.Configuration["DirectoryEnabled:Enabled"]) == true)
 {
     builder.Services
-        .AddTransient<IBiobankReadService, BiobankReadService>()
-        .AddTransient<IDiseaseStatusService, DiseaseStatusService>();
+        .AddTransient<IBiobankReadService, BiobankReadService>();
 }
 
 // Conditional services

--- a/src/Submissions/Api/Services/Directory/BiobankReadService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankReadService.cs
@@ -63,15 +63,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
         }
 
         #endregion
-
-        public async Task<IEnumerable<Funder>> ListBiobankFundersAsync(int biobankId)
-            => (await _organisationRepository.ListAsync(
-                    false,
-                    x => x.OrganisationId == biobankId,
-                    null,
-                    x => x.Funders))
-                .Select(x => x.Funders)
-                .FirstOrDefault();
+        
         public async Task<IEnumerable<SampleSet>> GetSampleSetsByIdsForIndexingAsync(
             IEnumerable<int> sampleSetIds)
         {

--- a/src/Submissions/Api/Services/Directory/BiobankService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankService.cs
@@ -6,18 +6,26 @@ using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Entities.Data.ReferenceData;
 
 namespace Biobanks.Submissions.Api.Services.Directory
 {
     public class BiobankService : IBiobankService
     {
+        private readonly IGenericEFRepository<Organisation> _organisationRepository;
         private readonly IGenericEFRepository<OrganisationServiceOffering> _organisationServiceOfferingRepository;
         private readonly IGenericEFRepository<OrganisationUser> _organisationUserRepository;
         private readonly UserManager<ApplicationUser> _userManager;
 
 
-        public BiobankService(IGenericEFRepository<OrganisationServiceOffering> organisationServiceOfferingRepository, IGenericEFRepository<OrganisationUser> organisationUserRepository, UserManager<ApplicationUser> userManager)
+        public BiobankService(
+            IGenericEFRepository<Organisation> organisationRepository,
+            IGenericEFRepository<OrganisationServiceOffering> organisationServiceOfferingRepository,
+            IGenericEFRepository<OrganisationUser> organisationUserRepository,
+            UserManager<ApplicationUser> userManager
+            )
         {
+            _organisationRepository = organisationRepository;
             _organisationServiceOfferingRepository = organisationServiceOfferingRepository;
             _organisationUserRepository = organisationUserRepository;
             _userManager = userManager;
@@ -39,5 +47,14 @@ namespace Biobanks.Submissions.Api.Services.Directory
 
           return _userManager.Users.AsNoTracking().Where(x => adminIds.Contains(x.Id));
         }
+        
+        public async Task<IEnumerable<Funder>> ListBiobankFundersAsync(int biobankId)
+            => (await _organisationRepository.ListAsync(
+                    false,
+                    x => x.OrganisationId == biobankId,
+                    null,
+                    x => x.Funders))
+                .Select(x => x.Funders)
+                .FirstOrDefault();
     }
 }

--- a/src/Submissions/Api/Services/Directory/BiobankWriteService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankWriteService.cs
@@ -1,9 +1,6 @@
-using AutoMapper;
 using Biobanks.Entities.Data;
 using Biobanks.Entities.Data.ReferenceData;
-using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Services;
-using Biobanks.Submissions.Api.Models.Directory;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -17,125 +14,37 @@ namespace Biobanks.Submissions.Api.Services.Directory
     public class BiobankWriteService : IBiobankWriteService
     {
         #region Properties and ctor
-        private readonly IOntologyTermService _ontologyTermService;
-        private readonly ICapabilityService _capabilityService;
-        private readonly IOrganisationDirectoryService _organisationService;
-
+        
+        private readonly IBiobankIndexService _indexService;
         private readonly ILogoStorageProvider _logoStorageProvider;
-
-        private readonly IGenericEFRepository<OntologyTerm> _ontologyTermRepository;
-        private readonly IGenericEFRepository<MaterialType> _materialTypeRepository;
-
-        private readonly IGenericEFRepository<Collection> _collectionRepository;
-        private readonly IGenericEFRepository<DiagnosisCapability> _capabilityRepository;
-        private readonly IGenericEFRepository<SampleSet> _sampleSetRepository;
-        private readonly IGenericEFRepository<MaterialDetail> _materialDetailRepository;
-
-        private readonly IGenericEFRepository<Network> _networkRepository;
-        private readonly IGenericEFRepository<NetworkUser> _networkUserRepository;
-        private readonly IGenericEFRepository<NetworkRegisterRequest> _networkRegisterRequestRepository;
-        private readonly IGenericEFRepository<OrganisationNetwork> _networkOrganisationRepository;
-
+        private readonly IGenericEFRepository<Funder> _funderRepository;
         private readonly IGenericEFRepository<Organisation> _organisationRepository;
         private readonly IGenericEFRepository<OrganisationAnnualStatistic> _organisationAnnualStatisticRepository;
-        private readonly IGenericEFRepository<OrganisationRegisterRequest> _organisationRegisterRequestRepository;
         private readonly IGenericEFRepository<OrganisationRegistrationReason> _organisationRegistrationReasonRepository;
-        private readonly IGenericEFRepository<OrganisationUser> _organisationUserRepository;
-        private readonly IGenericEFRepository<OrganisationType> _organisationTypeRepository;
         private readonly IGenericEFRepository<OrganisationServiceOffering> _organisationServiceOfferingRepository;
-        private readonly IGenericEFRepository<OrganisationNetwork> _organisationNetworkRepository;
         private readonly IGenericEFRepository<RegistrationReason> _registrationReasonRepository;
         private readonly IGenericEFRepository<ServiceOffering> _serviceOfferingRepository;
-
-        private readonly IGenericEFRepository<ConsentRestriction> _consentRestrictionRepository;
-
-        private readonly IGenericEFRepository<Funder> _funderRepository;
-
-        private readonly IGenericEFRepository<Entities.Data.Config> _siteConfigRepository;
-
-        private readonly IBiobankIndexService _indexService;
-
-        private readonly IMapper _mapper;
-
+        
         public BiobankWriteService(
-            ICollectionService collectionService,
-            IOntologyTermService ontologyTermService,
-            ICapabilityService capabilityService,
-            INetworkService networkService,
-            IOrganisationDirectoryService organisationService,
-            IBiobankReadService biobankReadService,
-            IConfigService configService,
+            IBiobankIndexService indexService,
             ILogoStorageProvider logoStorageProvider,
-            IGenericEFRepository<OntologyTerm> ontologyTermRepository,
-            IGenericEFRepository<MaterialType> materialTypeRepository,
-            IGenericEFRepository<Collection> collectionRepository,
-            IGenericEFRepository<DiagnosisCapability> capabilityRepository,
-            IGenericEFRepository<SampleSet> sampleSetRepository,
-            IGenericEFRepository<MaterialDetail> materialDetailRepository,
-            IGenericEFRepository<Network> networkRepository,
-            IGenericEFRepository<NetworkUser> networkUserRepository,
-            IGenericEFRepository<NetworkRegisterRequest> networkRegisterRequestRepository,
-            IGenericEFRepository<OrganisationNetwork> networkOrganisationRepository,
-
+            IGenericEFRepository<Funder> funderRepository,
             IGenericEFRepository<Organisation> organisationRepository,
             IGenericEFRepository<OrganisationAnnualStatistic> organisationAnnualStatisticRepository,
-            IGenericEFRepository<OrganisationRegisterRequest> organisationRegisterRequestRepository,
             IGenericEFRepository<OrganisationRegistrationReason> organisationRegistrationReasonRepository,
-            IGenericEFRepository<OrganisationUser> organisationUserRepository,
-            IGenericEFRepository<OrganisationNetwork> organisationNetworkRepository,
-            IGenericEFRepository<OrganisationType> organisationTypeRepository,
             IGenericEFRepository<OrganisationServiceOffering> organisationServiceOfferingRepository,
             IGenericEFRepository<RegistrationReason> registrationReasonRepository,
-            IGenericEFRepository<ServiceOffering> serviceOfferingRepository,
-
-            IGenericEFRepository<ConsentRestriction> consentRestrictionRepository,
-
-            IGenericEFRepository<Entities.Data.Config> siteConfigRepository,
-
-            IBiobankIndexService indexService,
-            IMapper mapper,
-
-            IGenericEFRepository<Funder> funderRepository)
+            IGenericEFRepository<ServiceOffering> serviceOfferingRepository)
         {
-            _ontologyTermService = ontologyTermService;
-            _capabilityService = capabilityService;
-
-            _organisationService = organisationService;
-
+            _indexService = indexService;
             _logoStorageProvider = logoStorageProvider;
-
-            _ontologyTermRepository = ontologyTermRepository;
-            _materialTypeRepository = materialTypeRepository;
-
-            _collectionRepository = collectionRepository;
-            _capabilityRepository = capabilityRepository;
-            _sampleSetRepository = sampleSetRepository;
-            _materialDetailRepository = materialDetailRepository;
-
-            _networkRepository = networkRepository;
-            _networkUserRepository = networkUserRepository;
-            _networkRegisterRequestRepository = networkRegisterRequestRepository;
-            _networkOrganisationRepository = networkOrganisationRepository;
-
+            _funderRepository = funderRepository;
             _organisationRepository = organisationRepository;
             _organisationAnnualStatisticRepository = organisationAnnualStatisticRepository;
-            _organisationRegisterRequestRepository = organisationRegisterRequestRepository;
             _organisationRegistrationReasonRepository = organisationRegistrationReasonRepository;
-            _organisationUserRepository = organisationUserRepository;
-            _organisationNetworkRepository = organisationNetworkRepository;
-            _organisationTypeRepository = organisationTypeRepository;
             _organisationServiceOfferingRepository = organisationServiceOfferingRepository;
             _registrationReasonRepository = registrationReasonRepository;
             _serviceOfferingRepository = serviceOfferingRepository;
-
-            _consentRestrictionRepository = consentRestrictionRepository;
-
-            _siteConfigRepository = siteConfigRepository;
-
-            _indexService = indexService;
-
-            _mapper = mapper;
-            _funderRepository = funderRepository;
         }
 
         #endregion

--- a/src/Submissions/Api/Services/Directory/Contracts/IBiobankReadService.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/IBiobankReadService.cs
@@ -38,8 +38,6 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
 
         Task<IEnumerable<SampleSet>> GetSampleSetsByIdsForIndexDeletionAsync(IEnumerable<int> sampleSetIds);
 
-        Task<IEnumerable<Funder>> ListBiobankFundersAsync(int biobankId);
-
         Task<IEnumerable<ApplicationUser>> ListSoleBiobankAdminIdsAsync(int modelBiobankId);
 
 

--- a/src/Submissions/Api/bundleconfig.json
+++ b/src/Submissions/Api/bundleconfig.json
@@ -252,7 +252,7 @@
   // Capability
   {
     "outputFileName": "wwwroot/dist/js/Biobank/capability.min.js",
-    "inputFiles": ["Frontend/js/Biobank/associated-data-admin.js"],
+    "inputFiles": ["Frontend/js/pages/Biobank/associated-data-admin.js"],
     "minify": { "enabled": true },
     "sourceMap": true
   },


### PR DESCRIPTION
## Overview

Ports the details, funders, templogo, publications, and annual stats regions from the `BiobankController`, to the core `Biobanks` area: `ProfileController`.

Includes:
- Cleaning up `Program.cs` - removing duplicate service registrations, and activating when they're in use.
- Cleaning up `BiobankWriteService` and its DI 
- Fixed a misnaming in the JS bundling (last one)