### PR TITLE
AB#94114: Controller requests: historical

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "5.0.4",
+      "version": "6.0.10",
       "commands": [
         "dotnet-ef"
       ]

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Here's how to get that going.
 1. Install local repo tooling for .NET
    - `dotnet tool restore` anywhere inside the repo
 1. Run database migrations
-   - Change directory next to the `Data.csproj` (`/src/Data/Data.csproj`)
-   - `dotnet dotnet-ef database update -- <connection string>`
-   - For development, steal the connection string from one of the App's development configs.
+   - Change directory next to the `src` folder.
+   - You need to specify the DbContext, and target the `Data` project, using the `Submissions` project as the startup project.
+   - `dotnet ef database update -c Biobanks.Data.ApplicationDbContext -p Data/Data.csproj -s Submissions/Api/Api.csproj`
 1. Seed Reference Data
    - Copy seed data files from `/sample-seed-data` to `/src/DataSeed/data`
    - optionally modify the seed data

--- a/src/Submissions/Api/Areas/Admin/Controllers/RequestsController.cs
+++ b/src/Submissions/Api/Areas/Admin/Controllers/RequestsController.cs
@@ -15,11 +15,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Submissions.Api.Areas.Admin.Models.Requests;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Biobanks.Submissions.Api.Areas.Admin.Controllers;
 
-[AllowAnonymous]
 public class RequestsController : Controller
 {
   private INetworkService _networkService;

--- a/src/Submissions/Api/Areas/Admin/Controllers/RequestsController.cs
+++ b/src/Submissions/Api/Areas/Admin/Controllers/RequestsController.cs
@@ -16,8 +16,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Submissions.Api.Areas.Admin.Models.Requests;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Biobanks.Submissions.Api.Areas.Admin.Controllers;
+
+[AllowAnonymous]
 public class RequestsController : Controller
 {
   private INetworkService _networkService;
@@ -85,7 +88,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           "That request doesn't exist",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //what if the request is already accepted/declined?
@@ -94,7 +97,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           $"{request.UserName} ({request.UserEmail}) request for {request.OrganisationName} has already been approved or declined.",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //try and get the user for the request
@@ -171,7 +174,7 @@ public class RequestsController : Controller
         $"{request.UserName} ({request.UserEmail}) request for {request.OrganisationName} accepted!",
         FeedbackMessageType.Success);
 
-    return RedirectToAction("Requests");
+    return RedirectToAction("Index");
   }
 
   public async Task<ActionResult> BiobankActivity()
@@ -210,7 +213,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           "That request doesn't exist",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //what if the request is already accepted/declined?
@@ -219,7 +222,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           $"{request.UserName} ({request.UserEmail}) request for {request.OrganisationName} has already been approved or declined.",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //update the request
@@ -237,7 +240,7 @@ public class RequestsController : Controller
         $"{request.UserName} ({request.UserEmail}) request for {request.OrganisationName} declined!",
         FeedbackMessageType.Success);
 
-    return RedirectToAction("Requests");
+    return RedirectToAction("Index");
   }
 
   public async Task<ActionResult> AcceptNetworkRequest(int requestId)
@@ -249,7 +252,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           "That request doesn't exist",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //what if the request is already accepted/declined?
@@ -258,7 +261,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           $"{request.UserName} ({request.UserEmail}) request for {request.NetworkName} has already been approved or declined.",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //try and get the user for the request
@@ -331,7 +334,7 @@ public class RequestsController : Controller
         $"{request.UserName} ({request.UserEmail}) request for {request.NetworkName} accepted!",
         FeedbackMessageType.Success);
 
-    return RedirectToAction("Requests");
+    return RedirectToAction("Index");
   }
 
   public async Task<ActionResult> DeclineNetworkRequest(int requestId)
@@ -343,7 +346,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           "That request doesn't exist",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //what if the request is already accepted/declined?
@@ -352,7 +355,7 @@ public class RequestsController : Controller
       this.SetTemporaryFeedbackMessage(
           $"{request.UserName} ({request.UserEmail}) request for {request.NetworkName} has already been approved or declined.",
           FeedbackMessageType.Danger);
-      return RedirectToAction("Requests");
+      return RedirectToAction("Index");
     }
 
     //update the request
@@ -370,7 +373,7 @@ public class RequestsController : Controller
         $"{request.UserName} ({request.UserEmail}) request for {request.NetworkName} declined!",
         FeedbackMessageType.Success);
 
-    return RedirectToAction("Requests");
+    return RedirectToAction("Index");
   }
 
   public async Task<ActionResult> ManualActivation(string userEmail)

--- a/src/Submissions/Api/Areas/Admin/Controllers/RequestsController.cs
+++ b/src/Submissions/Api/Areas/Admin/Controllers/RequestsController.cs
@@ -1,6 +1,5 @@
 using AutoMapper;
 using Biobanks.Data.Entities;
-using Biobanks.Shared.Services.Contracts;
 using Biobanks.Submissions.Api.Areas.Admin.Models;
 using Biobanks.Submissions.Api.Constants;
 using Biobanks.Submissions.Api.Models.Emails;

--- a/src/Submissions/Api/Areas/Admin/Models/Requests/HistoricalModel.cs
+++ b/src/Submissions/Api/Areas/Admin/Models/Requests/HistoricalModel.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Biobanks.Submissions.Api.Areas.Admin.Models.Requests;
+
+public class HistoricalModel
+{
+  public ICollection<HistoricalRequestModel> HistoricalRequests { get; set; }
+}

--- a/src/Submissions/Api/Areas/Admin/Models/Requests/HistoricalRequestModel.cs
+++ b/src/Submissions/Api/Areas/Admin/Models/Requests/HistoricalRequestModel.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Biobanks.Submissions.Api.Areas.Admin.Models.Requests;
+
+public class HistoricalRequestModel
+{
+  public string UserName { get; set; }
+  public string UserEmail { get; set; }
+
+  public string EntityName { get; set; }
+  public string Action { get; set; }
+  public DateTime Date { get; set; }
+
+  public bool UserEmailConfirmed { get; set; }
+
+  // the biobank or network created from finishing the registration
+  public string ResultingOrgExternalId { get; set; }
+  
+}

--- a/src/Submissions/Api/Areas/Admin/Views/Requests/Historical.cshtml
+++ b/src/Submissions/Api/Areas/Admin/Views/Requests/Historical.cshtml
@@ -1,0 +1,103 @@
+@using System.Linq
+@using Microsoft.AspNetCore.Http.Extensions
+
+@model Biobanks.Submissions.Api.Areas.Admin.Models.Requests.HistoricalModel;
+
+@{
+    ViewBag.Title = "ADAC Admin";
+}
+
+<partial name = "_ADACTabs" model = "BiobankActivity" />
+
+<h3>Request History</h3>
+
+<div class="row">
+    <div class="col-sm-12">
+        @if (@Model.HistoricalRequests.Any())
+        {
+            <table id="adac-request-history" class="table">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Requesting Org Name</th>
+                    <th>Action</th>
+                    <th>Date & Time</th>
+                    <th>Profile</th>
+                    <th></th>
+                </tr>
+                </thead>
+                <tbody>
+                @foreach (var request in Model.HistoricalRequests)
+                {
+					<tr class="@Html.Raw(request.Action == "Accepted" ? "success" : "danger")">
+						<td>
+							@request.UserName
+						</td>
+						<td>
+							@request.UserEmail
+						</td>
+						<td>
+							@request.EntityName
+						</td>
+						<td>
+							@request.Action
+						</td>
+						<td>
+							@request.Date
+						</td>
+
+
+						@if (!string.IsNullOrWhiteSpace(request.ResultingOrgExternalId))
+						{
+							<!-- Accepted Biobank -->
+							<td>
+								<a href="@Url.Action("Biobank", "Profile", new { id = request.ResultingOrgExternalId })">
+									<span class="fa fa-user labelled-icon"></span>Profile
+								</a>
+							</td>
+							<td></td>
+						}
+						else if (request.Action == "Accepted" && !request.UserEmailConfirmed)
+						{
+							<!-- Accepted Biobank - User Not Confirmed Email -->
+							<td>
+								<a class="manual-confirm"
+								   href="@Url.Action("ManualActivation", "Requests")"
+								   data-admin-name="@request.UserName"
+								   data-admin-email="@request.UserEmail">
+									<span class="fa fa-bolt labelled-icon"></span>Activate
+								</a>
+							</td>
+							<td>
+								<a class="resend-confirm"
+								   href="@Url.Action("ResendConfirmLink", "Account", new { userEmail = request.UserEmail, onBehalf = true, returnUrl = @Context.Request.GetEncodedUrl() })"
+								   data-admin-name="@request.UserName"
+								   data-admin-email="@request.UserEmail">
+									<span class="fa fa-repeat labelled-icon"></span>Resend
+								</a>
+							</td>
+						}
+						else
+						{
+							<td></td>
+							<td></td>
+						}
+					</tr>
+                }
+                </tbody>
+            </table>
+        }
+        else
+        {
+            <div class="alert alert-info">
+                There is no historical request data available yet.
+            </div>
+        }
+    </div>
+</div>
+
+@section FooterScripts
+{
+    <script src="~/dist/js/Admin/historical.min.js" asp-append-version="true"></script>
+}


### PR DESCRIPTION
## Overview

Ports the missing controller methods:

Directory: Controller: ADAC, Action: Historical
Migrated: Area: Admin, Controller: Requests, Action: Historical

See [#84331](https://dev.azure.com/UniversityOfNottingham/DRS/_backlogs/backlog/ADAC0001%20-%20Biobanks/Epics/?workitem=84331)

## Notes

Also:
- Updates dotnet ef tools to 6
- Temporary update to migrations documentation
- Fix action methods routing on the `RequestsController`