### PR TITLE
AB#34691: manage user roles cli command

### DIFF
--- a/src/Submissions/Api/Commands/ManageUserRoles.cs
+++ b/src/Submissions/Api/Commands/ManageUserRoles.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Biobanks.Data;
+using Biobanks.Data.Entities;
+using Biobanks.Submissions.Api.Commands.Helpers;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Biobanks.Submissions.Api.Commands;
+
+internal class ManageUserRoles : Command
+{
+  public ManageUserRoles(string name)
+    : base(name, "Manage roles for a User; listing, adding and/or removing.")
+  {
+    var argEmail = new Argument<string>("email", "The user's email address");
+    Add(argEmail);
+
+    var optConnectionString = new Option<string>(new[] { "--connection-string", "-c" },
+      "Database Connection String if not specified in Configuration");
+    Add(optConnectionString);
+
+    var optRemoveRoles = new Option<List<string>>(new[] { "--remove-roles", "--remove" },
+      "Role names to remove the user from. `users list-roles` can be used to list valid role names.")
+    {
+      AllowMultipleArgumentsPerToken = true
+    };
+    Add(optRemoveRoles);
+
+    var optAddRoles = new Option<List<string>>(new[] { "--add-roles", "--add" },
+      "Role names to add the user to. `users list-roles` can be used to list valid role names.")
+    {
+      AllowMultipleArgumentsPerToken = true
+    };
+    Add(optAddRoles);
+
+    this.SetHandler(
+      async (config, console,
+        email,
+        overrideConnectionString,
+        removeRoles, addRoles) =>
+      {
+        // figure out the connection string from the option, or config
+        var connectionString = overrideConnectionString ?? config.GetConnectionString("Default");
+
+        // Configure DI and run the command handler
+        await this
+          .ConfigureServices(s =>
+          {
+            s.AddSingleton(_ => config)
+              .AddSingleton(_ => console)
+              .AddDbContext<ApplicationDbContext>(o => o.UseNpgsql(connectionString));
+
+            s.AddLogging()
+              .AddIdentity<ApplicationUser, IdentityRole>()
+              .AddEntityFrameworkStores<ApplicationDbContext>();
+
+            s.AddTransient<Runners.ManageUserRoles>();
+          })
+          .GetRequiredService<Runners.ManageUserRoles>()
+          .Run(email, removeRoles, addRoles);
+      },
+      Bind.FromServiceProvider<IConfiguration>(),
+      Bind.FromServiceProvider<IConsole>(),
+      argEmail,
+      optConnectionString, optRemoveRoles, optAddRoles);
+  }
+}

--- a/src/Submissions/Api/Commands/Runners/ManageUserRoles.cs
+++ b/src/Submissions/Api/Commands/Runners/ManageUserRoles.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Biobanks.Data.Entities;
+using ConsoleTableExt;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Biobanks.Submissions.Api.Commands.Runners;
+
+public class ManageUserRoles
+{
+  private readonly IConsole _console;
+  private readonly UserManager<ApplicationUser> _users;
+
+  public ManageUserRoles(
+    IConsole console,
+    UserManager<ApplicationUser> users)
+  {
+    _console = console;
+    _users = users;
+  }
+
+  public async Task Run(string email, List<string> removeRoles, List<string> addRoles)
+  {
+    var user = await _users.FindByEmailAsync(email);
+
+    var outputRows = new List<List<object>>
+    {
+      new() { "User Email", email },
+    };
+
+    if (removeRoles.Any())
+    {
+      await _users.RemoveFromRolesAsync(user, removeRoles);
+      outputRows.Add(new() { "Roles Removed", string.Join(", ", removeRoles) });
+    }
+
+    if (addRoles.Any())
+    {
+      await _users.AddToRolesAsync(user, addRoles);
+      outputRows.Add(new() { "Roles Added", string.Join(", ", addRoles) });
+    }
+
+    var currentRoles = await _users.GetRolesAsync(user);
+    outputRows.Add(new() { "Current Roles", string.Join(", ", currentRoles) });
+
+    _console.Out.Write(ConsoleTableBuilder
+      .From(outputRows)
+      .WithCharMapDefinition(CharMapDefinition.FramePipDefinition)
+      .Export()
+      .ToString());
+  }
+}

--- a/src/Submissions/Api/Startup/Cli/CliEntrypoint.cs
+++ b/src/Submissions/Api/Startup/Cli/CliEntrypoint.cs
@@ -30,6 +30,7 @@ public class CliEntrypoint : RootCommand
     AddCommand(new Command("users", "Actions for managing BiobankingUK Users")
     {
       new AddUser("add"),
+      new ManageUserRoles("roles"),
       new ListRoles("list-roles")
     });
   }


### PR DESCRIPTION
## Overview

This PR adds a Manage User Roles CLI command, so existing users can be added to or removed from roles in the cli

## Notes

### Check existing roles

```bash
dotnet run -- users roles test3@test.com
```
```
┌───────────────┬───────────────────────────┐
│ User Email    │ test3@test.com            │
├───────────────┼───────────────────────────┤
│ Current Roles │ DirectoryAdmin, SuperUser │
└───────────────┴───────────────────────────┘
```

### Modify roles

```bash
dotnet run -- users roles test3@test.com --add BiobankAdmin --remove DirectoryAdmin SuperUser
```
```
┌───────────────┬───────────────────────────┐
│ User Email    │ test3@test.com            │
├───────────────┼───────────────────────────┤
│ Roles Removed │ DirectoryAdmin, SuperUser │
├───────────────┼───────────────────────────┤
│ Roles Added   │ BiobankAdmin              │
├───────────────┼───────────────────────────┤
│ Current Roles │ BiobankAdmin              │
└───────────────┴───────────────────────────┘
```