### PR TITLE
AB#96575: Add CustomClaimsPrincipalFactory 

### DIFF
--- a/src/Submissions/Api/Auth/CustomClaimTypes.cs
+++ b/src/Submissions/Api/Auth/CustomClaimTypes.cs
@@ -17,10 +17,6 @@ namespace Biobanks.Submissions.Api.Auth
         
         public const string FullName = "FullName";
         public const string Email = "Email";
-        public const string Biobank = "Biobank";
-        public const string Network = "Network";
-        public const string BiobankRequest = "BiobankRequest";
-        public const string NetworkRequest = "NetworkRequest";
 
-  }
+    }
 }

--- a/src/Submissions/Api/Auth/CustomClaimTypes.cs
+++ b/src/Submissions/Api/Auth/CustomClaimTypes.cs
@@ -14,6 +14,13 @@ namespace Biobanks.Submissions.Api.Auth
         /// Claim representing the API Client ID of the holder
         /// </summary>
         public const string ClientId = "ClientId";
+        
+        public const string FullName = "FullName";
+        public const string Email = "Email";
+        public const string Biobank = "Biobank";
+        public const string Network = "Network";
+        public const string BiobankRequest = "BiobankRequest";
+        public const string NetworkRequest = "NetworkRequest";
 
   }
 }

--- a/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
+++ b/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
+++ b/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
@@ -1,21 +1,35 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Biobanks.Data.Entities;
+using Biobanks.Submissions.Api.Constants;
+using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Options;
 
 namespace Biobanks.Submissions.Api.Auth;
 
 public class CustomClaimsPrincipalFactory : UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>
 {
+  private readonly IOrganisationDirectoryService _organisationDirectoryService;
+  private readonly INetworkService _networkService;
 
   public CustomClaimsPrincipalFactory(
     UserManager<ApplicationUser> userManager,
     RoleManager<IdentityRole> roleManager,
-    IOptions<IdentityOptions> optionsAccessor)
-    : base(userManager, roleManager, optionsAccessor){}
+    IOptions<IdentityOptions> optionsAccessor,
+    IOrganisationDirectoryService organisationDirectoryService,
+    INetworkService networkService
+    )
+    : base(userManager, roleManager, optionsAccessor)
+  {
+    _organisationDirectoryService = organisationDirectoryService;
+    _networkService = networkService;
+  }
   
   public async override Task<ClaimsPrincipal> CreateAsync(ApplicationUser user)
   {
@@ -30,6 +44,43 @@ public class CustomClaimsPrincipalFactory : UserClaimsPrincipalFactory<Applicati
       new Claim(CustomClaimTypes.Email, user.Email),
     };
     
+    // If they're a Biobank Admin then populate the claim for the ID of their Biobank.
+    // Additionally, add claims for accepted biobank requests
+    if (principal.IsInRole(Role.BiobankAdmin))
+    {
+      var organisations = await _organisationDirectoryService.ListByUserId(user.Id);
+  
+      var organisationsRequests = await _organisationDirectoryService.ListAcceptedRegistrationRequestsByUserId(user.Id);
+      
+      claims.AddRange(
+        organisations
+          .Select(x => new KeyValuePair<int, string>(x.OrganisationId, x.Name))
+          .Select(x => new Claim(CustomClaimType.Biobank, JsonSerializer.Serialize(x))));
+  
+      claims.AddRange(
+        organisationsRequests
+          .Where(x => x.UserEmail == user.Email)
+          .Select(x => new KeyValuePair<int, string>(x.OrganisationRegisterRequestId, x.OrganisationName))
+          .Select(x => new Claim(CustomClaimType.BiobankRequest, JsonSerializer.Serialize(x))));
+    }
+    
+    // If they're a Network Admin then populate the claim for the ID of their Network.
+    // Additionally, add claims for accepted network requests
+    if (principal.IsInRole(Role.NetworkAdmin))
+    {
+      var networks = await _networkService.ListByUserId(user.Id);
+
+      var networkRequests = await _networkService.ListAcceptedRegistrationRequestsByUserId(user.Id);
+      
+      claims.AddRange(networks
+        .Select(x => new KeyValuePair<int, string>(x.NetworkId, x.Name))
+        .Select(x => new Claim(CustomClaimType.Network, JsonSerializer.Serialize(x))));
+
+      claims.AddRange(networkRequests
+        .Select(x => new KeyValuePair<int, string>(x.NetworkRegisterRequestId, x.NetworkName))
+        .Select(x => new Claim(CustomClaimType.NetworkRequest, JsonSerializer.Serialize(x))));
+    }
+
     identity.AddClaims(claims);
     return principal;
   }

--- a/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
+++ b/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
@@ -9,7 +9,6 @@ using Biobanks.Data.Entities;
 using Biobanks.Submissions.Api.Constants;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Options;
 
 namespace Biobanks.Submissions.Api.Auth;

--- a/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
+++ b/src/Submissions/Api/Auth/CustomClaimsPrincipalFactory.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Biobanks.Data.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Biobanks.Submissions.Api.Auth;
+
+public class CustomClaimsPrincipalFactory : UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>
+{
+
+  public CustomClaimsPrincipalFactory(
+    UserManager<ApplicationUser> userManager,
+    RoleManager<IdentityRole> roleManager,
+    IOptions<IdentityOptions> optionsAccessor)
+    : base(userManager, roleManager, optionsAccessor){}
+  
+  public async override Task<ClaimsPrincipal> CreateAsync(ApplicationUser user)
+  {
+    var principal = await base.CreateAsync(user);
+    var identity = (ClaimsIdentity?)principal.Identity
+                   ?? throw new InvalidOperationException(
+                     "No ClaimsIdentity present on this user");
+
+    List<Claim> claims = new()
+    {
+      new Claim(CustomClaimTypes.FullName, user.Name),
+      new Claim(CustomClaimTypes.Email, user.Email),
+    };
+    
+    identity.AddClaims(claims);
+    return principal;
+  }
+  
+}

--- a/src/Submissions/Api/Middleware/UpdateLastLoginMiddleware.cs
+++ b/src/Submissions/Api/Middleware/UpdateLastLoginMiddleware.cs
@@ -1,15 +1,9 @@
 using Biobanks.Data;
-using Biobanks.Submissions.Api.Constants;
-using Biobanks.Submissions.Api.Services.Directory;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Security.Claims;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Biobanks.Submissions.Api.Middleware
@@ -34,83 +28,17 @@ namespace Biobanks.Submissions.Api.Middleware
                 user.LastLogin = DateTime.Now;
                 dbContext.Update(user);
                 dbContext.SaveChanges();
+                
+            }
 
-                var claims = new List<Claim>
-                {
-                    new Claim(CustomClaimType.FullName, user.Name),
-                    new Claim(CustomClaimType.Email, user.Email)
-                };
+            //call the next delegate/middleware in the pipeline
+            await _next(context);
+        }
+    }
 
-                // If they're a Biobank Admin then populate the claim for the ID of their Biobank.
-                // Additionally, add claims for accepted biobank requests
-                if (context.User.IsInRole(Role.BiobankAdmin))
-                {
-                    //TODO look at using organisationdirectoryservice.getbyuserid
-                    //and ListAcceptedRegistrationRequests
-                    var organisations = await dbContext.OrganisationUsers.AsNoTracking()
-                    .Include(x => x.Organisation)
-                    .Where(x => x.OrganisationUserId == user.Id)
-                    .Select(x => x.Organisation)
-                    .ToListAsync();
-
-                    var organisationsRequests = await dbContext.OrganisationRegisterRequests
-                        .AsNoTracking()
-                        .Where(x =>
-                        x.AcceptedDate != null &&
-                        x.DeclinedDate == null &&
-                        x.OrganisationCreatedDate == null)
-                        .ToListAsync();
-
-                    claims.AddRange(
-                    organisations
-                        .Select(x => new KeyValuePair<int, string>(x.OrganisationId, x.Name))
-                        .Select(x => new Claim(CustomClaimType.Biobank, JsonSerializer.Serialize(x))));
-
-                    claims.AddRange(
-                    organisationsRequests
-                        .Where(x => x.UserEmail == user.Email)
-                        .Select(x => new KeyValuePair<int, string>(x.OrganisationRegisterRequestId, x.OrganisationName))
-                        .Select(x => new Claim(CustomClaimType.BiobankRequest, JsonSerializer.Serialize(x))));
-                }
-
-                // If they're a Network Admin then populate the claim for the ID of their Network.
-                // Additionally, add claims for accepted network requests
-                if (context.User.IsInRole(Role.NetworkAdmin))
-                {
-                    var networks = await dbContext.NetworkUsers.AsNoTracking()
-                    .Include(x => x.Network)
-                    .Where(x => x.NetworkUserId == user.Id)
-                    .Select(x => x.Network)
-                    .ToListAsync();
-
-                    var networkRequests =  await dbContext.NetworkRegisterRequests
-                        .AsNoTracking()
-                        .Where(x => x.UserEmail == user.Email)
-                        .Where(x => x.AcceptedDate != null && x.DeclinedDate == null && x.NetworkCreatedDate == null)
-                        .ToListAsync();
-
-                    claims.AddRange(networks
-                        .Select(x => new KeyValuePair<int, string>(x.NetworkId, x.Name))
-                        .Select(x => new Claim(CustomClaimType.Network, JsonSerializer.Serialize(x))));
-
-                    claims.AddRange(networkRequests
-                        .Select(x => new KeyValuePair<int, string>(x.NetworkRegisterRequestId, x.NetworkName))
-                        .Select(x => new Claim(CustomClaimType.NetworkRequest, JsonSerializer.Serialize(x))));
-                }
-
-                var appIdentity = new ClaimsIdentity(claims);
-                context.User.AddIdentity(appIdentity);       
-
-                }
-
-//call the next delegate/middleware in the pipeline
-await _next(context);
-}
-}
-
-public static class DirectoryLoginMiddlewareExtension
-{
-public static IApplicationBuilder UseDirectoryLogin(this IApplicationBuilder builder)
-=> builder.UseMiddleware<DirectoryLoginMiddleware>();
-}
+    public static class DirectoryLoginMiddlewareExtension
+    {
+      public static IApplicationBuilder UseDirectoryLogin(this IApplicationBuilder builder)
+        => builder.UseMiddleware<DirectoryLoginMiddleware>();
+    }
 }

--- a/src/Submissions/Api/Services/Directory/Contracts/IOrganisationDirectoryService.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/IOrganisationDirectoryService.cs
@@ -135,7 +135,14 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
         /// List all untracked, accepted Organisation Registration Requests
         /// </summary>
         /// <returns>Enumerable of all accepted registration requests</returns>
-        Task<IEnumerable<OrganisationRegisterRequest>> ListAcceptedRegistrationRequests();
+        Task<IEnumerable<OrganisationRegisterRequest>> ListAcceptedRegistrationRequests();        
+        
+        /// <summary>
+        /// List all untracked, accepted Organisation Registration Requests for a given user
+        /// </summary>
+        /// <param name="userId">The Id of the user</param>
+        /// <returns>Enumerable of all accepted <see cref="OrganisationRegisterRequest"/> for a given user</returns>
+        Task<IEnumerable<OrganisationRegisterRequest>> ListAcceptedRegistrationRequestsByUserId(string userId);
 
         /// <summary>
         /// List all untracked, open Organisation Registration Requests

--- a/src/Submissions/Api/Services/Directory/OrganisationDirectoryService.cs
+++ b/src/Submissions/Api/Services/Directory/OrganisationDirectoryService.cs
@@ -410,6 +410,21 @@ namespace Biobanks.Submissions.Api.Services.Directory
                     x.DeclinedDate == null &&
                     x.OrganisationCreatedDate == null)
                 .ToListAsync();
+        
+        /// <inheritdoc/>
+        public async Task<IEnumerable<OrganisationRegisterRequest>> ListAcceptedRegistrationRequestsByUserId(string userId)
+        {
+          var userEmail = _userManager.Users.First(u => u.Id == userId).Email;
+
+          return await QueryRegistrationRequests()
+            .AsNoTracking()
+            .Where(x => x.UserEmail == userEmail)
+            .Where(x => 
+              x.AcceptedDate != null && 
+              x.DeclinedDate == null && 
+              x.OrganisationCreatedDate == null)
+            .ToListAsync();
+        }
 
         /// <inheritdoc/>
         public async Task<IEnumerable<OrganisationRegisterRequest>> ListHistoricalRegistrationRequests()

--- a/src/Submissions/Api/Startup/Web/ConfigureWebServices.cs
+++ b/src/Submissions/Api/Startup/Web/ConfigureWebServices.cs
@@ -85,6 +85,7 @@ public static class ConfigureWebServices
 
     // Identity
     b.Services.AddIdentity<ApplicationUser, IdentityRole>(options => options.SignIn.RequireConfirmedAccount = true)
+      .AddClaimsPrincipalFactory<CustomClaimsPrincipalFactory>()
       .AddEntityFrameworkStores<ApplicationDbContext>()
       .AddDefaultTokenProviders();
     b.Services.ConfigureApplicationCookie(opts =>


### PR DESCRIPTION
## Overview

Changes the claims pattern to use a CustomClaimsPrincipalFactory, removing the claims population from the custom middleware.

This was necessary to allow claims to be used as part of the auth, as well as in the views. And is also just a more effective way of handling claims on login than request.

## Notes

The middleware `UpdateLastLoginMiddleware` is still used to update the users last login, but will be removed in [AB#95275](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/95275).

Unblocks #536 #537 #539