### PR TITLE
AB#96660: SuperUser Controller

### DIFF
--- a/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
@@ -57,8 +57,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
       _context = context;
       _elasticsearchConfig = elasticsearchConfig.Value;
     }
-
-    [SuppressMessage("ReSharper.DPA", "DPA0009: High execution time of DB command", MessageId = "time: 807ms")]
+    
     private async Task<IEnumerable<SampleSet>> GetSampleSetsByIdsForIndexingAsync(
        IEnumerable<int> sampleSetIds) =>
     (

--- a/src/Submissions/Api/Services/Directory/CapabilityService.cs
+++ b/src/Submissions/Api/Services/Directory/CapabilityService.cs
@@ -71,11 +71,12 @@ public class CapabilityService : ICapabilityService
     }
     private async Task<OntologyTerm> Get(string id = null, string value = null, List<string> tags = null, bool onlyDisplayable = false)
       => await ReadOnlyQuery(id, value, tags, onlyDisplayable).FirstOrDefaultAsync();
-  /// <inheritdoc/>
-  public async Task<IEnumerable<int>> GetAllCapabilityIdsAsync()
-        => (await _db.DiagnosisCapabilities.Select(x => x.DiagnosisCapabilityId)
-                .ToListAsync()
-            );
+    
+    /// <inheritdoc/>
+    public async Task<IEnumerable<int>> GetAllCapabilityIdsAsync()
+          => (await _db.DiagnosisCapabilities.Select(x => x.DiagnosisCapabilityId)
+                  .ToListAsync()
+              );
     
     /// <inheritdoc/>
     public async Task<int> GetCapabilityCountAsync()
@@ -98,8 +99,10 @@ public class CapabilityService : ICapabilityService
         => (await _db.DiagnosisCapabilities.Where(x =>
                 capabilityIds.Contains(x.DiagnosisCapabilityId) && !x.Organisation.IsSuspended)
                 .Include(x => x.Organisation)
-                .Include(x => x.Organisation.OrganisationNetworks.Select(on => on.Network))
-                .Include(x => x.Organisation.OrganisationServiceOfferings.Select(s => s.ServiceOffering))
+                .Include(x => x.Organisation.OrganisationNetworks)
+                    .ThenInclude(on => on.Network)
+                .Include(x => x.Organisation.OrganisationServiceOfferings)
+                    .ThenInclude(s => s.ServiceOffering)
                 .Include(x => x.OntologyTerm)
                 .Include(x => x.AssociatedData)
                 .Include(x => x.SampleCollectionMode)
@@ -113,8 +116,10 @@ public class CapabilityService : ICapabilityService
                 .AsNoTracking()
                 .Where(x => capabilityIds.Contains(x.DiagnosisCapabilityId))
                 .Include(x => x.Organisation)
-                .Include(x => x.Organisation.OrganisationNetworks.Select(on => on.Network))
-                .Include(x => x.Organisation.OrganisationServiceOfferings.Select(s => s.ServiceOffering))
+                .Include(x => x.Organisation.OrganisationNetworks)
+                    .ThenInclude(on => on.Network)
+                .Include(x => x.Organisation.OrganisationServiceOfferings)
+                    .ThenInclude(s => s.ServiceOffering)
                 .Include(x => x.OntologyTerm)
                 .Include(x => x.AssociatedData)
                 .Include(x => x.SampleCollectionMode)

--- a/src/Submissions/Api/Services/Directory/OrganisationDirectoryService.cs
+++ b/src/Submissions/Api/Services/Directory/OrganisationDirectoryService.cs
@@ -204,7 +204,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
 
 
                 var allRegistrationReasons = await _db.OrganisationRegistrationReasons.ToListAsync();
-                foreach (var orr in organisation.OrganisationRegistrationReasons)
+                foreach (var orr in organisation.OrganisationRegistrationReasons ?? new List<OrganisationRegistrationReason>())
                 {
                     var orgReason = allRegistrationReasons.SingleOrDefault(x => x.OrganisationId == orr.OrganisationId
                         && x.RegistrationReasonId == orr.RegistrationReasonId);
@@ -212,7 +212,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
                 }
 
                 var allServiceOfferings = await _db.OrganisationServiceOfferings.ToListAsync();
-                foreach (var ser in organisation.OrganisationServiceOfferings)
+                foreach (var ser in organisation.OrganisationServiceOfferings ?? new List<OrganisationServiceOffering>())
                 {
                     var serviceOffering = allServiceOfferings.SingleOrDefault(x => x.OrganisationId == ser.ServiceOfferingId
                         && x.ServiceOfferingId == ser.ServiceOfferingId);

--- a/src/Submissions/Api/Startup/Web/ConfigureWebServices.cs
+++ b/src/Submissions/Api/Startup/Web/ConfigureWebServices.cs
@@ -363,6 +363,7 @@ public static class ConfigureWebServices
           ? hangfireConnectionString
           : c.GetConnectionString("Default"),
         new() { SchemaName = hangfireConfig.SchemaName }));
+      s.AddHangfireServer();
     }
 
     switch (workersConfig.QueueService)

--- a/src/Submissions/Api/Views/SuperUser/Index.cshtml
+++ b/src/Submissions/Api/Views/SuperUser/Index.cshtml
@@ -6,7 +6,7 @@
 
 <br />
 
-<partial name="_SuperUserTabs" model= "Model" />
+@await Html.PartialAsync("_SuperUserTabs", "Info")
 
 <h2>
     Biobanks

--- a/src/Submissions/Api/Views/SuperUser/SearchIndex.cshtml
+++ b/src/Submissions/Api/Views/SuperUser/SearchIndex.cshtml
@@ -1,11 +1,12 @@
 @model Biobanks.Submissions.Api.Models.SuperUser.SearchIndexModel
+
 @{
     ViewBag.Title = "Search index";
 }
 
 <br />
 
-@* <partial name="_SuperUserTabs" model= "Model" /> *@
+@await Html.PartialAsync("_SuperUserTabs", "Search index")
 
 <h3>Search Index Maintenance</h3>
 
@@ -119,10 +120,3 @@ else if (ViewBag.Status == "red")
         </p>
     </div>
 }
-
-
-
-@*
-  TODO:
-@Scripts.Render("~/bundles/bootbox")
-*@

--- a/src/Submissions/Api/Views/SuperUser/SearchIndex.cshtml
+++ b/src/Submissions/Api/Views/SuperUser/SearchIndex.cshtml
@@ -5,7 +5,7 @@
 
 <br />
 
-<partial name="_SuperUserTabs" model= "Model" />
+@* <partial name="_SuperUserTabs" model= "Model" /> *@
 
 <h3>Search Index Maintenance</h3>
 

--- a/src/Submissions/Api/Views/SuperUser/Tools.cshtml
+++ b/src/Submissions/Api/Views/SuperUser/Tools.cshtml
@@ -7,7 +7,7 @@
 
 <br />
 
- <partial name = "_SuperUserTabs" model="Model" />
+@await Html.PartialAsync("_SuperUserTabs", "Tools")
 
 <h2>
     Superuser Tools
@@ -29,8 +29,3 @@
         </p>
     </div>
 }
-
-@*
-  TODO:
-@Scripts.Render("~/bundles/bootbox")
-*@


### PR DESCRIPTION
## Overview

Fixes for the root area, SuperUser controller. Super users can now run tasks to reindex the search, and fix organisation urls. 

Fixes are mostly in the index querying to update for EF, and using the correct elasticsearch config.
 