### PR TITLE
AB#98808: Historical requests, frontend bundling, and bugs

### DIFF
--- a/src/Submissions/Api/Api.csproj
+++ b/src/Submissions/Api/Api.csproj
@@ -84,9 +84,11 @@
 
     <ItemGroup>
       <Assets_Fonts Include="Frontend/node_modules/font-awesome/fonts/**/*.*" />
+      <Assets_Markdown Include="Frontend/node_modules/markdowndeep/clientSide/*.png;Frontend/node_modules/markdowndeep/clientSide/*.gif" />
     </ItemGroup>
 
     <Copy SourceFiles="@(Assets_Fonts)" DestinationFiles="wwwroot/dist/fonts/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(Assets_Markdown)" DestinationFiles="wwwroot/dist/css/%(RecursiveDir)%(Filename)%(Extension)" />
   </Target>
  
 </Project>

--- a/src/Submissions/Api/Areas/Admin/Views/Biobanks/Index.cshtml
+++ b/src/Submissions/Api/Areas/Admin/Views/Biobanks/Index.cshtml
@@ -29,16 +29,17 @@
                 {
                     <tr class="@(biobank.IsSuspended ? "danger" : "")">
                         <td class="vtop">
-                            @Html.ActionLink(@biobank.Name, "Index", "Profile", new { Area = "Biobank", id=@biobank.BiobankExternalId }, null)
+                            @Html.ActionLink(@biobank.Name, "Biobank", "Profile", new { Area = "", id=@biobank.BiobankExternalId }, null)
                         </td>
                         <td class="vtop">
                             <a href="mailto:@biobank.ContactEmail">@biobank.ContactEmail</a>
-                        </td>
                         <td class="vtop">
-                            @(biobank.IsSuspended ? Html.Raw("Suspended") : Html.Raw("Active"))
+                          @(biobank.IsSuspended ? "Suspended" : "Active")
                         </td>
                         <td>
-                            @Html.ActionLink("Admin", "BiobankAdmin", "Biobanks", new {id = biobank.BiobankId}, new {@class = "btn btn-edit"})
+                            <a href="@Url.Action("BiobankAdmin", "Biobanks", new { Area = "Admin", id = biobank.BiobankId })">
+                                <span class="fa fa-tools labelled-icon"></span>Admin
+                            </a>
                         </td>
                     </tr>
                 }

--- a/src/Submissions/Api/Areas/Admin/Views/Biobanks/Index.cshtml
+++ b/src/Submissions/Api/Areas/Admin/Views/Biobanks/Index.cshtml
@@ -29,7 +29,7 @@
                 {
                     <tr class="@(biobank.IsSuspended ? "danger" : "")">
                         <td class="vtop">
-                            @Html.ActionLink(@biobank.Name, "Biobank", "Profile", new { Area = "", id=@biobank.BiobankExternalId }, null)
+                            @Html.ActionLink(@biobank.Name, "Biobank", "Profile", new { Area = "", id=biobank.BiobankExternalId }, null)
                         </td>
                         <td class="vtop">
                             <a href="mailto:@biobank.ContactEmail">@biobank.ContactEmail</a>

--- a/src/Submissions/Api/Areas/Admin/Views/Biobanks/Index.cshtml
+++ b/src/Submissions/Api/Areas/Admin/Views/Biobanks/Index.cshtml
@@ -33,6 +33,7 @@
                         </td>
                         <td class="vtop">
                             <a href="mailto:@biobank.ContactEmail">@biobank.ContactEmail</a>
+                        </td>
                         <td class="vtop">
                           @(biobank.IsSuspended ? "Suspended" : "Active")
                         </td>

--- a/src/Submissions/Api/Areas/Biobank/Views/Collections/EditSampleSet.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Collections/EditSampleSet.cshtml
@@ -58,7 +58,7 @@
             }
 
             // Material Preservation Details
-            @if (!string.IsNullOrEmpty(Model.MaterialPreservationDetailsJson))
+            @if (Model.MaterialPreservationDetails.Count > 0)
             {
                 @:sampleSetVM.materialPreservationDetails(ko.utils.arrayMap(@Html.Raw(Model.MaterialPreservationDetailsJson), function(x)
                 @:{

--- a/src/Submissions/Api/Areas/Biobank/Views/Collections/_SampleSetSharedFields.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Collections/_SampleSetSharedFields.cshtml
@@ -105,7 +105,7 @@
             </thead>
 
             <tbody data-bind="dataTablesForEach: {data: materialPreservationDetails, dataTableOptions: {
-                          paging: false,
+                          paging: true,
                           searching: false,
                           info: false,
                           columnDefs: [{ 'orderable': false, 'targets': '_all' }]

--- a/src/Submissions/Api/Areas/Biobank/Views/Report/Analytics.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Report/Analytics.cshtml
@@ -7,7 +7,7 @@
     ViewBag.Title = "Analytics";
 }
 
-<partial name = "_BiobankTabs" model ="Analytics" />
+@await Html.PartialAsync("_BiobankTabs", "Analytics")
 
 @* Report Header *@
 <h1>TDCC Analytics Report</h1>

--- a/src/Submissions/Api/Auth/AuthPolicies.cs
+++ b/src/Submissions/Api/Auth/AuthPolicies.cs
@@ -141,7 +141,7 @@ namespace Biobanks.Submissions.Api.Auth
 
               // check if we allow suspended biobanks
               var siteOptions = httpContext?.RequestServices.GetService<IOptions<SitePropertiesOptions>>();
-              if (!siteOptions.Value.AllowSuspendedBiobanks)
+              if (siteOptions != null && !siteOptions.Value.AllowSuspendedBiobanks)
               {
                 // get the biobank
                 var organisationService = httpContext?.RequestServices.GetService<IOrganisationDirectoryService>();

--- a/src/Submissions/Api/Auth/AuthPolicies.cs
+++ b/src/Submissions/Api/Auth/AuthPolicies.cs
@@ -11,7 +11,9 @@ using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Config;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Biobanks.Submissions.Api.Auth
 {
@@ -107,16 +109,21 @@ namespace Biobanks.Submissions.Api.Auth
               if (!biobanks.ContainsKey(biobankId))
                 return false;
 
-              // get the biobank
-              var organisationService = httpContext?.RequestServices.GetService<IOrganisationDirectoryService>();
-              if (organisationService is null)
-                return false;
+              // check if we allow suspended biobanks
+              var siteOptions = httpContext?.RequestServices.GetService<IOptions<SitePropertiesOptions>>();
+              if (!siteOptions.Value.AllowSuspendedBiobanks)
+              {
+                // get the biobank
+                var organisationService = httpContext?.RequestServices.GetService<IOrganisationDirectoryService>();
+                if (organisationService is null)
+                  return false;
 
-              var biobank = Task.Run(async () => await organisationService.Get(biobankId)).Result;
+                var biobank = Task.Run(async () => await organisationService.Get(biobankId)).Result;
 
-              //only fail if suspended
-              if (biobank is { IsSuspended: true })
-                return false;
+                //only fail if suspended
+                if (biobank is { IsSuspended: true })
+                  return false;
+              }
 
               return true;
             })

--- a/src/Submissions/Api/Config/SitePropertiesOptions.cs
+++ b/src/Submissions/Api/Config/SitePropertiesOptions.cs
@@ -32,7 +32,7 @@ namespace Biobanks.Submissions.Api.Config
     public string GoogleRecaptchaPublicKey { get; set; } = string.Empty;
     
     /// <summary>
-    /// 
+    /// Allow users to access their own suspended biobanks.
     /// </summary>
     public bool AllowSuspendedBiobanks { get; set; } = true;
 

--- a/src/Submissions/Api/Config/SitePropertiesOptions.cs
+++ b/src/Submissions/Api/Config/SitePropertiesOptions.cs
@@ -30,6 +30,11 @@ namespace Biobanks.Submissions.Api.Config
     public string GoogleRecaptchaSecret { get; set; } = string.Empty;
     
     public string GoogleRecaptchaPublicKey { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool AllowSuspendedBiobanks { get; set; } = true;
 
     /// <summary>
     /// How long in milliseconds authenticated user sessions should last on the client side

--- a/src/Submissions/Api/Frontend/js/pages/Admin/adac-disease-statuses.js
+++ b/src/Submissions/Api/Frontend/js/pages/Admin/adac-disease-statuses.js
@@ -197,7 +197,7 @@ $(function () {
     columns: [
       { data: "description" },
       { data: "ontologyTermId" },
-      { data: "otherTerms" },
+      { data: "otherTerms", defaultContent: "" },
       { data: "collectionCapabilityCount" },
       {
         data: "displayOnDirectory",
@@ -287,7 +287,7 @@ $(function () {
     ],
     createdRow: function (row, data, dataIndex) {
       // Highlight In Use Disease Statuses
-      if (data.CollectionCapabilityCount > 0) {
+      if (data.collectionCapabilityCount > 0) {
         $(row).addClass("info");
       }
 

--- a/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankIndexService.cs
@@ -129,6 +129,10 @@ namespace Biobanks.Submissions.Api.Services.Directory
           .ThenInclude(x => x.MaterialType)
       .Include(x => x.MaterialDetails)
           .ThenInclude(x => x.StorageTemperature)
+      .Include(x => x.MaterialDetails)
+          .ThenInclude(x => x.ExtractionProcedure)
+      .Include(x => x.MaterialDetails)
+          .ThenInclude(x => x.PreservationType)
       .Include(x => x.Collection.Organisation.Country)
       .Include(x => x.Collection.Organisation.County)
       .FirstOrDefaultAsync()
@@ -306,7 +310,9 @@ namespace Biobanks.Submissions.Api.Services.Directory
                             x.StorageTemperature.SortOrder
                           }),
                           MacroscopicAssessment = x.MacroscopicAssessment.Value,
-                          PercentageOfSampleSet = x.CollectionPercentage?.Value
+                          PercentageOfSampleSet = x.CollectionPercentage?.Value,
+                          PreservationType = x.PreservationType?.Value,
+                          ExtractionProcedure = x.ExtractionProcedure?.Value
                         })
                         .ToList(),
         SampleSetSummary = SampleSetExtensions.BuildSampleSetSummary(

--- a/src/Submissions/Api/Services/Directory/OrganisationDirectoryService.cs
+++ b/src/Submissions/Api/Services/Directory/OrganisationDirectoryService.cs
@@ -440,7 +440,7 @@ namespace Biobanks.Submissions.Api.Services.Directory
             => await QueryRegistrationRequests()
                 .AsNoTracking()
                 .Where(x =>
-                    x.AcceptedDate != null &&
+                    x.AcceptedDate != null ||
                     x.DeclinedDate != null)
                 .ToListAsync();
 

--- a/src/Submissions/Api/Views/Account/Index.cshtml
+++ b/src/Submissions/Api/Views/Account/Index.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = "Account details";
 }
 
-<h2>Account details @Html.ActionLink("Edit your account details", "Edit", "Account", null,new { @class = "btn btn-primary pull-right" })</h2>
+<h2>Account details @Html.ActionLink("Edit your account details", "Edit", "Account", null, new { @class = "btn btn-primary pull-right" })</h2>
 
 <dl class="dl-horizontal">
     <dt class="form-group">

--- a/src/Submissions/Api/Views/Account/Index.cshtml
+++ b/src/Submissions/Api/Views/Account/Index.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = "Account details";
 }
 
-<h2>Account details @Html.ActionLink("Edit your account details", "Edit", null, new { @class = "btn btn-primary pull-right" })</h2>
+<h2>Account details @Html.ActionLink("Edit your account details", "Edit", "Account", null,new { @class = "btn btn-primary pull-right" })</h2>
 
 <dl class="dl-horizontal">
     <dt class="form-group">

--- a/src/Submissions/Api/Views/Shared/_Layout.cshtml
+++ b/src/Submissions/Api/Views/Shared/_Layout.cshtml
@@ -19,6 +19,7 @@
     <title>@siteProperties.PageTitle - @ViewBag.Title</title>
 
     <link rel="stylesheet" href="~/dist/css/site.min.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/override.css" asp-append-version="true" />
 
     <script type="text/javascript">
         window.cookieconsent_options = {

--- a/src/Submissions/Api/bundleconfig.json
+++ b/src/Submissions/Api/bundleconfig.json
@@ -46,7 +46,7 @@
       // DataTables
       "Frontend/node_modules/datatables.net/js/jquery.dataTables.min.js",
       "Frontend/node_modules/datetime-moment/datetime-moment.js",
-      "Frontend/node_modules/datatables.net-bs/js/dataTables.bootstrap.min.js", // TODO: copy images
+      "Frontend/node_modules/datatables.net-bs/js/dataTables.bootstrap.min.js",
       "Frontend/node_modules/datatables.net-buttons/js/dataTables.buttons.min.js",
       "Frontend/node_modules/datatables.net-buttons-bs/js/buttons.bootstrap.min.js",
       "Frontend/node_modules/datatables.net-buttons/js/buttons.html5.min.js",
@@ -80,7 +80,7 @@
   {
     "outputFileName": "wwwroot/dist/js/markdown-editor.min.js",
     "inputFiles": [
-      "Frontend/node_modules/markdowndeep/clientSide/MarkdownDeepLib.min.js", // TODO: copy images
+      "Frontend/node_modules/markdowndeep/clientSide/MarkdownDeepLib.min.js",
       "Frontend/js/init/markdown-editor.js"
     ],
     "minify": { "enabled": true },

--- a/src/Submissions/Api/wwwroot/override.css
+++ b/src/Submissions/Api/wwwroot/override.css
@@ -1,0 +1,1 @@
+/* Add any styles to override */


### PR DESCRIPTION
## Overview

Including:

- [AB#84967](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/84967) - Adds an empty `override.css` to the repo, and layout, so styles can be easily overridden (FINDX)
- [AB#84958](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/84958) - Adds any assets needed copying in `Api.csproj`
- [AB#98808](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/98808) - Fixes Historical biobank requests, previous accepted biobank requests were completely filtered out (this is a bug from the live app)
- [AB#98475](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/98475) - Resolves a duplicate material type bug with Knockout - changing paging to `true` was enough.
- [AB#98936](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/98936) - Fix a datatable error, where being initialised with an empty list caused it to error.
- [AB#98936](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/98936) - Fix Disease Statuses ref data datatables loading - needed a default value as the endpoint does not provide the field if there are no 'other terms'.
- [AB#98937](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/98937) - Fix sample set material type properties not being added to the index on create/edit.
- Adds `AllowSuspendedBiobanks` to config, and adds the check for this in the auth policies. This was previously in the app, but was missing. 
- Some cosmetic fixes (tables and buttons)
