### PR TITLE
AB#98894: Fix biobank suspended warning

### DIFF
--- a/src/Submissions/Api/Areas/Biobank/Controllers/CapabilitiesController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/CapabilitiesController.cs
@@ -1,7 +1,7 @@
 using Biobanks.Entities.Data;
 using Biobanks.Submissions.Api.Areas.Biobank.Models.Capabilities;
-using Biobanks.Submissions.Api.Areas.Biobank.Models.Collections;
 using Biobanks.Submissions.Api.Auth;
+using Biobanks.Submissions.Api.Filters;
 using Biobanks.Submissions.Api.Models.Directory;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Utilities;
@@ -14,6 +14,7 @@ namespace Biobanks.Submissions.Api.Areas.Biobank.Controllers;
 
 [Area("Biobank")]
 [Authorize(nameof(AuthPolicies.IsBiobankAdmin))]
+[SuspendedWarning]
 public class CapabilitiesController : Controller
 {
   private readonly IAbstractCrudService _abstractCrudService;

--- a/src/Submissions/Api/Areas/Biobank/Controllers/CollectionsController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/CollectionsController.cs
@@ -3,8 +3,7 @@ using Biobanks.Entities.Data;
 using Biobanks.Entities.Data.ReferenceData;
 using Biobanks.Submissions.Api.Areas.Biobank.Models.Collections;
 using Biobanks.Submissions.Api.Areas.Biobank.Models.Capabilities;
-using Biobanks.Submissions.Api.Constants;
-using Biobanks.Submissions.Api.Models.Biobank;
+using Biobanks.Submissions.Api.Filters;
 using Biobanks.Submissions.Api.Models.Shared;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Utilities;
@@ -23,6 +22,7 @@ namespace Biobanks.Submissions.Api.Areas.Biobank.Controllers;
 
 [Area("Biobank")]
 [Authorize(nameof(AuthPolicies.IsBiobankAdmin))]
+[SuspendedWarning]
 public class CollectionsController : Controller
 {
   private readonly ICollectionService _collectionService;

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -495,7 +495,7 @@ public class ProfileController : Controller
             SharingOptOut = bb.SharingOptOut,
             EthicsRegistration = bb.EthicsRegistration,
             BiobankAnnualStatistics = bb.OrganisationAnnualStatistics,
-            OtherRegistrationReason = bb.OtherRegistrationReason,
+            OtherRegistrationReason = bb.OtherRegistrationReason
         };
 
         model = await AddCountiesToModel(model);

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -167,6 +167,9 @@ public class ProfileController : Controller
                 biobank.OrganisationServiceOfferings.Add(new OrganisationServiceOffering
                 { OrganisationId = biobank.OrganisationId, ServiceOfferingId = sm.ServiceOfferingId });
         }
+        
+        // Preserve its suspended state
+        biobank.IsSuspended = await _organisationService.IsSuspended(biobank.OrganisationId);
 
         biobank.Logo = logoName;
         return await _organisationService.Update(biobank);
@@ -492,7 +495,7 @@ public class ProfileController : Controller
             SharingOptOut = bb.SharingOptOut,
             EthicsRegistration = bb.EthicsRegistration,
             BiobankAnnualStatistics = bb.OrganisationAnnualStatistics,
-            OtherRegistrationReason = bb.OtherRegistrationReason
+            OtherRegistrationReason = bb.OtherRegistrationReason,
         };
 
         model = await AddCountiesToModel(model);

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -16,8 +16,8 @@ using Biobanks.Submissions.Api.Auth;
 using Biobanks.Submissions.Api.Config;
 using Biobanks.Submissions.Api.Constants;
 using Biobanks.Submissions.Api.Extensions;
+using Biobanks.Submissions.Api.Filters;
 using Biobanks.Submissions.Api.Models.Directory;
-using Biobanks.Submissions.Api.Models.Profile;
 using Biobanks.Submissions.Api.Models.Shared;
 using Biobanks.Submissions.Api.Services.Directory;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
@@ -36,6 +36,7 @@ namespace Biobanks.Submissions.Api.Areas.Biobank.Controllers;
 
 [Area("Biobank")]
 [Authorize(nameof(AuthPolicies.IsBiobankAdmin))]
+[SuspendedWarning]
 public class ProfileController : Controller
 {
     private readonly IReferenceDataCrudService<AnnualStatisticGroup> _annualStatisticGroupService;

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ReportController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ReportController.cs
@@ -6,6 +6,7 @@ using AutoMapper;
 using Biobanks.Submissions.Api.Areas.Biobank.Models;
 using Biobanks.Submissions.Api.Auth;
 using Biobanks.Submissions.Api.Config;
+using Biobanks.Submissions.Api.Filters;
 using Biobanks.Submissions.Api.Services.Directory;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.ApplicationInsights;
@@ -17,7 +18,7 @@ namespace Biobanks.Submissions.Api.Areas.Biobank.Controllers;
 
 [Area("Biobank")]
 [Authorize(nameof(AuthPolicies.IsBiobankAdmin))]
-
+[SuspendedWarning]
 public class ReportController : Controller
 {
     private readonly IAnalyticsReportGenerator _analyticsReportGenerator;

--- a/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
@@ -7,6 +7,7 @@ using Biobanks.Entities.Data.ReferenceData;
 using Biobanks.Submissions.Api.Areas.Biobank.Models.Settings;
 using Biobanks.Submissions.Api.Auth;
 using Biobanks.Submissions.Api.Constants;
+using Biobanks.Submissions.Api.Filters;
 using Biobanks.Submissions.Api.Models.Emails;
 using Biobanks.Submissions.Api.Models.Shared;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
@@ -21,6 +22,7 @@ namespace Biobanks.Submissions.Api.Areas.Biobank.Controllers;
 
 [Area("Biobank")]
 [Authorize(nameof(AuthPolicies.IsBiobankAdmin))]
+[SuspendedWarning]
 public class SettingsController : Controller
 {
   private readonly UserManager<ApplicationUser> _userManager;

--- a/src/Submissions/Api/Filters/SuspendedWarningAttribute.cs
+++ b/src/Submissions/Api/Filters/SuspendedWarningAttribute.cs
@@ -1,0 +1,41 @@
+using Biobanks.Submissions.Api.Services.Directory.Contracts;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Biobanks.Submissions.Api.Filters;
+
+/// <summary>
+/// An <see cref="ActionFilterAttribute"/> that can be applied to a Biobank controller
+/// to check if a biobank is suspended and show the warning message if needed.
+/// </summary>
+/// <remarks>
+/// This attribute overrides the OnActionExecuting method of the base class and checks
+/// the 'biobankId' parameter of the action's context to determine if the biobank is suspended. 
+/// If it is, it sets the 'ShowSuspendedWarning' property of the controller's ViewBag to true.
+/// </remarks>
+public class SuspendedWarningAttribute : ActionFilterAttribute
+{
+  /// <summary>
+  /// Overrides the <see cref="OnActionExecuting"/> method of the base class to implement the suspended warning
+  /// functionality.
+  /// </summary>
+  /// <param name="context">The context of the action being executed.</param>
+  public override async void OnActionExecuting(ActionExecutingContext context)
+  {
+    if (context.Controller is Controller controller)
+    {
+      // TODO: Make this safer - can't assume every action on the controller has a biobankId.
+      int biobankId = (int)context.ActionArguments["biobankId"];
+      // int.TryParse(context.ActionArguments.TryGetValue("biobankId", out var biobankId) ?? String.Empty);
+      // if (!int.TryParse((string?)httpContext?.Request.RouteValues.GetValueOrDefault("biobankId") ?? string.Empty,
+      //       out var biobankId))
+      //   return false;
+  
+      var organisationService = context.HttpContext.RequestServices.GetService<IOrganisationDirectoryService>();
+      
+      controller.ViewBag.ShowSuspendedWarning = await organisationService.IsSuspended(biobankId);
+    }
+  }
+}
+

--- a/src/Submissions/Api/Filters/SuspendedWarningAttribute.cs
+++ b/src/Submissions/Api/Filters/SuspendedWarningAttribute.cs
@@ -8,13 +8,14 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Biobanks.Submissions.Api.Filters;
 
 /// <summary>
-/// An <see cref="ActionFilterAttribute"/> that can be applied to a Biobank controller
-/// to check if a biobank is suspended and show the warning message if needed.
+/// An <see cref="ActionFilterAttribute"/> that can be applied to a biobank area controller
+/// to check if a biobank is suspended, and show the warning message if it is.
 /// </summary>
 /// <remarks>
-/// This attribute overrides the OnActionExecuting method of the base class and checks
+/// This attribute overrides the <see cref="OnActionExecuting"/> method of the base class and checks
 /// the 'biobankId' parameter of the action's context to determine if the biobank is suspended. 
 /// If it is, it sets the 'ShowSuspendedWarning' property of the controller's ViewBag to true.
+/// The property is implemented in the 'SuspendedWarning' partial view.
 /// </remarks>
 public class SuspendedWarningAttribute : ActionFilterAttribute
 {
@@ -27,7 +28,7 @@ public class SuspendedWarningAttribute : ActionFilterAttribute
   {
     if (context.Controller is Controller controller)
     {
-      // Get the biobankId from the route parameter safely
+      // Get the biobankId from the route value safely
       int.TryParse((string)context.RouteData.Values.GetValueOrDefault("biobankId") ?? string.Empty,
         out var biobankId);
 


### PR DESCRIPTION
## Overview

Adds an attribute filter to check if a biobank is suspended, and show the warning message if it is.  

Additionally:
- [AB#99393](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/99393): Fix a user updating their own biobank which would remove the suspension. 
- [AB#89403](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/89403): Related - check if warnings are working
