### PR TITLE
AB#99558: Update to BuildBundlerMinifier fork

### DIFF
--- a/src/Submissions/Api/Api.csproj
+++ b/src/Submissions/Api/Api.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
+    <PackageReference Include="BuildBundlerMinifierPlus" Version="5.3.0" />
     <PackageReference Include="ClacksMiddlware" Version="2.1.0" />
     <PackageReference Include="cloudscribe.Web.Navigation" Version="6.0.1" />
     <PackageReference Include="cloudscribe.Web.SiteMap" Version="6.0.0" />


### PR DESCRIPTION
## Overview

Fixes the project css bundling - the BuildBundlerMinifier library is no longer in development, so moving to [BuildBundlerMinifierPlus](https://github.com/salarcode/BundlerMinifierPlus) to benefit from NUglify updates. 

The repo now will work from a fresh install.
