### PR TITLE
AB#99991: Fixes Configuration manager, todos, and api auth

### DIFF
--- a/src/Submissions/Api/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/src/Submissions/Api/Areas/Admin/Controllers/AnalyticsController.cs
@@ -37,7 +37,7 @@ public class AnalyticsController : Controller
     {
         //If turned off in site config
         if (await _configService.GetFlagConfigValue(ConfigKey.DisplayAnalytics) == false)
-            return RedirectToAction(""); // TODO: Redirect to reference data controller lockedref.
+            return RedirectToAction("LockedRef", "ReferenceData");
 
         //set default options
         if (year == 0)

--- a/src/Submissions/Api/Areas/Biobank/Views/Collections/_CollectionSharedFields.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Collections/_CollectionSharedFields.cshtml
@@ -1,11 +1,13 @@
-@using System.Configuration
+@using Biobanks.Submissions.Api.Config
+@using Microsoft.Extensions.Options
+@inject IOptions<SitePropertiesOptions> _sitePropertiesOptions
 @model Biobanks.Submissions.Api.Areas.Biobank.Models.Collections.AbstractCRUDCollectionModel
 
 <div id="bloodhound" class="form-group">
     <label for="Diagnosis" class="col-sm-4 control-label required">
         @Html.DisplayNameFor(x => x.Diagnosis)
         <span class="fa fa-info-circle help-icon-button help-icon-for-label help-label-diseasestatus"></span>
-        <span id="support-email" data-email="@ConfigurationManager.AppSettings["AdacSupportEmail"]"></span>
+        <span id="support-email" data-email="@_sitePropertiesOptions.Value.SupportAddress"></span>
     </label>
     <div class="col-sm-8">
         @Html.TextBoxFor(x => x.Diagnosis, new { @class = "form-control diagnosis-search", autocomplete = "off" })

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/Edit.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/Edit.cshtml
@@ -278,9 +278,7 @@
 
     @Html.HiddenFor(x => x.AccessConditionId)
     @Html.HiddenFor(x => x.CollectionTypeId)
-
-    @* TODO: 'other' registration reason *@
-
+    
     <div class="form-group">
         <div class="col-sm-12 text-center">
           @Html.ActionLink("Cancel", "Index", "Profile", new { biobankId = Model.BiobankId }, new { @class = "btn btn-default" })

--- a/src/Submissions/Api/Areas/Biobank/Views/Profile/EditorTemplates/AddFunderModel.cshtml
+++ b/src/Submissions/Api/Areas/Biobank/Views/Profile/EditorTemplates/AddFunderModel.cshtml
@@ -10,7 +10,6 @@
   var fieldWidth = (bool?)ViewData["Modal"] ?? false ? "col-sm-6" : "col-sm-4";
 }
 
-@*  TODO Typeahead *@
 <div id="bloodhound" class="form-group">
   @Html.LabelFor(x => x.FunderName, new { @class = @labelWidth + " control-label required" })
   <div class="@fieldWidth">
@@ -18,16 +17,3 @@
       new { @class = "form-control", placeholder = "Name", data_resource_url = Url.Action("SearchFunders") })
   </div>
 </div>
-
-@*<div class="row">
-    <div id="bloodhound" class="form-group">
-        <div class="col-sm-6">
-            <div class="input-group">
-                @Html.TextBoxFor(x => x.BiobankName, new { @class = "form-control", autocomplete = "off" })
-                <span class="input-group-btn">
-                    <button class="btn btn-primary" type="submit">Add</button>
-                </span>
-            </div>
-        </div>
-    </div>
-</div>*@

--- a/src/Submissions/Api/Controllers/ReferenceData/AccessConditionController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AccessConditionController.cs
@@ -7,10 +7,12 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
   
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/AgeRangeController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AgeRangeController.cs
@@ -8,9 +8,11 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/AnnualStatisticController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AnnualStatisticController.cs
@@ -7,11 +7,12 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
-
+using Biobanks.Submissions.Api.Auth;
 
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/AnnualStatisticGroupController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AnnualStatisticGroupController.cs
@@ -7,9 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/AssociatedDataProcurementTimeFrameController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AssociatedDataProcurementTimeFrameController.cs
@@ -5,13 +5,14 @@ using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using System;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/AssociatedDataTypeController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AssociatedDataTypeController.cs
@@ -1,20 +1,18 @@
 ﻿using Biobanks.Entities.Data.ReferenceData;
 using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Submissions.Api.Models.Shared;
-using Biobanks.Submissions.Api.Models.Submissions;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
-using Swashbuckle.AspNetCore.Annotations;
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]
@@ -38,7 +36,7 @@ namespace Biobanks.Submissions.Api.Controllers.ReferenceData
         /// </summary>
         /// <returns>List of Associated Data Type.</returns>
         /// <response code="200">Request Successful</response>
-        [HttpGet("")]
+        [HttpGet]
         [AllowAnonymous]
         public async Task<IActionResult> Get()
         {

--- a/src/Submissions/Api/Controllers/ReferenceData/AssociatedDataTypeGroupController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/AssociatedDataTypeGroupController.cs
@@ -1,20 +1,16 @@
 ﻿using Biobanks.Entities.Data.ReferenceData;
-using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Submissions.Api.Models.Shared;
-using Biobanks.Submissions.Api.Models.Submissions;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
-using Swashbuckle.AspNetCore.Annotations;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/BiobankController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/BiobankController.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
-    //TODO: Register IOrganisationService in startup.cs
-
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/BiobankController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/BiobankController.cs
@@ -1,12 +1,13 @@
-﻿using Biobanks.Entities.Data;
-using Biobanks.Submissions.Api.Models.Submissions;
-using Biobanks.Submissions.Api.Services.Directory.Contracts;
+﻿using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/CollectionPercentageController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/CollectionPercentageController.cs
@@ -7,11 +7,12 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml;
+using Biobanks.Submissions.Api.Auth;
 
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/CollectionStatusController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/CollectionStatusController.cs
@@ -7,16 +7,17 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
-using Biobanks.Submissions.Api.Models.Submissions;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]
     public class CollectionStatusController : ControllerBase
     {
-        private IReferenceDataCrudService<CollectionStatus> _collectionStatusService;
+        private readonly IReferenceDataCrudService<CollectionStatus> _collectionStatusService;
 
         public CollectionStatusController(IReferenceDataCrudService<CollectionStatus> collectionStatusService)
         {

--- a/src/Submissions/Api/Controllers/ReferenceData/CollectionTypeController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/CollectionTypeController.cs
@@ -7,11 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
-using Biobanks.Submissions.Api.Models.Submissions;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
-
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/ConsentRestrictionController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/ConsentRestrictionController.cs
@@ -1,5 +1,4 @@
-﻿using Biobanks.Entities.Shared.ReferenceData;
-using Biobanks.Submissions.Api.Services.Directory.Contracts;
+﻿using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Models.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,10 +7,11 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Entities.Data.ReferenceData;
-using Biobanks.Submissions.Api.Models.Submissions;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/CountryController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/CountryController.cs
@@ -7,9 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/CountyController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/CountyController.cs
@@ -4,14 +4,15 @@ using Biobanks.Submissions.Api.Models.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/DiseaseStatusController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/DiseaseStatusController.cs
@@ -12,17 +12,18 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     public class DiseaseStatusController : ControllerBase
     {
         private readonly IOntologyTermService _ontologyTermService;
-
         private readonly IDiseaseStatusService _diseaseStatusService;
-        //TODO ADAC authorization
+
         public DiseaseStatusController(
             IOntologyTermService ontologyTermService,
             IDiseaseStatusService diseaseStatusService)

--- a/src/Submissions/Api/Controllers/ReferenceData/DonorCountController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/DonorCountController.cs
@@ -9,9 +9,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/ExtractionProcedureController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/ExtractionProcedureController.cs
@@ -1,8 +1,6 @@
 ﻿using Biobanks.Entities.Data.ReferenceData;
-using Biobanks.Submissions.Api.Services.Directory;
 using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Models.Shared;
-using Biobanks.Submissions.Api.Config;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -12,9 +10,11 @@ using System.Threading.Tasks;
 using Biobanks.Entities.Shared.ReferenceData;
 using Biobanks.Submissions.Api.Services.Directory.Constants;
 using System.Collections.Generic;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/MacroscopicAssessmentController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/MacroscopicAssessmentController.cs
@@ -9,9 +9,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/MaterialTypeController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/MaterialTypeController.cs
@@ -7,9 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/MaterialTypeGroupController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/MaterialTypeGroupController.cs
@@ -7,9 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/PreservationTypeController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/PreservationTypeController.cs
@@ -7,9 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/RegistrationDomainRuleController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/RegistrationDomainRuleController.cs
@@ -8,9 +8,11 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Biobanks.Entities.Data;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]
@@ -29,6 +31,7 @@ namespace Biobanks.Submissions.Api.Controllers.ReferenceData
         /// <returns>The list of Registration Domain Rules.</returns>
         /// <response code="200">Request Successful</response>
         [HttpGet]
+        [AllowAnonymous]
         [SwaggerResponse(200, Type = typeof(RegistrationDomainRuleModel))]
         public async Task<IList> Get() =>
             (await _registrationDomainService.ListRules())

--- a/src/Submissions/Api/Controllers/ReferenceData/RegistrationReasonController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/RegistrationReasonController.cs
@@ -8,9 +8,11 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/SampleCollectionModeController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/SampleCollectionModeController.cs
@@ -1,5 +1,4 @@
-﻿using Biobanks.Entities.Shared.ReferenceData;
-using Biobanks.Submissions.Api.Services.Directory.Contracts;
+﻿using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Models.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,9 +7,11 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/ServiceOfferingController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/ServiceOfferingController.cs
@@ -7,11 +7,12 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
-using System;
 using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/SexController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/SexController.cs
@@ -7,9 +7,11 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/SopStatusController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/SopStatusController.cs
@@ -1,5 +1,4 @@
-﻿using Biobanks.Entities.Shared.ReferenceData;
-using Biobanks.Submissions.Api.Services.Directory.Contracts;
+﻿using Biobanks.Submissions.Api.Services.Directory.Contracts;
 using Biobanks.Submissions.Api.Models.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,10 +7,11 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Entities.Data.ReferenceData;
-using Biobanks.Submissions.Api.Services.Directory;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Controllers/ReferenceData/StorageTemperatureController.cs
+++ b/src/Submissions/Api/Controllers/ReferenceData/StorageTemperatureController.cs
@@ -9,10 +9,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Biobanks.Submissions.Api.Config;
 using Biobanks.Submissions.Api.Services.Directory;
-using Biobanks.Entities.Data.ReferenceData;
+using Biobanks.Submissions.Api.Auth;
 
 namespace Biobanks.Submissions.Api.Controllers.ReferenceData
 {
+    [Authorize(nameof(AuthPolicies.IsDirectoryAdmin))]
     [Route("api/[controller]")]
     [ApiController]
     [ApiExplorerSettings(GroupName = "Reference Data")]

--- a/src/Submissions/Api/Models/Shared/InviteRegisterEntityAdminModel.cs
+++ b/src/Submissions/Api/Models/Shared/InviteRegisterEntityAdminModel.cs
@@ -20,7 +20,6 @@ public class InviteRegisterEntityAdminModel
   /// <summary>
   /// The controller the form will be submitted to (either the biobank, network, or Admin depending on who is adding admins)
   /// </summary>
-  ///TODO: Fix once JS urls are done 
   public string ControllerName { get; set; }
   
   /// <summary>

--- a/src/Submissions/Api/Pages/StatusCode.cshtml
+++ b/src/Submissions/Api/Pages/StatusCode.cshtml
@@ -1,5 +1,7 @@
 @page "{statusCode:int}"
-@using System.Configuration
+@using Biobanks.Submissions.Api.Config
+@using Microsoft.Extensions.Options
+@inject IOptions<SitePropertiesOptions> _sitePropertiesOptions
 @model Biobanks.Submissions.Api.Pages.StatusCodeModel
 
 @{
@@ -37,7 +39,7 @@
                         <li>You could verify the logged in user is you (at the top right of this page).</li>
                         <li>You could try logging out and logging back in again</li>
                         <li>You could use the navigation above to get back to where you were, and try again.</li>
-                        <li>You could head back to the <a href="/">@ConfigurationManager.AppSettings["DirectoryName"] homepage</a>.</li>
+                        <li>You could head back to the <a href="/">@_sitePropertiesOptions.Value.ServiceName homepage</a>.</li>
                     </ul>
                 </div>
             </div>

--- a/src/Submissions/Api/Services/Directory/BiobankService.cs
+++ b/src/Submissions/Api/Services/Directory/BiobankService.cs
@@ -55,7 +55,6 @@ namespace Biobanks.Submissions.Api.Services.Directory
         public async Task<IEnumerable<ApplicationUser>> ListSoleBiobankAdminIdsAsync(int biobankId)
         {
           // Returns users who have admin role only for this biobank
-          // TODO remove the generic repo when upgrading to netcore, as it doesn't support groupby fully
           var admins = await _db.OrganisationUsers.AsNoTracking().ToListAsync();
           var adminIds = admins.GroupBy(a => a.OrganisationUserId)
             .Where(g => g.Count() == 1)

--- a/src/Submissions/Api/Services/Directory/Contracts/IAnalyticsReportGenerator.cs
+++ b/src/Submissions/Api/Services/Directory/Contracts/IAnalyticsReportGenerator.cs
@@ -6,9 +6,7 @@ namespace Biobanks.Submissions.Api.Services.Directory.Contracts
 {
     public interface IAnalyticsReportGenerator
     {
-        void Dispose();
         Task<OrganisationReportDto> GetBiobankReport(int Id, int year, int quarter, int period);
-        Task<DirectoryAnalyticReportDTO> GetDirectoryReport(int year, int quarter, int period);
         Task<ProfileStatusDTO> GetProfileStatus(string biobankId);
     }
 }


### PR DESCRIPTION
## Overview

- AB#100058 : Fixes vulnerable API endpoints missing auth policies, previously any authorised user (including non-admin) could change reference data. 
- AB#99991 : Replaces a few uses of ConfigurationManager.
- Remove now unused functionality in the AnalyticsReportGenerator
- Remove resolved TODO's in the app 