### PR TITLE
AB#100197: Fix auth vulnerabilities

### DIFF
--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -270,8 +270,7 @@ public class ProfileController : Controller
         model.Countries = await _countryService.List();
         return model;
     }
-
-    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
+    
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<ActionResult> Edit(BiobankDetailsModel model)

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -270,7 +270,7 @@ public class ProfileController : Controller
         model.Countries = await _countryService.List();
         return model;
     }
-    
+
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<ActionResult> Edit(BiobankDetailsModel model)

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -605,9 +605,9 @@ public class ProfileController : Controller
         });
     }
     
-    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
     [HttpPost]
     [ValidateAntiForgeryToken]
+    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
     public async Task<ActionResult> AddFunderAjax(int biobankId, AddFunderModel model)
     {
         if (!ModelState.IsValid)

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ProfileController.cs
@@ -271,6 +271,7 @@ public class ProfileController : Controller
         return model;
     }
 
+    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<ActionResult> Edit(BiobankDetailsModel model)
@@ -584,10 +585,6 @@ public class ProfileController : Controller
                 Name = bbFunder.Value
             }).ToList();
     
-    public async Task<JsonResult> GetFundersAjax(int biobankId, int timeStamp = 0)
-        //timeStamp can be used to avoid caching issues, notably on IE
-        => Json(await GetFundersAsync(biobankId));
-    
     public ActionResult AddFunderSuccess(int biobankId, string name)
     {
         //This action solely exists so we can set a feedback message
@@ -598,6 +595,7 @@ public class ProfileController : Controller
         return RedirectToAction("Funders", new { biobankId = biobankId });
     }
     
+    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
     public async Task<ActionResult> AddFunderAjax(int biobankId)
     {
         var bb = await _organisationService.Get(biobankId);
@@ -608,6 +606,7 @@ public class ProfileController : Controller
         });
     }
     
+    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<ActionResult> AddFunderAjax(int biobankId, AddFunderModel model)
@@ -730,7 +729,7 @@ public class ProfileController : Controller
 
     }
 
-    public async Task<Publication> PublicationSearch(string publicationId, int biobankId)
+    private async Task<Publication> PublicationSearch(string publicationId, int biobankId)
     {
         // Find Given Publication
         var publications = await _publicationService.ListByOrganisation(biobankId);

--- a/src/Submissions/Api/Areas/Biobank/Controllers/ReportController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/ReportController.cs
@@ -39,6 +39,7 @@ public class ReportController : Controller
         _telemetryClient = telemetryClient;
     }
 
+    [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
     public async Task<ActionResult> Analytics(int biobankId = 0, int year = 0, int endQuarter = 0, int reportPeriod = 0)
     {
         //If turned off in site config

--- a/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
@@ -90,13 +90,6 @@ public class SettingsController : Controller
             return admins;
         }
 
-        public async Task<ActionResult> GetAdminsAjax(int biobankId, bool excludeCurrentUser = false, int timeStamp = 0)
-        {
-            //timeStamp can be used to avoid caching issues, notably on IE
-            
-            return Ok(await GetAdminsAsync(biobankId, excludeCurrentUser));
-        }
-
         public ActionResult InviteAdminSuccess(int biobankId, string name)
         {
             //This action solely exists so we can set a feedback message
@@ -107,6 +100,7 @@ public class SettingsController : Controller
             return RedirectToAction("Admins", new { biobankId });
         }
 
+        [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
         public async Task<ActionResult> InviteAdminAjax(int biobankId)
         {
             var bb = await _organisationDirectoryService.Get(biobankId);
@@ -123,6 +117,7 @@ public class SettingsController : Controller
         }
 
         [HttpPost]
+        [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> InviteAdminAjax(InviteRegisterEntityAdminModel model)
         {
@@ -332,6 +327,7 @@ public class SettingsController : Controller
           return View(model);
         }
 
+        [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
         public async Task<ActionResult> AcceptNetworkRequest(int biobankId, int networkId)
         {
           var organisationNetwork = await _networkService.GetOrganisationNetwork(biobankId, networkId);

--- a/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
@@ -33,7 +33,6 @@ public class SettingsController : Controller
   private readonly IReferenceDataCrudService<AccessCondition> _accessConditionService;
   private readonly IReferenceDataCrudService<CollectionType> _collectionTypeService;
   private readonly ITokenLoggingService _tokenLoggingService;
-  private readonly SignInManager<ApplicationUser> _signInManager;
 
   public SettingsController(
       UserManager<ApplicationUser> userManager,
@@ -43,8 +42,7 @@ public class SettingsController : Controller
       INetworkService networkService,
       IReferenceDataCrudService<AccessCondition> accessConditionService,
       IReferenceDataCrudService<CollectionType> collectionTypeService,
-      ITokenLoggingService tokenLoggingService,
-      SignInManager<ApplicationUser> signInManager)
+      ITokenLoggingService tokenLoggingService)
   {
       _userManager = userManager;
       _biobankService = biobankService;
@@ -54,7 +52,6 @@ public class SettingsController : Controller
       _accessConditionService = accessConditionService;
       _collectionTypeService = collectionTypeService;
       _tokenLoggingService = tokenLoggingService;
-      _signInManager = signInManager;
   }
 
         #region Admins  

--- a/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
@@ -117,8 +117,8 @@ public class SettingsController : Controller
         }
 
         [HttpPost]
-        [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
         [ValidateAntiForgeryToken]
+        [Authorize(nameof(AuthPolicies.HasBiobankClaim))]
         public async Task<ActionResult> InviteAdminAjax(InviteRegisterEntityAdminModel model)
         {
             if (!ModelState.IsValid)

--- a/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
+++ b/src/Submissions/Api/Areas/Biobank/Controllers/SettingsController.cs
@@ -221,7 +221,7 @@ public class SettingsController : Controller
             var userBiobanks = await _organisationDirectoryService.ListByUserId(biobankUserId);
             
             if (!userBiobanks.Any())
-              //and remove them from the role if they are not.
+              // and remove them from the admin role if they are not.
               await _userManager.RemoveFromRolesAsync(biobankUser, new List<string> { Role.BiobankAdmin });
 
             this.SetTemporaryFeedbackMessage($"{userFullName} has been removed from your admins!", FeedbackMessageType.Success);

--- a/src/Submissions/Api/Areas/Network/Controllers/ProfileController.cs
+++ b/src/Submissions/Api/Areas/Network/Controllers/ProfileController.cs
@@ -406,7 +406,7 @@ public class ProfileController : Controller
   }
 
   [HttpPost]
-  [Authorize(Roles = "BiobankAdmin")]
+  [Authorize(nameof(AuthPolicies.IsNetworkAdmin))]
   public void RemoveTempLogo()
   {
     HttpContext.Session.Remove("TempLogo");

--- a/src/Submissions/Api/Auth/AuthPolicies.cs
+++ b/src/Submissions/Api/Auth/AuthPolicies.cs
@@ -115,7 +115,7 @@ namespace Biobanks.Submissions.Api.Auth
 
         /// <summary>
         /// Requires a request <see cref="IsAuthenticated"/>, <see cref="IsBiobankAdmin"/>,
-        /// and has a claim to the specific biobank, which is not suspended.
+        /// and has a claim to the specific biobank.
         /// </summary>
         /// <returns>A new <see cref="AuthorizationPolicy"/> built from the requirements.</returns>
         public static AuthorizationPolicy HasBiobankClaim


### PR DESCRIPTION
## Overview

Fixed a few vulnerabilities for the biobank and network areas, mostly in managing the attributes (funders, publications, admins) on a biobank - critically for example, stopping a biobank admin making themselves an admin on another biobank.

Includes:
- Adds missing auth attributes
- Removes unused ajax methods
- [AB#100199](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/100199) fixed removing admin role when removing a biobank / network permissions - added a check to see if they should still be in the admin role. The code comment here was wrong, there is nothing to stop being an admin of multiple biobanks/networks.

