### PR TITLE
AB#157605: OntologyTerm matching (Typeahead) fixes

### DIFF
--- a/app/Directory/Controllers/Directory/SearchController.cs
+++ b/app/Directory/Controllers/Directory/SearchController.cs
@@ -21,364 +21,371 @@ namespace Biobanks.Directory.Controllers.Directory;
 [AllowAnonymous]
 public class SearchController : Controller
 {
-        private readonly IReferenceDataCrudService<Country> _countryController;
+  private readonly IReferenceDataCrudService<Country> _countryController;
 
-        private readonly IOntologyTermService _ontologyTermService;
-    
-        private readonly IOrganisationDirectoryService _organisationDirectoryService;
+  private readonly IOntologyTermService _ontologyTermService;
 
-        private readonly ISearchProvider _searchProvider;
-        private readonly IMapper _mapper;
+  private readonly IOrganisationDirectoryService _organisationDirectoryService;
 
-        private readonly ICollectionService _collectionService;
-        
-        private readonly IConfigService _configService;
+  private readonly ISearchProvider _searchProvider;
+  private readonly IMapper _mapper;
 
-        public SearchController(IReferenceDataCrudService<Country> countryController,
-            IOntologyTermService ontologyTermService,
-            IOrganisationDirectoryService organisationDirectoryService,
-            ISearchProvider searchProvider,
-            IMapper mapper,
-            ICollectionService collectionService,
-            IConfigService configService)
+  private readonly ICollectionService _collectionService;
+
+  private readonly IConfigService _configService;
+
+  public SearchController(IReferenceDataCrudService<Country> countryController,
+    IOntologyTermService ontologyTermService,
+    IOrganisationDirectoryService organisationDirectoryService,
+    ISearchProvider searchProvider,
+    IMapper mapper,
+    ICollectionService collectionService,
+    IConfigService configService)
+  {
+    _countryController = countryController;
+    _ontologyTermService = ontologyTermService;
+    _organisationDirectoryService = organisationDirectoryService;
+    _searchProvider = searchProvider;
+    _mapper = mapper;
+    _collectionService = collectionService;
+    _configService = configService;
+  }
+
+  [HttpGet]
+  public async Task<ViewResult> Collections(string ontologyTerm, string selectedFacets)
+  {
+    // Check If Valid and Visible Term
+    if (!string.IsNullOrWhiteSpace(ontologyTerm))
+    {
+      var term = await _ontologyTermService.Get(value: ontologyTerm, onlyDisplayable: true);
+
+      if (term is null)
+      {
+        return await NoResults(new NoResultsModel
         {
-            _countryController = countryController;
-            _ontologyTermService = ontologyTermService;
-            _organisationDirectoryService = organisationDirectoryService;
-            _searchProvider = searchProvider;
-            _mapper = mapper;
-            _collectionService = collectionService;
-            _configService = configService;
-        }
+          OntologyTerm = ontologyTerm,
+          SearchType = SearchDocumentType.Collection
+        });
+      }
+    }
 
-        [HttpGet]
-        public async Task<ViewResult> Collections(string ontologyTerm, string selectedFacets)
+    // Build the base model.
+    var model = new BaseSearchModel
+    {
+      OntologyTerm = ontologyTerm,
+      StorageTemperatureName = await _configService.GetSiteConfigValue(ConfigKey.StorageTemperatureName),
+      MacroscopicAssessmentName = await _configService.GetSiteConfigValue(ConfigKey.MacroscopicAssessmentName),
+      DonorCount = await _configService.GetSiteConfigValue(ConfigKey.DonorCountName),
+      // Extract the search facets.
+      SelectedFacets = ExtractSearchFacets(selectedFacets)
+    };
+
+    // Search based on the provided criteria.
+    var searchResults = _searchProvider.CollectionSearchByOntologyTerm(
+      ontologyTerm,
+      BuildSearchFacets(model.SelectedFacets),
+      0);
+
+    // Build up the rest of the model from the search results.
+    _mapper.Map(searchResults, model);
+
+    //Handle no results
+    if (!model.Biobanks.Any())
+      return await NoResults(new NoResultsModel
+      {
+        OntologyTerm = model.OntologyTerm,
+        SearchType = SearchDocumentType.Collection
+      });
+
+    model.Countries = (await _countryController.List())
+      .ToDictionary(
+        x => x.Value,
+        x => x.Counties.Select(y => y.Value).ToList()
+      );
+    return View(model);
+  }
+
+  private async Task<ViewResult> NoResults(NoResultsModel model)
+  {
+    model.Suggestions = await GetOntologyTermSearchResultsAsync(model.SearchType, model.OntologyTerm?.ToLower());
+
+    //BIO-455 special case for cancer (will override this with a genericised approach in BIO-447
+    if (string.Equals(model.OntologyTerm, "cancer", StringComparison.CurrentCultureIgnoreCase))
+    {
+      //get suggestions for the relevant correct searches
+      var malignant = await GetOntologyTermSearchResultsAsync(model.SearchType, "malignant");
+      var neoplasm = await GetOntologyTermSearchResultsAsync(model.SearchType, "neoplasm");
+
+      //munge them into a distinct list
+      var results = new List<OntologyTermModel>();
+      results.AddRange(malignant);
+      results.AddRange(neoplasm);
+      model.Suggestions = results
+        .DistinctBy(x => x.Description)
+        .OrderBy(x => x.Description)
+        .ToList();
+    }
+
+    return View("NoResults", model);
+  }
+
+  [HttpGet]
+  public async Task<ViewResult> CollectionsDetail(string biobankExternalId, string ontologyTerm, string selectedFacets)
+  {
+    // Get the search facets.
+    var searchFacets = string.IsNullOrEmpty(selectedFacets)
+      ? null
+      : BuildSearchFacets(ExtractSearchFacets(selectedFacets));
+
+    // Search based on the provided criteria.
+    var searchResults =
+      _searchProvider.CollectionSearchByOntologyTermAndBiobank(biobankExternalId, ontologyTerm, searchFacets);
+
+    var model = _mapper.Map<DetailedCollectionSearchModel>(searchResults);
+
+    model.OntologyTerm = ontologyTerm;
+    model.SelectedFacets = selectedFacets;
+
+    // Config 
+    model.StorageTemperatureName = await _configService.GetSiteConfigValue(ConfigKey.StorageTemperatureName);
+    model.MacroscopicAssessmentName = await _configService.GetSiteConfigValue(ConfigKey.MacroscopicAssessmentName);
+    model.ShowPreservationPercentage = await _configService.GetSiteConfigValue(ConfigKey.ShowPreservationPercentage);
+
+    // Get the biobank logo name from the database.
+    model.LogoName = (await _organisationDirectoryService.GetByExternalId(biobankExternalId)).Logo;
+
+    //Get Collection Descriptions in bulk
+    var descriptions =
+      await _collectionService.GetDescriptionsByCollectionIds(
+        model.Collections.Select(x => x.CollectionId));
+
+    foreach (var collection in model.Collections)
+    {
+      collection.Description = descriptions[collection.CollectionId];
+    }
+
+    return View(model);
+  }
+
+  [HttpGet]
+  public async Task<ViewResult> Capabilities(string ontologyTerm, string selectedFacets)
+  {
+    // Check If Valid and Visible Term
+    if (!string.IsNullOrEmpty(ontologyTerm))
+    {
+      var term = await _ontologyTermService.Get(value: ontologyTerm, onlyDisplayable: true);
+
+      if (term is null)
+      {
+        return await NoResults(new NoResultsModel
         {
-            // Check If Valid and Visible Term
-            if (!string.IsNullOrWhiteSpace(ontologyTerm))
-            {
-                var term = await _ontologyTermService.Get(value: ontologyTerm, onlyDisplayable: true);
+          OntologyTerm = ontologyTerm,
+          SearchType = SearchDocumentType.Collection
+        });
+      }
+    }
 
-                if (term is null)
-                {
-                    return await NoResults(new NoResultsModel
-                    {
-                        OntologyTerm = ontologyTerm,
-                        SearchType = SearchDocumentType.Collection
-                    });
-                }
-            }
+    // Build the base model.
+    var model = new BaseSearchModel
+    {
+      OntologyTerm = ontologyTerm,
+      StorageTemperatureName = await _configService.GetSiteConfigValue(ConfigKey.StorageTemperatureName),
+      MacroscopicAssessmentName = await _configService.GetSiteConfigValue(ConfigKey.MacroscopicAssessmentName),
+      DonorCount = await _configService.GetSiteConfigValue(ConfigKey.DonorCountName),
 
-            // Build the base model.
-            var model = new BaseSearchModel
-            {
-                OntologyTerm = ontologyTerm,
-                StorageTemperatureName = await _configService.GetSiteConfigValue(ConfigKey.StorageTemperatureName),
-                MacroscopicAssessmentName = await _configService.GetSiteConfigValue(ConfigKey.MacroscopicAssessmentName),
-                DonorCount = await _configService.GetSiteConfigValue(ConfigKey.DonorCountName),
-                // Extract the search facets.
-                SelectedFacets = ExtractSearchFacets(selectedFacets)
-            };
+      // Extract the search facets.
+      SelectedFacets = ExtractSearchFacets(selectedFacets)
+    };
 
-            // Search based on the provided criteria.
-            var searchResults = _searchProvider.CollectionSearchByOntologyTerm(
-                ontologyTerm,
-                BuildSearchFacets(model.SelectedFacets),
-                0);
-            
-            // Build up the rest of the model from the search results.
-            _mapper.Map(searchResults, model);
+    // Search based on the provided criteria.
+    var searchResults = _searchProvider.CapabilitySearchByOntologyTerm(
+      ontologyTerm,
+      BuildSearchFacets(model.SelectedFacets),
+      0);
 
-            //Handle no results
-            if (!model.Biobanks.Any())
-                return await NoResults(new NoResultsModel
-                {
-                    OntologyTerm = model.OntologyTerm,
-                    SearchType = SearchDocumentType.Collection
-                });
+    // Build up the rest of the model from the search results.
+    _mapper.Map(searchResults, model);
 
-            model.Countries = (await _countryController.List())
-                .ToDictionary(
-                    x => x.Value,
-                    x => x.Counties.Select(y => y.Value).ToList()
-                );
-            return View(model);
-        }
+    //Handle no results
+    if (!model.Biobanks.Any())
+      return await NoResults(new NoResultsModel
+      {
+        OntologyTerm = model.OntologyTerm,
+        SearchType = SearchDocumentType.Collection
+      });
 
-        private async Task<ViewResult> NoResults(NoResultsModel model)
+    return View(model);
+  }
+
+  [HttpGet]
+  public async Task<ViewResult> CapabilitiesDetail(string biobankExternalId, string ontologyTerm, string selectedFacets)
+  {
+    // Get the search facets.
+    var searchFacets = string.IsNullOrEmpty(selectedFacets)
+      ? null
+      : BuildSearchFacets(ExtractSearchFacets(selectedFacets));
+
+    // Search based on the provided criteria.
+    var searchResults =
+      _searchProvider.CapabilitySearchByOntologyTermAndBiobank(biobankExternalId, ontologyTerm, searchFacets);
+
+    var model = _mapper.Map<DetailedCapabilitySearchModel>(searchResults);
+
+    model.OntologyTerm = ontologyTerm;
+    model.SelectedFacets = selectedFacets;
+
+    // Get the biobank logo name from the database.
+    model.LogoName = (await _organisationDirectoryService.GetByExternalId(biobankExternalId)).Logo;
+
+    return View(model);
+  }
+
+
+  #region Diagnosis Type Ahead
+
+  [AllowAnonymous]
+  public async Task<ActionResult> ListOntologyTerms(string wildcard, string callback)
+  {
+    var ontologyTermModels = await GetOntologyTermsAsync(wildcard);
+
+    return Ok(ontologyTermModels);
+  }
+
+  [AllowAnonymous]
+  public async Task<ActionResult> SearchOntologyTerms(string searchDocumentType, string wildcard, string callback)
+  {
+    SearchDocumentType type;
+
+    switch (searchDocumentType)
+    {
+      case "Collections":
+        type = SearchDocumentType.Collection;
+        break;
+      case "Capabilities":
+        type = SearchDocumentType.Capability;
+        break;
+      default:
+        throw new ArgumentOutOfRangeException();
+    }
+
+    var ontologyTermModel = await GetOntologyTermSearchResultsAsync(type, wildcard.ToLower());
+
+    return Ok(ontologyTermModel);
+  }
+
+  private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type,
+    string wildcard)
+  {
+    var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
+    var directoryOntologyTerms = await _ontologyTermService.List(wildcard, onlyDisplayable: true, tags: new List<string>
+    {
+      SnomedTags.Disease,
+      SnomedTags.Finding
+    }, doLowerCaseMatch: true);
+
+    // Join Ontology Terms In Search and Directory Based On Ontology Term Value
+    var model = directoryOntologyTerms.Join(searchOntologyTerms,
+      outer => outer.Value.ToLower(),
+      inner => inner.OntologyTerm,
+      (directoryTerm, searchTerm) =>
+      {
+        var nonMatchingTerms = directoryTerm.OtherTerms?
+          .Split(',')
+          .Select(m => m.Trim())
+          .Where(m => !searchTerm.MatchingOtherTerms.Contains(m))
+          .ToList();
+
+        return new OntologyTermModel
         {
-            model.Suggestions = await GetOntologyTermSearchResultsAsync(model.SearchType, model.OntologyTerm?.ToLower());
+          OntologyTermId = directoryTerm.Id,
+          Description = directoryTerm.Value,
+          OtherTerms = directoryTerm.OtherTerms ?? "",
+          DisplayOnDirectory = directoryTerm.DisplayOnDirectory,
+          MatchingOtherTerms = searchTerm.MatchingOtherTerms,
+          NonMatchingOtherTerms = nonMatchingTerms ?? new List<string>()
+        };
+      });
 
-            //BIO-455 special case for cancer (will override this with a genericised approach in BIO-447
-            if (string.Equals(model.OntologyTerm, "cancer", StringComparison.CurrentCultureIgnoreCase))
-            {
-                //get suggestions for the relevant correct searches
-                var malignant = await GetOntologyTermSearchResultsAsync(model.SearchType, "malignant");
-                var neoplasm = await GetOntologyTermSearchResultsAsync(model.SearchType, "neoplasm");
+    return model.ToList();
+  }
 
-                //munge them into a distinct list
-                var results = new List<OntologyTermModel>();
-                results.AddRange(malignant);
-                results.AddRange(neoplasm);
-                model.Suggestions = results
-                    .DistinctBy(x => x.Description)
-                    .OrderBy(x => x.Description)
-                    .ToList();
-            }
+  private async Task<List<OntologyTermModel>> GetOntologyTermsAsync(string wildcard)
+  {
+    var ontologyTerms = await _ontologyTermService.List(wildcard, onlyDisplayable: true, tags: new List<string>
+    {
+      SnomedTags.Disease,
+      SnomedTags.Finding
+    }, doLowerCaseMatch: true);
 
-            return View("NoResults", model);
-        }
-
-        [HttpGet]
-        public async Task<ViewResult> CollectionsDetail(string biobankExternalId, string ontologyTerm, string selectedFacets)
+    var model = ontologyTerms.Select(x =>
+        new OntologyTermModel
         {
-            // Get the search facets.
-            var searchFacets = string.IsNullOrEmpty(selectedFacets)
-                ? null
-                : BuildSearchFacets(ExtractSearchFacets(selectedFacets));
-
-            // Search based on the provided criteria.
-            var searchResults = _searchProvider.CollectionSearchByOntologyTermAndBiobank(biobankExternalId, ontologyTerm, searchFacets);
-
-            var model = _mapper.Map<DetailedCollectionSearchModel>(searchResults);
-
-            model.OntologyTerm = ontologyTerm;
-            model.SelectedFacets = selectedFacets;
-            
-            // Config 
-            model.StorageTemperatureName = await _configService.GetSiteConfigValue(ConfigKey.StorageTemperatureName);
-            model.MacroscopicAssessmentName = await _configService.GetSiteConfigValue(ConfigKey.MacroscopicAssessmentName);
-            model.ShowPreservationPercentage = await _configService.GetSiteConfigValue(ConfigKey.ShowPreservationPercentage);
-
-            // Get the biobank logo name from the database.
-            model.LogoName = (await _organisationDirectoryService.GetByExternalId(biobankExternalId)).Logo;
-
-            //Get Collection Descriptions in bulk
-            var descriptions =
-                await _collectionService.GetDescriptionsByCollectionIds(
-                    model.Collections.Select(x => x.CollectionId));
-
-            foreach (var collection in model.Collections)
-            {
-                collection.Description = descriptions[collection.CollectionId];
-            }
-
-            return View(model);
+          OntologyTermId = x.Id,
+          Description = x.Value,
+          OtherTerms = x.OtherTerms,
+          DisplayOnDirectory = x.DisplayOnDirectory
         }
+      )
+      .ToList();
 
-        [HttpGet]
-        public async Task<ViewResult> Capabilities(string ontologyTerm, string selectedFacets)
-        {
-            // Check If Valid and Visible Term
-            if (!string.IsNullOrEmpty(ontologyTerm))
-            {
-                var term = await _ontologyTermService.Get(value: ontologyTerm, onlyDisplayable: true);
+    return model;
+  }
 
-                if (term is null)
-                {
-                    return await NoResults(new NoResultsModel
-                    {
-                        OntologyTerm = ontologyTerm,
-                        SearchType = SearchDocumentType.Collection
-                    });
-                }
-            }
+  #endregion
 
-            // Build the base model.
-            var model = new BaseSearchModel
-            {
-                OntologyTerm = ontologyTerm,
-                StorageTemperatureName = await _configService.GetSiteConfigValue(ConfigKey.StorageTemperatureName),
-                MacroscopicAssessmentName = await _configService.GetSiteConfigValue(ConfigKey.MacroscopicAssessmentName),
-                DonorCount = await _configService.GetSiteConfigValue(ConfigKey.DonorCountName),
-                
-                // Extract the search facets.
-                SelectedFacets = ExtractSearchFacets(selectedFacets)
-            };
+  #region Utility functions related directly to search
 
-            // Search based on the provided criteria.
-            var searchResults = _searchProvider.CapabilitySearchByOntologyTerm(
-                ontologyTerm,
-                BuildSearchFacets(model.SelectedFacets),
-                0);
+  private static IList<string> ExtractSearchFacets(string selectedFacets)
+  {
+    if (string.IsNullOrEmpty(selectedFacets))
+      return new List<string>();
 
-            // Build up the rest of the model from the search results.
-            _mapper.Map(searchResults, model);
+    return (List<string>)JsonConvert.DeserializeObject(selectedFacets, typeof(List<string>));
+  }
 
-            //Handle no results
-            if (!model.Biobanks.Any())
-                return await NoResults(new NoResultsModel
-                {
-                    OntologyTerm = model.OntologyTerm,
-                    SearchType = SearchDocumentType.Collection
-                });
+  private static IEnumerable<SelectedFacet> BuildSearchFacets(IEnumerable<string> facetIds)
+  {
+    return facetIds.Select(x => new SelectedFacet
+    {
+      Name = FacetList.GetFacetName(GetFacetSlug(x)),
+      Value = GetFacetValue(x)
+    }).Where(x => !(x.Name is null));
+  }
 
-            return View(model);
-        }
+  private static string GetFacetValue(string facetId)
+  {
+    return facetId.Substring(facetId.IndexOf('_') + 1);
+  }
 
-        [HttpGet]
-        public async Task<ViewResult> CapabilitiesDetail(string biobankExternalId, string ontologyTerm, string selectedFacets)
-        {
-            // Get the search facets.
-            var searchFacets = string.IsNullOrEmpty(selectedFacets)
-                ? null
-                : BuildSearchFacets(ExtractSearchFacets(selectedFacets));
+  private static string GetFacetSlug(string facetId)
+  {
+    // if the string is null, return null
+    if (facetId == null)
+    {
+      return null;
+    }
 
-            // Search based on the provided criteria.
-            var searchResults = _searchProvider.CapabilitySearchByOntologyTermAndBiobank(biobankExternalId, ontologyTerm, searchFacets);
+    // get the index of the first delimiter character
+    var indexOf = facetId.IndexOf('_');
 
-            var model = _mapper.Map<DetailedCapabilitySearchModel>(searchResults);
+    // if the delimiter doesn't exist in the string, return the whole string.
+    // otherwise return from the beginning up to BUT NOT INCLUDING the delimiter.
+    return indexOf < 0 ? facetId : facetId[..indexOf];
+  }
 
-            model.OntologyTerm = ontologyTerm;
-            model.SelectedFacets = selectedFacets;
+  #endregion
 
-            // Get the biobank logo name from the database.
-            model.LogoName = (await _organisationDirectoryService.GetByExternalId(biobankExternalId)).Logo;
-
-            return View(model);
-        }
-
-
-        #region Diagnosis Type Ahead
-
-        [AllowAnonymous]
-        public async Task<ActionResult> ListOntologyTerms(string wildcard, string callback)
-        {
-            var ontologyTermModels = await GetOntologyTermsAsync(wildcard);
-            
-            return Ok(ontologyTermModels);
-        }
-
-        [AllowAnonymous]
-        public async Task<ActionResult> SearchOntologyTerms(string searchDocumentType, string wildcard, string callback)
-        {
-            SearchDocumentType type;
-
-            switch (searchDocumentType)
-            {
-                case "Collections":
-                    type = SearchDocumentType.Collection;
-                    break;
-                case "Capabilities":
-                    type = SearchDocumentType.Capability;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
-            var ontologyTermModel = await GetOntologyTermSearchResultsAsync(type, wildcard.ToLower());
-            
-            return Ok(ontologyTermModel);
-        }
-
-        private async Task<List<OntologyTermModel>> GetOntologyTermSearchResultsAsync(SearchDocumentType type, string wildcard)
-        {
-            var searchOntologyTerms = _searchProvider.ListOntologyTerms(type, wildcard);
-            var directoryOntologyTerms = await _ontologyTermService.List(wildcard, onlyDisplayable: true, tags: new List<string>
-            {
-                SnomedTags.Disease,
-                SnomedTags.Finding
-            });
-
-            // Join Ontology Terms In Search and Directory Based On Ontology Term Value
-            var model = directoryOntologyTerms.Join(searchOntologyTerms, 
-                outer => outer.Value.ToLower(), 
-                inner => inner.OntologyTerm, 
-                (directoryTerm, searchTerm) =>
-                {
-                    var nonMatchingTerms = directoryTerm.OtherTerms?
-                        .Split(',')
-                        .Select(m => m.Trim())
-                        .Where(m => !searchTerm.MatchingOtherTerms.Contains(m))
-                        .ToList();
-
-                    return new OntologyTermModel
-                    {
-                        OntologyTermId = directoryTerm.Id,
-                        Description = directoryTerm.Value,
-                        OtherTerms = directoryTerm.OtherTerms ?? "",
-                        DisplayOnDirectory = directoryTerm.DisplayOnDirectory,
-                        MatchingOtherTerms = searchTerm.MatchingOtherTerms,
-                        NonMatchingOtherTerms = nonMatchingTerms ?? new List<string>()
-                    };
-                });
-
-            return model.ToList();
-        }
-
-        private async Task<List<OntologyTermModel>> GetOntologyTermsAsync(string wildcard)
-        {
-            var ontologyTerms = await _ontologyTermService.List(wildcard, onlyDisplayable: true, tags: new List<string>
-            {
-                SnomedTags.Disease,
-                SnomedTags.Finding
-            });
-
-            var model = ontologyTerms.Select(x =>
-               new OntologyTermModel
-               {
-                   OntologyTermId = x.Id,
-                   Description = x.Value,
-                   OtherTerms = x.OtherTerms,
-                   DisplayOnDirectory = x.DisplayOnDirectory
-               }
-            )
-            .ToList();
-
-            return model;
-        }
-        #endregion
-
-        #region Utility functions related directly to search
-        private static IList<string> ExtractSearchFacets(string selectedFacets)
-        {
-            if (string.IsNullOrEmpty(selectedFacets))
-                return new List<string>();
-
-            return (List<string>)JsonConvert.DeserializeObject(selectedFacets, typeof(List<string>));
-        }
-
-        private static IEnumerable<SelectedFacet> BuildSearchFacets(IEnumerable<string> facetIds)
-        {
-            return facetIds.Select(x => new SelectedFacet
-            {
-                Name = FacetList.GetFacetName(GetFacetSlug(x)),
-                Value = GetFacetValue(x)
-            }).Where(x => !(x.Name is null));
-        }
-
-        private static string GetFacetValue(string facetId)
-        {
-            return facetId.Substring(facetId.IndexOf('_') + 1);
-        }
-
-        private static string GetFacetSlug(string facetId)
-        {
-            // if the string is null, return null
-            if (facetId == null)
-            {
-                return null;
-            }
-            // get the index of the first delimiter character
-            var indexOf = facetId.IndexOf('_');
-
-            // if the delimiter doesn't exist in the string, return the whole string.
-            // otherwise return from the beginning up to BUT NOT INCLUDING the delimiter.
-            return indexOf < 0 ? facetId : facetId[..indexOf];
-        }
-        #endregion
-
-        //this allows us to specify Collections / Capabilities with one box, using radios
-        public ActionResult Unified(string ontologyTerm, string searchRadio)
-        {
-            switch (searchRadio)
-            {
-                case "Collections":
-                    return RedirectToAction("Collections", new {ontologyTerm});
-                case "Capabilities":
-                    return RedirectToAction("Capabilities", new {ontologyTerm});
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+  //this allows us to specify Collections / Capabilities with one box, using radios
+  public ActionResult Unified(string ontologyTerm, string searchRadio)
+  {
+    switch (searchRadio)
+    {
+      case "Collections":
+        return RedirectToAction("Collections", new { ontologyTerm });
+      case "Capabilities":
+        return RedirectToAction("Capabilities", new { ontologyTerm });
+      default:
+        throw new ArgumentOutOfRangeException();
+    }
+  }
 }

--- a/app/Directory/Directory.csproj
+++ b/app/Directory/Directory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>4.0.0-beta.2</Version>
+    <Version>4.0.0-beta.3</Version>
     <!-- Append GitHash to Version if provided -->
     <Version Condition="'$(GitHash)' != ''">$(Version)+$(GitHash)</Version>
   </PropertyGroup>

--- a/app/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
+++ b/app/Directory/Search/Elastic/ElasticCollectionSearchProvider.cs
@@ -66,10 +66,15 @@ namespace Biobanks.Directory.Search.Elastic
         {
             //Matches based on ontologyTerms and onTologyOtherTerms
             var collections = _client.Search<CollectionDocument>(s => s
-                .Query(q => q.Wildcard(p => p.OntologyTerm, $"*{wildcard}*") || q.Nested(n => n
-                .Path(p => p.OntologyOtherTerms).InnerHits(i => i.Explain()
-                .Highlight(h => h.Fields(f => f.Field(o => o.OntologyOtherTerms.Select(on => on.Name)).PreTags("").PostTags(""))))
-                .Query(nq => nq.Wildcard("ontologyOtherTerms.name", $"*{wildcard}*"))))
+                .Query(q =>
+                  q.Wildcard(p => p.OntologyTerm, $"*{wildcard}*") ||
+                  q.Nested(n => n.Path(p => p.OntologyOtherTerms)
+                    .InnerHits(i => i.Explain()
+                      .Highlight(h => h.Fields(
+                        f => f.Field(o => o.OntologyOtherTerms.Select(on => on.Name))
+                          .PreTags("")
+                          .PostTags(""))))
+                    .Query(nq => nq.Wildcard("ontologyOtherTerms.name", $"*{wildcard}*"))))
                 .Size(SizeLimits.SizeMax)
                 .Aggregations(a => a
                     .Terms("diagnoses", t => t

--- a/app/Directory/Services/Directory/Contracts/IOntologyTermService.cs
+++ b/app/Directory/Services/Directory/Contracts/IOntologyTermService.cs
@@ -7,14 +7,15 @@ namespace Biobanks.Directory.Services.Directory.Contracts
 {
     public interface IOntologyTermService
     {
-        /// <summary>
-        /// Get all untracked OntologyTerms which match the given parameter filters
-        /// </summary>
-        /// <param name="value">The descriptive value of the OntologyTerm</param>
-        /// <param name="tags"></param>
-        /// <param name="onlyDisplayable">Whether to return only OntologyTerms that are displayable in the Directory</param>
-        /// <returns>An Enumerable of all applicable untracked OntologyTerms</returns>
-        Task<IEnumerable<OntologyTerm>> List(string value = null, List<string> tags = null, bool onlyDisplayable = false);
+      /// <summary>
+      /// Get all untracked OntologyTerms which match the given parameter filters
+      /// </summary>
+      /// <param name="value">The descriptive value of the OntologyTerm</param>
+      /// <param name="tags"></param>
+      /// <param name="onlyDisplayable">Whether to return only OntologyTerms that are displayable in the Directory</param>
+      /// <param name="doLowerCaseMatch">If true, value matching lower cases values in advance to approximate case-insensitive matching</param>
+      /// <returns>An Enumerable of all applicable untracked OntologyTerms</returns>
+      Task<IEnumerable<OntologyTerm>> List(string value = null, List<string> tags = null, bool onlyDisplayable = false,  bool doLowerCaseMatch = false);
 
         /// <summary>
         /// Get all untracked OntologyTerms which match the given parameter filters

--- a/app/Directory/Services/Directory/OntologyTermService.cs
+++ b/app/Directory/Services/Directory/OntologyTermService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,197 +10,204 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Biobanks.Directory.Services.Directory
 {
-    public class OntologyTermService : IOntologyTermService
-    {
-        
-        private readonly ApplicationDbContext _db;
-        private readonly ICapabilityService _capabilityService;
+  public class OntologyTermService : IOntologyTermService
+  {
+    private readonly ApplicationDbContext _db;
+    private readonly ICapabilityService _capabilityService;
 
     public OntologyTermService(ApplicationDbContext db, ICapabilityService capabilityService)
     {
-            _db = db;
-            _capabilityService = capabilityService;
+      _db = db;
+      _capabilityService = capabilityService;
     }
 
-        protected IQueryable<OntologyTerm> ReadOnlyQuery(
-            string id = null, string value = null, List<string> tags = null, bool onlyDisplayable = false, bool filterById = true)
-        {
-            var query = _db.OntologyTerms
-           .AsNoTracking()
-           .Include(x => x.SnomedTag)
-           .Include(x => x.MaterialTypes)
-           .Include(x => x.AssociatedDataTypes)
-           .Where(x => x.DisplayOnDirectory || !onlyDisplayable);
+    protected IQueryable<OntologyTerm> ReadOnlyQuery(
+      string id = null, string value = null, List<string> tags = null, bool onlyDisplayable = false,
+      bool filterById = true, bool doLowerCaseMatch = false)
+    {
+      var query = _db.OntologyTerms
+        .AsNoTracking()
+        .Include(x => x.SnomedTag)
+        .Include(x => x.MaterialTypes)
+        .Include(x => x.AssociatedDataTypes)
+        .Where(x => x.DisplayOnDirectory || !onlyDisplayable);
 
-            // Filter By ID
-            if (!string.IsNullOrEmpty(id) && filterById)
-                query = query.Where(x => x.Id == id);
+      // Filter By ID
+      if (!string.IsNullOrEmpty(id) && filterById)
+        query = query.Where(x => x.Id == id);
 
-            // Filter By OntologyTerm and OtherTerms
-            if (!string.IsNullOrEmpty(value))
-                query = query.Where(x => x.Value.Contains(value) || x.OtherTerms.Contains(value));
+      // Filter By OntologyTerm and OtherTerms
+      if (!string.IsNullOrEmpty(value))
+        query =
+          doLowerCaseMatch
+            ? query.Where(x =>
+              x.Value.ToLower().Contains(value.ToLower()) ||
+              x.OtherTerms.ToLower().Contains(value.ToLower()))
+            : query.Where(x =>
+              x.Value.Contains(value) ||
+              x.OtherTerms.Contains(value));
 
-            // Filter By SnomedTag
-            if (tags != null)
-                query = query.Where(x =>
-                    tags.Any()
-                        ? x.SnomedTag != null && tags.Contains(x.SnomedTag.Value) // Term With Included Tag
-                        : x.SnomedTag == null); // Terms Without Tags
+      // Filter By SnomedTag
+      if (tags != null)
+        query = query.Where(x =>
+          tags.Any()
+            ? x.SnomedTag != null && tags.Contains(x.SnomedTag.Value) // Term With Included Tag
+            : x.SnomedTag == null); // Terms Without Tags
 
-            return query;
-        }
-
-        /// <inheritdoc/>
-        public async Task<IEnumerable<OntologyTerm>> List(
-            string value = null, List<string> tags = null, bool onlyDisplayable = false)
-            => await ReadOnlyQuery(id: null, value, tags, onlyDisplayable).ToListAsync();
-
-
-        /// <inheritdoc/>
-        public async Task<IEnumerable<OntologyTerm>> ListPaginated(
-            int skip, int take, string value = null, List<string> tags = null, bool onlyDisplayable = false)
-        {
-            return await ReadOnlyQuery(id: null, value, tags, onlyDisplayable)
-                    .OrderByDescending(x => x.DisplayOnDirectory).ThenBy(x => x.Value)
-                    .Skip(skip)
-                    .Take(take)
-                    .ToListAsync();
-        }
-
-        /// <inheritdoc/>
-        public async Task<OntologyTerm> Get(string id = null, string value = null, List<string> tags = null, bool onlyDisplayable = false)
-            => await ReadOnlyQuery(id, value, tags, onlyDisplayable).FirstOrDefaultAsync();
-
-        /// <inheritdoc/>
-        public async Task<int> Count(string value = null, List<string> tags = null)
-            => await ReadOnlyQuery(id: null, value, tags).CountAsync();
-
-        /// <inheritdoc/>
-        public async Task<int> CountCollectionCapabilityUsage(string ontologyTermId)
-            => await _db.Collections.CountAsync(x => x.OntologyTermId == ontologyTermId)
-             + await _db.DiagnosisCapabilities.CountAsync(x => x.OntologyTermId == ontologyTermId);
-
-        /// <inheritdoc/>
-        public async Task<bool> Exists(string id = null, string value = null, List<string> tags = null, bool onlyDisplayable = false, bool filterById = true)
-            => await ReadOnlyQuery(id, value, tags, onlyDisplayable, filterById).AnyAsync(x => x.Id != id);
-
-        /// <inheritdoc/>
-        public async Task<bool> IsInUse(string id)
-            => (await CountCollectionCapabilityUsage(id) > 0);
-
-        /// <inheritdoc/>
-        public async Task<OntologyTerm> Create(OntologyTerm ontologyTerm)
-        {
-            // Get Attached References To MaterialType
-            var materialTypeIds = ontologyTerm?.MaterialTypes?.Select(x => x.Id) ?? new List<int>();
-
-            var materialTypes = await _db.MaterialTypes
-                .Where(x => materialTypeIds.Contains(x.Id))
-                .ToListAsync();
-
-            var newTerm = new OntologyTerm
-            {
-                Id = ontologyTerm.Id,
-                Value = ontologyTerm.Value,
-                OtherTerms = ontologyTerm.OtherTerms,
-                SnomedTagId = ontologyTerm.SnomedTagId,
-                DisplayOnDirectory = ontologyTerm.DisplayOnDirectory,
-                MaterialTypes = materialTypes,
-                AssociatedDataTypes = ontologyTerm.AssociatedDataTypes
-            };
-
-            _db.OntologyTerms.Add(newTerm);
-
-            await _db.SaveChangesAsync();
-
-            // Return OntologyTerm With Idenity ID
-            return newTerm;
-        }
-
-        /// <inheritdoc/>
-        public async Task<OntologyTerm> Update(OntologyTerm ontologyTerm)
-        {
-            // Reference Updated MaterialTypes By Id
-            var materialIds = ontologyTerm.MaterialTypes?.Select(x => x.Id) ?? Enumerable.Empty<int>();
-
-            // Update Current Term
-            var currentTerm = await _db.OntologyTerms
-                .Include(x => x.MaterialTypes)
-                .Include(x => x.AssociatedDataTypes)
-                .FirstAsync(x => x.Id == ontologyTerm.Id);
-
-            currentTerm.Value = ontologyTerm.Value;
-            currentTerm.OtherTerms = ontologyTerm.OtherTerms;
-            currentTerm.DisplayOnDirectory = ontologyTerm.DisplayOnDirectory;
-            currentTerm.SnomedTag = ontologyTerm.SnomedTag;
-            currentTerm.AssociatedDataTypes = ontologyTerm.AssociatedDataTypes;
-
-            // Link To Existing Material Types
-            currentTerm.MaterialTypes = await _db.MaterialTypes.Where(x => materialIds.Contains(x.Id)).ToListAsync();
-
-            await _db.SaveChangesAsync();
-
-            await _capabilityService.UpdateCapabilitiesOntologyOtherTerms(ontologyTerm.Value);
-
-            return currentTerm;
-        }
-
-        /// <inheritdoc/>
-        public async Task Delete(string id)
-        {
-            var ontologyTerm = new OntologyTerm { Id = id };
-
-            _db.OntologyTerms.Attach(ontologyTerm);
-            _db.OntologyTerms.Remove(ontologyTerm);
-
-            await _db.SaveChangesAsync();
-        }
-
-        public async Task<List<OntologyTerm>> GetByAssociatedDataType(int id)
-        {
-            var list = await _db.AssociatedDataTypes
-                    .Where(p => p.Id == id)
-                    .SelectMany(p => p.OntologyTerms)
-                    .OrderByDescending(p => p.Id)
-                    .ToListAsync();
-            return list;
-        }
-
-        public async Task<List<AssociatedDataType>> ListAssociatedDataTypesByOntologyTerm(string id)
-        {
-            var list = await _db.OntologyTerms
-                    .Where(p => p.Id == id)
-                    .SelectMany(p => p.AssociatedDataTypes)
-                    .OrderByDescending(p => p.Id)
-                    .ToListAsync();
-
-            return list;
-        }
-
-        public async Task<List<OntologyTerm>> GetOntologyTermsFromList(List<string> input)
-        {
-            var list = await _db.OntologyTerms
-                    .Where(r => input.Contains(r.Id))
-                    .ToListAsync();
-            return list;
-        }
-
-        public async Task<List<AssociatedDataType>> GetAssociatedDataFromList(List<int> input)
-        {
-            var list = await _db.AssociatedDataTypes
-                    .Where(r => input.Contains(r.Id))
-                    .ToListAsync();
-            return list;
-        }
-
-        /// <inheritdoc/>
-        public async Task<IEnumerable<SnomedTag>> ListSnomedTags()
-            => await _db.SnomedTags.ToListAsync();
-
-        /// <inheritdoc/>
-        public async Task<SnomedTag> GetSnomedTagByDescription(string description)
-            => await _db.SnomedTags.Where(x => x.Value == description).SingleOrDefaultAsync();
-        
+      return query;
     }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<OntologyTerm>> List(
+      string value = null, List<string> tags = null, bool onlyDisplayable = false, bool doLowerCaseMatch = false)
+      => await ReadOnlyQuery(id: null, value, tags, onlyDisplayable, doLowerCaseMatch: doLowerCaseMatch).ToListAsync();
+
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<OntologyTerm>> ListPaginated(
+      int skip, int take, string value = null, List<string> tags = null, bool onlyDisplayable = false)
+    {
+      return await ReadOnlyQuery(id: null, value, tags, onlyDisplayable)
+        .OrderByDescending(x => x.DisplayOnDirectory).ThenBy(x => x.Value)
+        .Skip(skip)
+        .Take(take)
+        .ToListAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task<OntologyTerm> Get(string id = null, string value = null, List<string> tags = null,
+      bool onlyDisplayable = false)
+      => await ReadOnlyQuery(id, value, tags, onlyDisplayable).FirstOrDefaultAsync();
+
+    /// <inheritdoc/>
+    public async Task<int> Count(string value = null, List<string> tags = null)
+      => await ReadOnlyQuery(id: null, value, tags).CountAsync();
+
+    /// <inheritdoc/>
+    public async Task<int> CountCollectionCapabilityUsage(string ontologyTermId)
+      => await _db.Collections.CountAsync(x => x.OntologyTermId == ontologyTermId)
+         + await _db.DiagnosisCapabilities.CountAsync(x => x.OntologyTermId == ontologyTermId);
+
+    /// <inheritdoc/>
+    public async Task<bool> Exists(string id = null, string value = null, List<string> tags = null,
+      bool onlyDisplayable = false, bool filterById = true)
+      => await ReadOnlyQuery(id, value, tags, onlyDisplayable, filterById).AnyAsync(x => x.Id != id);
+
+    /// <inheritdoc/>
+    public async Task<bool> IsInUse(string id)
+      => (await CountCollectionCapabilityUsage(id) > 0);
+
+    /// <inheritdoc/>
+    public async Task<OntologyTerm> Create(OntologyTerm ontologyTerm)
+    {
+      // Get Attached References To MaterialType
+      var materialTypeIds = ontologyTerm?.MaterialTypes?.Select(x => x.Id) ?? new List<int>();
+
+      var materialTypes = await _db.MaterialTypes
+        .Where(x => materialTypeIds.Contains(x.Id))
+        .ToListAsync();
+
+      var newTerm = new OntologyTerm
+      {
+        Id = ontologyTerm.Id,
+        Value = ontologyTerm.Value,
+        OtherTerms = ontologyTerm.OtherTerms,
+        SnomedTagId = ontologyTerm.SnomedTagId,
+        DisplayOnDirectory = ontologyTerm.DisplayOnDirectory,
+        MaterialTypes = materialTypes,
+        AssociatedDataTypes = ontologyTerm.AssociatedDataTypes
+      };
+
+      _db.OntologyTerms.Add(newTerm);
+
+      await _db.SaveChangesAsync();
+
+      // Return OntologyTerm With Idenity ID
+      return newTerm;
+    }
+
+    /// <inheritdoc/>
+    public async Task<OntologyTerm> Update(OntologyTerm ontologyTerm)
+    {
+      // Reference Updated MaterialTypes By Id
+      var materialIds = ontologyTerm.MaterialTypes?.Select(x => x.Id) ?? Enumerable.Empty<int>();
+
+      // Update Current Term
+      var currentTerm = await _db.OntologyTerms
+        .Include(x => x.MaterialTypes)
+        .Include(x => x.AssociatedDataTypes)
+        .FirstAsync(x => x.Id == ontologyTerm.Id);
+
+      currentTerm.Value = ontologyTerm.Value;
+      currentTerm.OtherTerms = ontologyTerm.OtherTerms;
+      currentTerm.DisplayOnDirectory = ontologyTerm.DisplayOnDirectory;
+      currentTerm.SnomedTag = ontologyTerm.SnomedTag;
+      currentTerm.AssociatedDataTypes = ontologyTerm.AssociatedDataTypes;
+
+      // Link To Existing Material Types
+      currentTerm.MaterialTypes = await _db.MaterialTypes.Where(x => materialIds.Contains(x.Id)).ToListAsync();
+
+      await _db.SaveChangesAsync();
+
+      await _capabilityService.UpdateCapabilitiesOntologyOtherTerms(ontologyTerm.Value);
+
+      return currentTerm;
+    }
+
+    /// <inheritdoc/>
+    public async Task Delete(string id)
+    {
+      var ontologyTerm = new OntologyTerm { Id = id };
+
+      _db.OntologyTerms.Attach(ontologyTerm);
+      _db.OntologyTerms.Remove(ontologyTerm);
+
+      await _db.SaveChangesAsync();
+    }
+
+    public async Task<List<OntologyTerm>> GetByAssociatedDataType(int id)
+    {
+      var list = await _db.AssociatedDataTypes
+        .Where(p => p.Id == id)
+        .SelectMany(p => p.OntologyTerms)
+        .OrderByDescending(p => p.Id)
+        .ToListAsync();
+      return list;
+    }
+
+    public async Task<List<AssociatedDataType>> ListAssociatedDataTypesByOntologyTerm(string id)
+    {
+      var list = await _db.OntologyTerms
+        .Where(p => p.Id == id)
+        .SelectMany(p => p.AssociatedDataTypes)
+        .OrderByDescending(p => p.Id)
+        .ToListAsync();
+
+      return list;
+    }
+
+    public async Task<List<OntologyTerm>> GetOntologyTermsFromList(List<string> input)
+    {
+      var list = await _db.OntologyTerms
+        .Where(r => input.Contains(r.Id))
+        .ToListAsync();
+      return list;
+    }
+
+    public async Task<List<AssociatedDataType>> GetAssociatedDataFromList(List<int> input)
+    {
+      var list = await _db.AssociatedDataTypes
+        .Where(r => input.Contains(r.Id))
+        .ToListAsync();
+      return list;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<SnomedTag>> ListSnomedTags()
+      => await _db.SnomedTags.ToListAsync();
+
+    /// <inheritdoc/>
+    public async Task<SnomedTag> GetSnomedTagByDescription(string description)
+      => await _db.SnomedTags.Where(x => x.Value == description).SingleOrDefaultAsync();
+  }
 }
-

--- a/elastic-search/docker-compose.yml
+++ b/elastic-search/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   elastic-search:
-    image: elasticsearch:8.6.2
+    image: elasticsearch:8.12.2
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false

--- a/elastic-search/docker-compose.yml
+++ b/elastic-search/docker-compose.yml
@@ -4,11 +4,30 @@
 # use Postman to hit the server on 9200, or stand up a kibana container if you really need to.
 
 services:
-  elastic-search:
-    image: elasticsearch:8.12.2
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
+  es01:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - 9200:9200
+      - 9300:9300
+    environment:
+      - node.name=es01
+      - cluster.name=elastic_dev
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+    mem_limit: 1073741824
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+
+volumes:
+  esdata:
+    driver: local
+
+networks:
+  default:
+    name: elastic
+    external: false


### PR DESCRIPTION
<!--
⚠ Ensure the PR title starts with a reference to the primary work item it completes, in the form `AB#<id> My PR Title`.
-->

## Overview

This PR enables case-insensitive partial matching of OntologyTerms from the database (now that we target a database with case-sensitive collation by default).

The case-insensitive form is only needed in some scenarios - others (e.g. #580) benefit from case-sensitivity, or indeed whole term exact matching.

This PR enables case-insensitive matching on the backend endpoints that support typeahead. This fixes #585 without re-breaking #580.
