### PR TITLE
AB#75938:  Material Details Preservation - Correcting Extraction Procedures

### DIFF
--- a/app/Directory/Areas/Biobank/Views/Collections/EditSampleSet.cshtml
+++ b/app/Directory/Areas/Biobank/Views/Collections/EditSampleSet.cshtml
@@ -25,10 +25,13 @@
             }));
 
             // Extraction Procedures
-            lookup.extractionProcedures(ko.utils.arrayMap(@Html.Raw(JsonConvert.SerializeObject(Model.ExtractionProcedures)), function (x) {
-                return new DropDownBinding(x.OntologyTermId, x.Description);
-            }));
-            lookup.materialExtractionProcedures(lookup.extractionProcedures());
+            var extractionProcedures = @Html.Raw(JsonConvert.SerializeObject(Model.ExtractionProcedures));
+            if (extractionProcedures.length > 0) {
+                lookup.extractionProcedures(ko.utils.arrayMap(extractionProcedures, function (x) {
+                    return new DropDownBinding(x.OntologyTermId, x.Description);
+                }));
+                lookup.materialExtractionProcedures(lookup.extractionProcedures());
+            }
 
             // Preservation Types
             lookup.preservationTypes(ko.utils.arrayMap(@Html.Raw(JsonConvert.SerializeObject(Model.PreservationTypes)), function (x) {

--- a/app/Directory/Areas/Biobank/Views/Collections/_SampleSetSharedFields.cshtml
+++ b/app/Directory/Areas/Biobank/Views/Collections/_SampleSetSharedFields.cshtml
@@ -89,7 +89,10 @@
             <thead>
                 <tr>
                     <th>Material type</th>
-                    <th>Extraction Procedure</th>
+                    @if (Model.ExtractionProcedures.Any())
+                    {
+                        <th>Extraction Procedure</th>
+                    }
                     <th>@await _config.GetSiteConfigValue(ConfigKey.StorageTemperatureName)</th>
                     <th>Preservation type</th>
 
@@ -114,7 +117,10 @@
                   }">
                 <tr>
                     <td data-bind="text: materialTypeDescription"></td>
-                    <td data-bind="text: extractionProcedureDescription"></td>
+                    @if (Model.ExtractionProcedures.Any())
+                    {
+                        <td data-bind="text: extractionProcedureDescription"></td>
+                    }
                     <td data-bind="text: storageTemperatureDescription"></td>
                     <td data-bind="text: preservationTypeDescription"></td>
                     @if (Model.ShowMacroscopicAssessment)
@@ -185,6 +191,7 @@
 
                 <div class="row">
                     <div class="col-sm-12">
+
                         <!-- Material Type -->
                         <div class="col-sm-12 form-group">
                             <label class="control-label required">Material type</label>
@@ -204,20 +211,25 @@
                         </div>
 
                         <!-- Extraction Procedure -->
-                        <div class="col-sm-12">
-                            <label class="control-label">Extraction Procedure</label>
-                            <p class="help-block col-sm-12">
-                                <span class="fa fa-info-circle"></span>
-                                Please select the extraction procedure for the material type;
-                                if is not there please get in touch.
-                            </p>
-                            <div class="col-sm-12">
-                                <label data-bind="validationOptions: {insertMessages: false}">
-                                    <select name="ddExtraction" class="form-control" style="width:300px"
-                                            data-bind="options: lookup.materialExtractionProcedures, optionsText: 'label', optionsValue: 'value', optionsCaption: 'Choose...', valueAllowUnset: true, value:$root.modal.materialPreservationDetail().extractionProcedure"></select>
-                                </label>
+                        @if (Model.ExtractionProcedures.Any())
+                        {
+                            <div class="col-sm-12 form-group">
+                                <label class="control-label">Extraction Procedure</label>
+                                <p class="help-block col-sm-12">
+                                    <span class="fa fa-info-circle"></span>
+                                    Please select the extraction procedure for the material type;
+                                    if is not there please get in touch.
+                                </p>
+                                <div class="col-sm-12" data-bind="foreach: lookup.extractionProcedures">
+                                    <div class="col-sm-6 radio">
+                                        <label data-bind="validationOptions: {insertMessages: false}">
+                                            <input type="radio" name="radExtractionProcedure" data-bind="checkedValue: $data.value, checked: $root.modal.materialPreservationDetail().extractionProcedure">
+                                            <span data-bind="text: $data.label"></span>
+                                        </label>
+                                    </div>
+                                </div>
                             </div>
-                        </div>
+                        }
 
                         <!-- Storage Temperature -->
                         <div class="col-sm-12 form-group">


### PR DESCRIPTION

<!--
⚠ Ensure the PR title starts with a reference to the primary work item it completes, in the form `AB#<id> My PR Title`.
-->

## Overview

This fixes the issue where extraction procedure data didn't display even if set to displayonDirectory=true. Additionally, it now 
displays extraction procedures in the same way as the other values (radio buttons).

Note two screenshots showing extraction procedure being displayed and not respectively.

<!--
ℹ If there are multiple relevant Azure Boards work items, please reference them in a list below, in the form `AB#<id>`.

Otherwise delete the section.
-->

## Azure Boards

- `75938`
![EPExists](https://github.com/biobankinguk/biobankinguk/assets/7585370/bc09ad4a-15b7-4902-b487-5648939a40e8)

![EPNotExisting](https://github.com/biobankinguk/biobankinguk/assets/7585370/172da86c-52d2-44eb-9486-32bf3c093889)

