### PR TITLE
AB#157605: Fix pipelines

### DIFF
--- a/.github/workflows/build.directory.yml
+++ b/.github/workflows/build.directory.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # pnpm install so we have frontend dependencies for bundling
       - uses: ./.github/actions/template.pnpm-install
         with:
           filter: ${{ env.frontend-package }}
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnet-version }}
       - name: dotnet build

--- a/.github/workflows/publish.directory.yml
+++ b/.github/workflows/publish.directory.yml
@@ -39,7 +39,7 @@ jobs:
       short-sha: ${{ steps.sha.outputs.sha }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # short git sha for use in versions
       - name: Get short SHA
@@ -49,7 +49,7 @@ jobs:
       # get app version from csproj
       - name: Read version
         id: version
-        uses: bbonkr/get-version-action@v1
+        uses: bbonkr/get-version-action@050c4c0c91ed925d5736322939ab5c4a1078cca5 # v1.3.1
         with:
           project: ${{ env.app-project }}
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # pnpm install so we have frontend dependencies for bundling
       - uses: ./.github/actions/template.pnpm-install
@@ -67,7 +67,7 @@ jobs:
           filter: ${{ env.frontend-package }}
 
       # dotnet publish now we have dependencies
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnet-version }}
 
@@ -80,7 +80,7 @@ jobs:
           -p:GitHash=${{ needs.init.outputs.short-sha }}
 
       # upload the published artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ format('directory-{0}_dotnet-{1}', needs.init.outputs.version, env.dotnet-version) }}
           path: ${{ env.publish-dir }}
@@ -103,8 +103,8 @@ jobs:
           - artifact: linux-x64
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnet-version }}
       - run: dotnet tool restore
@@ -117,7 +117,7 @@ jobs:
           ${{ matrix.args }}
           --self-contained
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ format('migrations-{0}_{1}', needs.init.outputs.version, matrix.artifact) }}
           path: ${{ format('{0}{1}', env.output-filename, matrix.file-extension) }}

--- a/.github/workflows/release.directory.yml
+++ b/.github/workflows/release.directory.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Get workflow run
         id: run-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { data: { workflow_id, head_sha, conclusion } } =
@@ -66,18 +66,18 @@ jobs:
     steps:
       # determine version from the workflow run's commit
       - name: Checkout target workflow run's commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.fetch-run.outputs.publish-commit }}
       - name: Read version
         id: version
-        uses: bbonkr/get-version-action@v1
+        uses: bbonkr/get-version-action@050c4c0c91ed925d5736322939ab5c4a1078cca5 # v1.3.1
         with:
           project: app/Directory/Directory.csproj
 
       # download artifacts from the run we want on the release
       - name: Download workflow artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9.0.0
         with:
           run_id: ${{ env.run-id }}
           skip_unpack: true # leave them zipped
@@ -93,7 +93,7 @@ jobs:
           echo "RELEASE_TAG=${{ github.event.inputs.override-tag }}" >> $GITHUB_ENV
 
       # make the release
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
<!--
⚠ Ensure the PR title starts with a reference to the primary work item it completes, in the form `AB#<id> My PR Title`.
-->

## Overview

Fixes pipelines: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The publish workflow would fail as it used V3, the above - but I have updated all the workflows pipelines to be pinned to versions as well. 

These are necessary to be fixed to publish, and deploy new versions of TDCC.
